### PR TITLE
Add a function to convert coordinates between two CRS, or from/to latlon

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1054,7 +1054,7 @@ to be cleared due to the setting of GCPs.")
     def value_at_coords(self, x, y, latlon=False, band=None, masked=False,
                         window=None, return_window=False, boundless=True,
                         reducer_function=np.ma.mean):
-        """ Extract the pixel value(s) at the specified coordinates.
+        """ Extract the pixel value(s) at the nearest pixel(s) from the specified coordinates.
 
         Extract pixel value of each band in dataset at the specified
         coordinates. Alternatively, if band is specified, return only that
@@ -1125,10 +1125,11 @@ to be cleared due to the setting of GCPs.")
 
         # Need to implement latlon option later
         if latlon:
-            raise NotImplementedError()
+            from geoutils import projtools
+            x, y = projtools.reproject_from_latlon((y, x), self.crs)
 
         # Convert coordinates to pixel space
-        row, col = self.ds.index(x, y)
+        row, col = self.ds.index(x, y, op=round)
 
         # Decide what pixel coordinates to read:
         if window != None:

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -73,7 +73,7 @@ def reproject_points(pts, in_crs, out_crs):
 
 crs_4326 = rio.crs.CRS.from_epsg(4326)
 
-def reproject_to_latlon(pts, in_crs):
+def reproject_to_latlon(pts, in_crs, round_: int = 8):
     """
     Reproject a set of point from in_crs to lat/lon.
 
@@ -81,14 +81,18 @@ def reproject_to_latlon(pts, in_crs):
     :type pts: list, tuple, np.ndarray'
     :param in_crs: Input CRS
     :type in_crs: rasterio.crs.CRS
+    :param round_: Output rounding. Default of 8 ensures cm accuracy
+    :type round_: int
 
     :returns: Reprojected points, of same shape as pts.
     :rtype: list
     """
-    return reproject_points(pts, in_crs, crs_4326)
+    proj_pts = reproject_points(pts, in_crs, crs_4326)
+    proj_pts = np.round(proj_pts, round_)
+    return proj_pts
 
 
-def reproject_from_latlon(pts, out_crs):
+def reproject_from_latlon(pts, out_crs, round_: int = 2):
     """
     Reproject a set of point from lat/lon to out_crs.
 
@@ -96,11 +100,15 @@ def reproject_from_latlon(pts, out_crs):
     :type pts: list, tuple, np.ndarray'
     :param out_crs: Output CRS
     :type out_crs: rasterio.crs.CRS
+    :param round_: Output rounding. Default of 2 ensures cm accuracy
+    :type round_: int
 
     :returns: Reprojected points, of same shape as pts.
     :rtype: list
     """
-    return reproject_points(pts, crs_4326, out_crs)
+    proj_pts = reproject_points(pts, crs_4326, out_crs)
+    proj_pts = np.round(proj_pts, round_)
+    return proj_pts
 
 
 def reproject_shape(inshape, in_crs, out_crs):

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -11,6 +11,7 @@ from rasterio.io import MemoryFile
 
 import geoutils.georaster as gr
 from geoutils import datasets
+import geoutils.projtools as pt
 
 
 DO_PLOT = False
@@ -454,3 +455,39 @@ class TestRaster:
         img2.data += 1
 
         assert img != img2
+
+    def test_value_at_coords(self):
+        """
+        Check that values returned at selected pixels correspond to what is expected, both for original CRS and lat/lon.
+        """
+        img = gr.Raster(datasets.get_path("landsat_B4"))
+
+        # Lower right pixel
+        x, y = [
+            img.bounds.right - img.res[0],
+            img.bounds.bottom + img.res[1]
+        ]
+        lat, lon = pt.reproject_to_latlon([x, y], img.crs)
+        assert img.value_at_coords(x, y) == \
+            img.value_at_coords(lon, lat, latlon=True) == \
+            img.data[0, -1, -1]
+
+        # One pixel above
+        x, y = [
+            img.bounds.right - img.res[0],
+            img.bounds.bottom + 2 * img.res[1]
+        ]
+        lat, lon = pt.reproject_to_latlon([x, y], img.crs)
+        assert img.value_at_coords(x, y) == \
+            img.value_at_coords(lon, lat, latlon=True) == \
+            img.data[0, -2, -1]
+
+        # One pixel left
+        x, y = [
+            img.bounds.right - 2 * img.res[0],
+            img.bounds.bottom + img.res[1]
+        ]
+        lat, lon = pt.reproject_to_latlon([x, y], img.crs)
+        assert img.value_at_coords(x, y) == \
+            img.value_at_coords(lon, lat, latlon=True) == \
+            img.data[0, -1, -2]

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -1,0 +1,29 @@
+"""
+Test projtools
+"""
+import numpy as np
+
+import geoutils.georaster as gr
+import geoutils.projtools as pt
+from geoutils import datasets
+
+
+class TestProjTools:
+
+    def test_latlon_reproject(self):
+        """
+        Check that to and from latlon projections are self consistent within tolerated rounding errors
+        """
+
+        img = gr.Raster(datasets.get_path('landsat_B4'))
+
+        # Test on random points
+        nsample = 100
+        randx = np.random.randint(low=img.bounds.left, high=img.bounds.right, size=(nsample,))
+        randy = np.random.randint(low=img.bounds.bottom, high=img.bounds.top, size=(nsample,))
+
+        lat, lon = pt.reproject_to_latlon([randx, randy], img.crs)
+        x, y = pt.reproject_from_latlon([lat, lon], img.crs)
+
+        assert np.all(x == randx)
+        assert np.all(y == randy)


### PR DESCRIPTION
To be used for example by Raster.value_at_coords or self.interp.

I need to add tests, but there is an issue with the accuracy of the results, e.g.:
```
from geoutils import georaster as gr
from geoutils import datasets
from geoutils import projtools as pt
img = gr.Raster(datasets.get_path('landsat_B4'))
lat, lon = pt.reproject_to_latlon([img.bounds.left, img.bounds.top], img.crs)
x, y = pt.reproject_from_latlon([lat, lon], img.crs)
x - img.bounds.left
```
=> -5.238689482212067e-10
This yields uncertain outputs if for example included in Raster.value_at_coords. If requesting the value of the top-left pixel, it will actually look for the pixel with column -1 instead of 0.
Any idea @rhugonnet ?