### PR TITLE
Add `copy()` and `query()` methods to Vector and add `test_geovector.py` file

### DIFF
--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -59,6 +59,11 @@ class Vector(object):
 
         return "".join(as_str)
 
+    def copy(self):
+        """Return a copy of the Vector."""
+        # Utilise the copy method of GeoPandas
+        return Vector(self.ds.copy())
+
     def crop2raster(self, rst):
         """
         Update self so that features outside the extent of a raster file are cropped. Reprojection is done on the fly if both data set have different projections.

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -162,3 +162,20 @@ class Vector(object):
                                   transform=transform, default_value=in_value)
 
         return mask
+
+    def query(self, expression: str, inplace=False):
+        """
+        Query the Vector dataset with a valid Pandas expression.
+
+        :param expression: A python-like expression to evaluate. Example: "col1 > col2"
+        :param inplace: Whether the query should modify the data in place or return a modified copy.
+
+        :returns: Vector resulting from the provided query expression or itself if inplace=True.
+        """
+        # Modify inplace if wanted and return the self instance.
+        if inplace:
+            self.ds.query(expression, inplace=True)
+            return self
+
+        # Otherwise, create a new Vector from the queried dataset.
+        return Vector(self.ds.query(expression))

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -2,10 +2,12 @@
 geoutils.vectortools provides a toolset for working with vector data.
 """
 import warnings
-import numpy as np
+
 import geopandas as gpd
+import numpy as np
 import rasterio as rio
-from rasterio import warp, features
+from rasterio import features, warp
+
 
 class Vector(object):
     """
@@ -22,11 +24,11 @@ class Vector(object):
         :return: A Vector object
         """
 
-        if isinstance(filename,str):
+        if isinstance(filename, str):
             ds = gpd.read_file(filename)
             self.ds = ds
             self.name = filename
-        elif isinstance(filename,gpd.GeoDataFrame):
+        elif isinstance(filename, gpd.GeoDataFrame):
             self.ds = filename
             self.name = None
         else:

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,0 +1,23 @@
+import geoutils as gu
+
+GLACIER_OUTLINES_URL = "http://public.data.npolar.no/cryoclim/CryoClim_GAO_SJ_1990.zip"
+
+
+class TestVector:
+    glacier_outlines = gu.Vector(GLACIER_OUTLINES_URL)
+
+    def test_init(self):
+
+        vector = gu.Vector(GLACIER_OUTLINES_URL)
+
+        assert isinstance(vector, gu.Vector)
+
+    def test_copy(self):
+
+        vector2 = self.glacier_outlines.copy()
+
+        assert vector2 is not self.glacier_outlines
+
+        vector2.ds = vector2.ds.query("NAME == 'Ayerbreen'")
+
+        assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -21,3 +21,11 @@ class TestVector:
         vector2.ds = vector2.ds.query("NAME == 'Ayerbreen'")
 
         assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]
+
+    def test_query(self):
+
+        vector2 = self.glacier_outlines.query("NAME == 'Ayerbreen'")
+
+        assert vector2 is not self.glacier_outlines
+
+        assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]


### PR DESCRIPTION
First off, no tests existed for `geovector.py`!
I created some very simple tests, but these should be improved in the future.

I have added two methods to `Vector`:

* `copy()` just returns a copy of itself. Since Vector is only a wrapper for a gpd.GeoDataFrame right now, this was dead simple.
* `query()` allows for text-based queries to the dataframe. In xdem, this is used to query individual glacier outlines from a larger outlines vector. It would be nice to have this method directly instead of a hacky copy approach done right now.