### PR TITLE
Raster data getter/setter methods

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: geoutils-dev
+name: build-geoutils-dev
 
 on:
   push:
@@ -22,8 +22,7 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        $CONDA/bin/conda install -c conda-forge flake8 pip rasterio pytest
-        if [ -f requirements.txt ]; then $CONDA/bin/pip install -r requirements.txt; fi
+        $CONDA/bin/conda env update --file environment.yml --name base
         $CONDA/bin/pip install .
     - name: Lint with flake8
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: []
 
+conda:
+  environment: environment.yml
+
 python:
-  version: 3.7
   install:
-    - requirements: requirements.txt
     - method: pip
       path: .
-  system_packages: false 
   

--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ More documentation to come!
 
 ## Installation ##
 
-* Main dependencies
+* Create environment and install dependencies
 
-rasterio, geopandas, pyproj
+`conda env create -f environment.yml`
 
-* Rapidly install dependencies (can be tricky because of gdal)
+* Activate environment
 
-`conda install -c conda-forge rasterio geopandas pyproj`
+`conda activate geoutils`
 
-* Package set up (once conda environment is create)
+* Install this package
 
 `pip install -e .` or `python setup.py install`
 
+* Check that everything is working by running the tests
+
+`pytest -rA`
 
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+name: geoutils
+channels:
+  - conda-forge
+dependencies:
+  - python=3
+  - geopandas
+  - matplotlib
+  - pyproj
+  - rasterio
+  - rioxarray
+
+  # code checks
+  - flake8
+
+  # testing
+  - pytest
+
+  # development
+  - pip

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -93,13 +93,13 @@ class Raster(object):
         self._read_attrs(attrs)
 
         if load_data:
-            self.data = self.ds.read(bands)
-            self.nbands = self.data.shape[0]
+            self._data = self.ds.read(bands)
+            self.nbands = self._data.shape[0]
             self.isLoaded = True
             if isinstance(filename, str):
                 self.matches_disk = True
         else:
-            self.data = None
+            self._data = None
             self.nbands = None
             self.isLoaded = False
 
@@ -194,6 +194,40 @@ class Raster(object):
         for attr in attrs:
             setattr(self, attr, getattr(self.ds, attr))
 
+    @property
+    def data(self):
+        """
+        Getter method for the _data class member.
+
+        Returns:
+            np.ndarray: the _data member of this instance of Raster
+        """
+        return self._data
+
+    @data.setter
+    def data(self, new_data):
+        """
+        Setter method for the _data class member.
+
+        :param new_data: New data to assign to this instance of Raster
+        :type new_data: np.ndarray
+        """
+        # Check that new_data is a Numpy array
+        if not isinstance(new_data, np.ndarray):
+            raise ValueError("New data must be a numpy array.")
+
+        # Check that new_data has correct shape
+        if new_data.shape != self._data.shape:
+            raise ValueError("New data must be of the same shape as\
+ existing data: {}.".format(self.shape))
+
+        # Check that new_data has the right type
+        if new_data.dtype != self._data.dtype:
+            raise ValueError("New data must be of the same type as existing\
+ data: {}".format(self.data.dtype))
+
+        self._data = new_data
+
     def _update(self, imgdata=None, metadata=None, vrt_to_driver='GTiff'):
         """
         Update the object with a new image or metadata.
@@ -208,7 +242,7 @@ class Raster(object):
         """
         memfile = MemoryFile()
         if imgdata is None:
-            imgdata = self.data
+            imgdata = self._data
         if metadata is None:
             metadata = self.ds.meta
 
@@ -249,32 +283,32 @@ class Raster(object):
                   'Lower Right Corner:   {}, {}\n'.format(*self.bounds[2:])]
 
         if stats:
-            if self.data is not None:
+            if self._data is not None:
                 if self.nbands == 1:
                     as_str.append('[MAXIMUM]:          {:.2f}\n'.format(
-                        np.nanmax(self.data)))
+                        np.nanmax(self._data)))
                     as_str.append('[MINIMUM]:          {:.2f}\n'.format(
-                        np.nanmin(self.data)))
+                        np.nanmin(self._data)))
                     as_str.append('[MEDIAN]:           {:.2f}\n'.format(
-                        np.nanmedian(self.data)))
+                        np.nanmedian(self._data)))
                     as_str.append('[MEAN]:             {:.2f}\n'.format(
-                        np.nanmean(self.data)))
+                        np.nanmean(self._data)))
                     as_str.append('[STD DEV]:          {:.2f}\n'.format(
-                        np.nanstd(self.data)))
+                        np.nanstd(self._data)))
                 else:
                     for b in range(self.nbands):
                         # try to keep with rasterio convention.
                         as_str.append('Band {}:'.format(b + 1))
                         as_str.append('[MAXIMUM]:          {:.2f}\n'.format(
-                            np.nanmax(self.data[b, :, :])))
+                            np.nanmax(self._data[b, :, :])))
                         as_str.append('[MINIMUM]:          {:.2f}\n'.format(
-                            np.nanmin(self.data[b, :, :])))
+                            np.nanmin(self._data[b, :, :])))
                         as_str.append('[MEDIAN]:           {:.2f}\n'.format(
-                            np.nanmedian(self.data[b, :, :])))
+                            np.nanmedian(self._data[b, :, :])))
                         as_str.append('[MEAN]:             {:.2f}\n'.format(
-                            np.nanmean(self.data[b, :, :])))
+                            np.nanmean(self._data[b, :, :])))
                         as_str.append('[STD DEV]:          {:.2f}\n'.format(
-                            np.nanstd(self.data[b, :, :])))
+                            np.nanstd(self._data[b, :, :])))
 
         return "".join(as_str)
 
@@ -289,7 +323,7 @@ class Raster(object):
         if new_array is not None:
             data=new_array
         else:
-            data=self.data
+            data=self._data
 
         cp = Raster.from_array(data=data,transform=self.transform,crs=self.crs,nodata=self.nodata)
 
@@ -303,12 +337,12 @@ class Raster(object):
         :type bands: int, or list of ints
         """
         if bands is None:
-            self.data = self.ds.read()
+            self._data = self.ds.read()
         else:
-            self.data = self.ds.read(bands)
+            self._data = self.ds.read(bands)
 
-        if self.data.ndim == 3:
-            self.nbands = self.data.shape[0]
+        if self._data.ndim == 3:
+            self.nbands = self._data.shape[0]
         else:
             self.nbands = 1
 
@@ -355,11 +389,11 @@ class Raster(object):
             new_tfm = rio.transform.from_bounds(xmin, ymin, xmax, ymax, width=new_width, height=new_height)
 
             if self.isLoaded:
-                new_img = np.zeros((self.nbands, new_height, new_width), dtype=self.data.dtype)
+                new_img = np.zeros((self.nbands, new_height, new_width), dtype=self._data.dtype)
             else:
-                new_img = np.zeros((self.count, new_height, new_width), dtype=self.data.dtype)
+                new_img = np.zeros((self.count, new_height, new_width), dtype=self._data.dtype)
 
-            crop_img, tfm = rio.warp.reproject(self.data, new_img,
+            crop_img, tfm = rio.warp.reproject(self._data, new_img,
                                                src_transform=self.transform,
                                                dst_transform=new_tfm,
                                                src_crs=self.crs,
@@ -514,7 +548,7 @@ class Raster(object):
         # Currently reprojects all in-memory bands at once.
         # This may need to be improved to allow reprojecting from-disk.
         # See rio.warp.reproject docstring for more info.
-        dst_data, dst_transformed = rio.warp.reproject(self.data, **reproj_kwargs)
+        dst_data, dst_transformed = rio.warp.reproject(self._data, **reproj_kwargs)
 
         # Check for funny business.
         if dst_transform is not None:
@@ -563,7 +597,7 @@ class Raster(object):
             ndv = ndv[0]
 
         meta = self.ds.meta
-        imgdata = self.data
+        imgdata = self._data
         pre_ndv = self.nodata
 
         meta.update({'nodata': ndv})
@@ -611,7 +645,7 @@ class Raster(object):
             dtypes = tuple(dtypes)
 
         meta = self.ds.meta
-        imgdata = self.data
+        imgdata = self._data
 
         #for rio.DatasetReader.meta, the proper name is "dtype"
         meta.update({'dtype': dtypes[0]})
@@ -636,10 +670,10 @@ class Raster(object):
         """ Write the Raster to a geo-referenced file.
 
         Given a filename to save the Raster to, create a geo-referenced file
-        on disk which contains the contents of self.data.
+        on disk which contains the contents of self._data.
 
         If blank_value is set to an integer or float, then instead of writing
-        the contents of self.data to disk, write this provided value to every
+        the contents of self._data to disk, write this provided value to every
         pixel instead.
 
         :param filename: Filename to write the file to.
@@ -664,9 +698,9 @@ class Raster(object):
         :returns: None.
         """
 
-        dtype = self.data.dtype if dtype is None else dtype
+        dtype = self._data.dtype if dtype is None else dtype
 
-        if (self.data is None) & (blank_value is None):
+        if (self._data is None) & (blank_value is None):
             return AttributeError('No data loaded, and alterative blank_value not set.')
         elif blank_value is not None:
             if isinstance(blank_value, int) | isinstance(blank_value, float):
@@ -676,7 +710,7 @@ class Raster(object):
                 raise ValueError(
                     'blank_values must be one of int, float (or None).')
         else:
-            save_data = self.data
+            save_data = self._data
 
         with rio.open(filename, 'w',
                       driver=driver,
@@ -841,7 +875,7 @@ to be cleared due to the setting of GCPs.")
             raise ValueError("band must be int or None")
 
         # Use data array directly, as rshow on self.ds will re-load data
-        rshow(self.data[band, :, :], transform=self.transform, **kwargs)
+        rshow(self._data[band, :, :], transform=self.transform, **kwargs)
 
     def value_at_coords(self, x, y, latlon=False, band=None, masked=False,
                         window=None, return_window=False, boundless=True,
@@ -1109,7 +1143,7 @@ to be cleared due to the setting of GCPs.")
                 y = yy[i - nsize:i + nsize + 1]
 
                 #TODO: read only that window?
-                z = self.data[band-1, i - nsize:i + nsize + 1, j - nsize:j + nsize + 1]
+                z = self._data[band-1, i - nsize:i + nsize + 1, j - nsize:j + nsize + 1]
                 if mode in ['linear', 'cubic', 'quintic', 'nearest']:
                     X, Y = np.meshgrid(x, y)
                     try:

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1,5 +1,5 @@
 """
-GeoUtils.raster_tools provides a toolset for working with raster data.
+geoutils.georaster provides a toolset for working with raster data.
 """
 import os
 import warnings
@@ -1129,10 +1129,3 @@ to be cleared due to the setting of GCPs.")
         rpts = np.array(rpts)
 
         return rpts
-
-
-class SatelliteImage(Raster):
-
-
-
-    pass

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -1,5 +1,5 @@
 """
-GeoUtils.vectortools provides a toolset for working with vector data.
+geoutils.vectortools provides a toolset for working with vector data.
 """
 import warnings
 import numpy as np

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -1,0 +1,317 @@
+"""
+geoutils.satimg provides a toolset for working with satellite data.
+"""
+import os
+import re
+import datetime as dt
+import numpy as np
+from geoutils.georaster import Raster
+import collections
+
+lsat_sensor = {'C': 'OLI/TIRS', 'E': 'ETM+', 'T': 'TM', 'M': 'MSS', 'O': 'OLI', 'TI': 'TIRS'}
+
+def parse_landsat(gname):
+    attrs = []
+    if len(gname.split('_')[0])>15:
+        attrs.append('Landsat {}'.format(int(gname[2])))
+        attrs.append(lsat_sensor[gname[1]])
+        attrs.append(None)
+        attrs.append(None)
+        attrs.append((int(gname[3:6]), int(gname[6:9])))
+        year = int(gname[9:13])
+        doy = int(gname[13:16])
+        attrs.append(dt.datetime.fromordinal(dt.date(year - 1, 12, 31).toordinal() + doy))
+    elif re.match('L[COTEM][0-9]{2}', gname.split('_')[0]):
+        split_name = gname.split('_')
+        attrs.append('Landsat {}'.format(int(split_name[0][2:4])))
+        attrs.append(lsat_sensor[split_name[0][1]])
+        attrs.append(None)
+        attrs.append(None)
+        attrs.append((int(split_name[2][0:3]), int(split_name[2][3:6])))
+        attrs.append(dt.datetime.strptime(split_name[3], '%Y%m%d'))
+        attrs.append(attrs[3].date())
+    return attrs
+
+def parse_metadata_from_fn(fname):
+
+    bname = os.path.splitext(os.path.basename(fname))[0]
+
+    # assumes that the filename has a form XX_YY.ext
+    if '_' in bname:
+
+        spl = bname.split('_')
+
+        # attrs corresponds to: satellite, sensor, product, version, tile_name, datetime
+        if re.match('L[COTEM][0-9]{2}', spl[0]):
+            attrs = parse_landsat(bname)
+        elif spl[0][0] == 'L' and len(spl) == 1:
+            attrs = parse_landsat(bname)
+        elif re.match('T[0-9]{2}[A-Z]{3}', spl[0]):
+            attrs = ('Sentinel-2', 'MSI', None, None, spl[0][1:], dt.datetime.strptime(spl[1], '%Y%m%dT%H%M%S'))
+        elif spl[0] == 'SETSM':
+            attrs = ('WorldView',spl[1], 'ArcticDEM/REMA', spl[7], None, dt.datetime.strptime(spl[2], '%Y%m%d'))
+        elif spl[0] == 'SPOT':
+            attrs = ('HFS', 'SPOT5', None, None, None, dt.datetime.strptime(spl[2], '%Y%m%d'))
+        elif spl[0] == 'IODEM3':
+            attrs = ('IceBridge', 'DMS', 'IODEM3', None, None, dt.datetime.strptime(spl[1] + spl[2], '%Y%m%d%H%M%S'))
+        elif spl[0] == 'ILAKS1B':
+            attrs = ('IceBridge', 'UAF-LS', 'ILAKS1B', None, None, dt.datetime.strptime(spl[1], '%Y%m%d'))
+        elif spl[0] == 'AST' and spl[1] == 'L1A':
+            attrs = (
+            'Terra', 'ASTER', 'L1A', spl[2][2], None, dt.datetime.strptime(bname.split('_')[2][3:], '%m%d%Y%H%M%S'))
+        elif spl[0] == 'ASTGTM2':
+            attrs = ('Terra', 'ASTER', 'ASTGTM2', '2', spl[1], None)
+        elif spl[0] == 'NASADEM':
+            attrs = ('SRTM', 'SRTM', 'NASADEM-' + spl[1], '1', spl[2], dt.datetime(year=2000, month=2, day=15))
+        elif spl[0] == 'TDM1' and spl[1] == 'DEM':
+            attrs = ('TanDEM-X', 'TanDEM-X', 'TDM1', '1', spl[4], None)
+        elif spl[0] == 'srtm':
+            attrs = ('SRTM', 'SRTM', 'SRTMv4.1', None, '_'.join(spl[1:]), dt.datetime(year=2000, month=2, day=15))
+        else:
+            print("No metadata could be read from filename.")
+            attrs = (None for i in range(6))
+
+    # if the form is only XX.ext (only the first versions of SRTM had a naming that... bad (simplfied?))
+    elif os.path.splitext(os.path.basename(fname))[1] == '.hgt':
+        attrs = ('SRTM', 'SRTM', 'SRTMGL1', '3', os.path.splitext(os.path.basename(fname))[0],
+                 dt.datetime(year=2000, month=2, day=15))
+
+    else:
+        print("No metadata could be read from filename.")
+        attrs = (None for i in range(6))
+
+    return attrs
+
+def parse_tile_attr_from_name(tile_name,product=None):
+    """
+    Convert tile naming to metadata coordinates based on sensor and product
+    by default the SRTMGL1 1x1° tile naming convention to lat, lon (originally SRTMGL1)
+
+    :param tile_name: tile name
+    :type tile_name: str
+    :param product: satellite product
+    :type product: str
+
+    :returns: lat, lon of southwestern corner
+    """
+
+    if product is None or product in ['ASTGTM2','SRTMGL1','NASADEM']:
+        ymin, xmin = sw_naming_to_latlon(tile_name)
+        yx_sizes = (1,1)
+        epsg = 4326
+    elif product in ['TDM1']:
+        ymin, xmin = sw_naming_to_latlon(tile_name)
+        #TDX tiling
+        if ymin >= 80 or ymin < -80:
+            yx_sizes = (1,4)
+        elif ymin >= 60 or ymin < -60:
+            yx_sizes = (1,2)
+        else:
+            yx_sizes = (1,1)
+        epsg = 4326
+    else:
+        raise ValueError('Tile naming '+tile_name+' not recognized for product '+str(product))
+
+    return ymin, xmin, yx_sizes, epsg
+
+def sw_naming_to_latlon(tile_name):
+
+    """
+    Get latitude and longitude corresponding to southwestern corner of tile naming (originally SRTMGL1 convention)
+    parsing is robust to lower/upper letters to formats with 2 or 3 digits for latitude (NXXWYYY for most existing products,
+    but for example it is NXXXWYYY for ALOS) and to reverted formats (WXXXNYY).
+
+    :param tile_name: name of tile
+    :type tile_name: str
+
+    :return: latitude and longitude of southwestern corner
+    :rtype: tuple
+    """
+
+    tile_name = tile_name.upper()
+    if tile_name[0] in ['S','N']:
+        if 'W' in tile_name:
+            lon = -int(tile_name[1:].split('W')[1])
+            lat_unsigned = int(tile_name[1:].split('W')[0])
+        elif 'E' in tile_name:
+            lon = int(tile_name[1:].split('E')[1])
+            lat_unsigned = int(tile_name[1:].split('E')[0])
+        else:
+            raise ValueError('No west (W) or east (E) in the tile name')
+
+        if tile_name[0] == 'S':
+            lat = -lat_unsigned
+        else:
+            lat = lat_unsigned
+
+    elif tile_name[0] in ['W','E']:
+        if 'S' in tile_name:
+            lon_unsigned = int(tile_name[1:].split('S')[0])
+            lat = -int(tile_name[1:].split('S')[1])
+        elif 'N' in tile_name:
+            lon_unsigned = int(tile_name[1:].split('N')[0])
+            lat = int(tile_name[1:].split('N')[1])
+        else:
+            raise ValueError('No south (S) or north (N) in the tile name')
+
+        if tile_name[0] == 'W':
+            lon = -lon_unsigned
+        else:
+            lon = lon_unsigned
+
+    else:
+        raise ValueError('Tile not recognized: should start with south (S), north (N), east (E) or west(W)')
+
+    return lat, lon
+
+def latlon_to_sw_naming(latlon,latlon_sizes=((1,1),),lat_lims=((0,90.1),)):
+    """
+    Convert latitude and longitude to widely used southwestern corner tile naming (originally for SRTMGL1)
+    Can account for varying tile sizes, and a dependency with the latitude (e.g., TDX global DEM)
+
+    :param latlon: latitude and longitude
+    :type latlon: collections.abc.Iterable
+    :param latlon_sizes: sizes of lat/lon tiles corresponding to latitude intervals
+    :type latlon_sizes: collections.abc.Iterable
+    :param lat_lims: latitude intervals
+    :type lat_lims: collections.abc.Iterable
+
+    :returns: tile name
+    :rtype: str
+    """
+
+    lon = latlon[1]
+    lon = ((lon + 180) % 360) - 180
+    lat = latlon[0]
+    lat = ((lat + 90) % 180) - 90
+
+    if lat<0:
+        str_lat = 'S'
+    else:
+        str_lat = 'N'
+
+    if lon<0:
+        str_lon = 'W'
+    else:
+        str_lon = 'E'
+
+
+    tile_name = None
+    for latlim in lat_lims:
+        if latlim[0] <= np.abs(lat) < latlim[1]:
+            ind = lat_lims.index(latlim)
+            lat_corner = np.floor(lat/latlon_sizes[ind][0])*latlon_sizes[ind][0]
+            lon_corner = np.floor(lon/latlon_sizes[ind][1])*latlon_sizes[ind][1]
+            tile_name = str_lat+str(int(abs(lat_corner))).zfill(2)+str_lon+str(int(abs(lon_corner))).zfill(3)
+
+    if tile_name is None:
+        raise ValueError('Latitude intervals provided do not contain the lat/lon coordinates')
+
+    return tile_name
+
+
+class SatelliteImage(Raster):
+
+    def __init__(self, filename, attrs=None, load_data=True, bands=None,
+                 as_memfile=False, read_from_fn=True, datetime=None, tile_name=None, satellite=None, sensor=None, product=None,
+                 version=None, read_from_meta=True,fn_meta=None,silent=False):
+
+        """
+        Load satellite data through the Raster class and parse additional attributes from filename or metadata.
+
+        :param filename: The filename of the dataset.
+        :type filename: str
+        :param attrs: Additional attributes from rasterio's DataReader class to add to the Raster object.
+           Default list is ['bounds', 'count', 'crs', 'dataset_mask', 'driver', 'dtypes', 'height', 'indexes',
+           'name', 'nodata', 'res', 'shape', 'transform', 'width'] - if no attrs are specified, these will be added.
+        :type attrs: list of strings
+        :param load_data: Load the raster data into the object. Default is True.
+        :type load_data: bool
+        :param bands: The band(s) to load into the object. Default is to load all bands.
+        :type bands: int, or list of ints
+        :param as_memfile: open the dataset via a rio.MemoryFile.
+        :type as_memfile: bool
+        :param read_from_fn: Try to read metadata from the filename
+        :type: bool
+        :param datetime: Provide datetime attribute
+        :type datetime: dt.datetime
+        :param tile_name: Provide tile name
+        :type tile_name: str
+        :param satellite: Provide satellite name
+        :type satellite: str
+        :param sensor: Provide sensor name
+        :type sensor: str
+        :param product: Provide data product name
+        :type product: str
+        :param version: Provide data version
+        :type version: str
+        :param read_from_meta: Try to read metadata from known associated metadata files
+        :type read_from_meta: bool
+        :param fn_meta: Provide filename of associated metadata
+        :type: fn_meta: str
+        :param silent: No informative output when trying to read metadata
+        :type silent: bool
+
+        :return: A SatelliteImage object (Raster subclass)
+        """
+
+        super().__init__(filename, attrs=attrs, load_data=load_data, bands=bands, as_memfile=as_memfile)
+
+        #TODO: maybe the Raster class should have an "original filename" attribute that doesn't get erased during
+        # in-memory manipulation for the possibility of parsing metadata a later stage?
+
+        # priority to user input
+        self.datetime = datetime
+        self.tile_name = tile_name
+        self.satellite = satellite
+        self.sensor = sensor
+        self.product = product
+        self.version = version
+
+        # trying to get metadata from separate metadata file
+        if read_from_meta and self.filename is not None:
+            self.__parse_metadata_from_file(fn_meta)
+
+        # trying to get metadata from filename for the None attributes
+        if read_from_fn and self.filename is not None:
+            self.__parse_metadata_from_fn()
+
+        self.__get_date()
+
+    def __get_date(self):
+
+        """
+        Get date from datetime
+        :return:
+        """
+        if self.datetime is not None:
+            self.date = self.datetime.date()
+        else:
+            self.date = None
+
+    def __parse_metadata_from_fn(self,silent=False):
+
+        """
+        Attempts to pull metadata (e.g., sensor, date information) from fname, setting sensor, satellite,
+        tile, datetime, and date attributes.
+        """
+
+        fname = self.filename
+        name_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime']
+        attrs = parse_metadata_from_fn(fname)
+
+        for n in name_attrs:
+            a = self.__getattribute__(n)
+            a_fn =  attrs[name_attrs.index(n)]
+            if a is None and a_fn is not None:
+                if not silent:
+                    print('From filename: setting '+n+ ' as '+str(a_fn))
+                setattr(self,n,a_fn)
+            elif a is not None and attrs[name_attrs.index(n)] is not None:
+                if not silent:
+                    print('Leaving user input of '+str(a)+' for attribute '+n+' despite reading '+str(attrs[name_attrs.index(n)])+ 'from filename')
+
+    def __parse_metadata_from_file(self,fn_meta):
+        pass
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-numpy
-rasterio
-shapely
-rioxarray
-geopandas
-matplotlib

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1,5 +1,5 @@
 """
-Test functions for geoutils
+Test functions for georaster
 """
 import os
 import inspect
@@ -15,6 +15,7 @@ DO_PLOT = False
 
 @pytest.fixture()
 def path_data():
+
     data_folder = os.path.join('tests', 'data')
 
     path2data = {}
@@ -71,18 +72,17 @@ class TestRaster:
 
         b_minmax = (max(b[0],b2[0]),max(b[1],b2[1]),min(b[2],b2[2]),min(b[3],b2[3]))
 
-        #TODO: add copy here (with copy() method) and plot all at the end?
+        r_init = r.copy()
 
-        if DO_PLOT:
-            plt.figure()
-            r.show(title='Raster 1')
-            plt.figure()
-            r2.show(title='Raster 2')
-
+        #cropping overwrites the current Raster object
         r.crop(r2)
         b_crop = tuple(r.bounds)
 
         if DO_PLOT:
+            plt.figure()
+            r_init.show(title='Raster 1')
+            plt.figure()
+            r2.show(title='Raster 2')
             plt.figure()
             r.show(title='Raster 1 cropped to Raster 2')
 
@@ -117,8 +117,6 @@ class TestRaster:
         r = gr.Raster(path_data['fn_img'])
 
         xmin, ymin, xmax, ymax = r.ds.bounds
-
-        print(xmin, ymin, xmax, ymax)
 
         # testing interp, find_value, and read when it falls right on the coordinates
         xrand = np.random.randint(low=0,high=r.ds.width,size=(10,))*list(r.ds.transform)[0] + xmin + list(r.ds.transform)[0]/2

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -157,12 +157,13 @@ class TestRaster:
 
         r = gr.Raster(path_data['fn_img'])
         r.set_ndv(ndv=[255])
-        ndv_index = r.data==r.nodata
+        data = r.data
+        ndv_index = data==r.nodata
 
         #change data in case
-        r.data[r.data == 254]=0
+        data[data == 254]=0
         r.set_ndv(ndv=254,update_array=True)
-        ndv_index_2 = r.data==r.nodata
+        ndv_index_2 = data==r.nodata
 
         assert np.count_nonzero(~ndv_index_2==ndv_index) == 0
 

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -1,0 +1,82 @@
+"""
+Test functions for SatelliteImage class
+"""
+import os
+import inspect
+import geoutils.georaster as gr
+import geoutils.satimg as si
+import pytest
+import datetime as dt
+
+DO_PLOT = False
+
+@pytest.fixture()
+def path_data():
+    data_folder = os.path.join('tests', 'data')
+    fn_img = os.path.join(data_folder, 'LE71400412000304SGS00_B4_crop.TIF')
+    fn_img2 = os.path.join(data_folder,'LE71400412000304SGS00_B4_crop2.TIF')
+
+    return fn_img, fn_img2
+
+class TestSatelliteImage:
+
+    def test_load_subclass(self,path_data):
+
+        fn_img, _ = path_data
+
+        img = si.SatelliteImage(fn_img,read_from_fn=False)
+        img = si.SatelliteImage(fn_img)
+
+    def test_filename_parsing(self):
+
+        copied_names = ['TDM1_DEM__30_N00E104_DEM.tif',
+                        'SETSM_WV02_20141026_1030010037D17F00_10300100380B4000_mosaic5_2m_v3.0_dem.tif',
+                        'AST_L1A_00303132015224418_final.tif',
+                        'ILAKS1B_20190928_271_Gilkey-DEM.tif',
+                        'srtm_06_01.tif',
+                        'ASTGTM2_N00E108_dem.tif',
+                        'N00E015.hgt',
+                        'NASADEM_HGT_n00e041.hgt']
+        #corresponding data, filled manually
+        satellites = ['TanDEM-X','WorldView','Terra','IceBridge','SRTM','Terra','SRTM','SRTM']
+        sensors = ['TanDEM-X','WV02','ASTER','UAF-LS','SRTM','ASTER','SRTM','SRTM']
+        products = ['TDM1','ArcticDEM/REMA','L1A','ILAKS1B','SRTMv4.1','ASTGTM2','SRTMGL1','NASADEM-HGT']
+        #we can skip the version, bit subjective...
+        tiles = ['N00E104',None,None,None,'06_01','N00E108','N00E015','n00e041']
+        datetimes = [None,dt.datetime(year=2014,month=10,day=26),dt.datetime(year=2015,month=3,day=13,hour=22,minute=44,second=18),
+                     dt.datetime(year=2019,month=9,day=28),dt.datetime(year=2000,month=2,day=15),None,dt.datetime(year=2000,month=2,day=15),
+                     dt.datetime(year=2000,month=2,day=15)]
+
+
+        for names in copied_names:
+            attrs = si.parse_metadata_from_fn(names)
+            i = copied_names.index(names)
+            assert satellites[i] == attrs[0]
+            assert sensors[i] == attrs[1]
+            assert products[i] == attrs[2]
+            assert tiles[i] == attrs[4]
+            assert datetimes[i] == attrs[5]
+
+    def test_sw_tile_naming_parsing(self):
+
+        #normal examples
+        test_tiles = ['N14W065','S14E065','N014W065','W065N014','W065N14','N00E000']
+        test_latlon = [(14,-65),(-14,65),(14,-65),(14,-65),(14,-65),(0,0)]
+
+        for tile in test_tiles:
+            assert si.sw_naming_to_latlon(tile)[0] == test_latlon[test_tiles.index(tile)][0]
+            assert si.sw_naming_to_latlon(tile)[1] == test_latlon[test_tiles.index(tile)][1]
+
+        for latlon in test_latlon:
+            assert si.latlon_to_sw_naming(latlon) == test_tiles[test_latlon.index(latlon)]
+
+        #check possible exceptions, rounded lat/lon belong to their southwest border
+        assert si.latlon_to_sw_naming((0,0)) == 'N00E000'
+        #those are the same point, should give same naming
+        assert si.latlon_to_sw_naming((-90,0)) == 'S90E000'
+        assert si.latlon_to_sw_naming((90,0)) == 'S90E000'
+        #same here
+        assert si.latlon_to_sw_naming((0,-180)) == 'N00W180'
+        assert si.latlon_to_sw_naming((0,180)) == 'N00W180'
+
+


### PR DESCRIPTION
Closes #24 

`get_data()` and `set_data()` methods added to the Raster class.
I put a low level check in `set_data` that makes sure new data array is the same shape as the existing one. I'm not sure that addresses the check that @atedstone discussed in his issue - Ted will you review and let me know?

I'm also a bit confused as to how this `set_data()` method conflicts with the purpose of _update(), which seems to update the original file with new data. I'm pretty sure that is distinct from the goal of `set_data()`, but again, @atedstone, let me know.

I changed the tests accordingly and those are passing on my machine.

Note that this will probably break people's existing code that lives outside of GeoUtils.