### PR TITLE
add bands attribute to Raster

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -271,6 +271,8 @@ class Raster(object):
         """
         Setter method for the _data class member.
 
+        new_data must have the same shape as existing data! (bands dimension included)
+
         :param new_data: New data to assign to this instance of Raster
         :type new_data: np.ndarray
         """
@@ -411,8 +413,11 @@ class Raster(object):
         """
         if bands is None:
             self._data = self.ds.read(masked=self._masked, **kwargs)
+            bands = self.ds.indexes
         else:
             self._data = self.ds.read(bands, masked=self._masked, **kwargs)
+            if type(bands) is int:
+                bands = (bands)
 
         # If ndim is 2, expand to 3
         if self._data.ndim == 2:
@@ -420,6 +425,7 @@ class Raster(object):
 
         self.nbands = self._data.shape[0]
         self.is_loaded = True
+        self.bands = bands
 
     def crop(self, cropGeom, mode='match_pixel'):
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -113,6 +113,7 @@ class TestRaster:
         assert r.count == 3
         assert r.indexes == (1, 2, 3)
         assert r.nbands == 3
+        assert r.bands == (1, 2, 3)
         assert r.data.shape == (r.count, r.height, r.width)
 
         # Test 5 - multiple bands, load one band only
@@ -120,13 +121,15 @@ class TestRaster:
         assert r.count == 3
         assert r.indexes == (1, 2, 3)
         assert r.nbands == 1
+        assert r.bands == (1)
         assert r.data.shape == (r.nbands, r.height, r.width)
 
         # Test 6 - multiple bands, load a list of bands
-        r = gr.Raster(datasets.get_path("landsat_RGB"), load_data=True, bands=(1,2))
+        r = gr.Raster(datasets.get_path("landsat_RGB"), load_data=True, bands=(2, 3))
         assert r.count == 3
         assert r.indexes == (1, 2, 3)
         assert r.nbands == 2
+        assert r.bands == (2, 3)
         assert r.data.shape == (r.nbands, r.height, r.width)
 
     def test_downsampling(self):


### PR DESCRIPTION
Resolves #121 

Note that there is also the attribute `self.indexes`. This is always set by the contents of `ds.indexes`. Here, `self.bands` refers uniquely to the band order of `self.data`, only if data has been loaded.