### PR TITLE
Fix circular dependencies bug

### DIFF
--- a/GeoUtils/raster_tools.py
+++ b/GeoUtils/raster_tools.py
@@ -9,7 +9,6 @@ from rasterio.io import MemoryFile
 from rasterio.crs import CRS
 from affine import Affine
 from shapely.geometry.polygon import Polygon
-import GeoUtils.vector_tools as vt
 
 try:
     import rioxarray
@@ -263,6 +262,8 @@ class Raster(object):
         """
         assert mode in ['match_extent', 'match_pixel'], "mode must be one of 'match_pixel', 'match_extent'"
 
+        import GeoUtils.vector_tools as vt
+        
         if mode == 'match_pixel':
             if isinstance(cropGeom, Raster):
                 xmin, ymin, xmax, ymax = cropGeom.bounds

--- a/GeoUtils/vector_tools.py
+++ b/GeoUtils/vector_tools.py
@@ -7,8 +7,6 @@ import geopandas as gpd
 import rasterio as rio
 from rasterio import warp, features
 
-from GeoUtils.raster_tools import Raster
-
 
 class Vector():
     """
@@ -63,6 +61,7 @@ class Vector():
         """
         # If input is string, open as Raster
         if isinstance(rst, str):
+
             rst = Raster(rst)
 
         # Convert raster extent into self CRS
@@ -100,6 +99,7 @@ class Vector():
         """
         # If input rst is string, open as Raster
         if isinstance(rst, str):
+            from GeoUtils.raster_tools import Raster
             rst = Raster(rst)
 
         # If no rst given, use provided dimensions


### PR DESCRIPTION
Both raster_tools and vector_tools were attempting to load each other into their module namespaces, resulting in circular dependencies.

Now, the relevant module is only imported within the scope of the method which needs it.