### PR TITLE
Simplify import statements

### DIFF
--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -7,6 +7,10 @@ from . import geovector
 from . import datasets
 from . import satimg
 
+from .georaster import Raster
+from .geovector import Vector
+from .satimg import SatelliteImage
+
 try:
     from geoutils.version import version as __version__
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
See the rationale in #141.

Example:
```python
import geoutils as gu

r = gu.Raster("...")
v = gu.Vector("...")
img = gu.SatelliteImage("...")
```