### PR TITLE
Add `split_bands()` method to Raster

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1446,10 +1446,10 @@ to be cleared due to the setting of GCPs.")
 
         :returns: A list of Rasters for each band.
         """
-        bands: list[Raster] = []
+        bands: list[self] = []
 
         for band_n in range(self.nbands):
-            bands.append(Raster.from_array(
+            bands.append(self.from_array(
                 self.data[band_n, :, :],
                 transform=self.transform,
                 crs=self.crs,

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1439,3 +1439,21 @@ to be cleared due to the setting of GCPs.")
         rpts = np.array(rpts)
 
         return rpts
+
+    def split_bands(self):
+        """
+        Split the bands into separate copied rasters.
+
+        :returns: A list of Rasters for each band.
+        """
+        bands: list[Raster] = []
+
+        for band_n in range(self.nbands):
+            bands.append(Raster.from_array(
+                self.data[band_n, :, :],
+                transform=self.transform,
+                crs=self.crs,
+                nodata=self.nodata
+            ))
+
+        return bands

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -555,3 +555,22 @@ class TestRaster:
         img.data.mask[0, 0, 0] = True
         out_img = gr.Raster.from_array(img.data, img.transform, img.crs, nodata=0)
         assert out_img.data.mask[0, 0, 0]
+
+    def test_split_bands(self):
+
+        img = gr.Raster(datasets.get_path('landsat_RGB'))
+
+        red, green, blue = img.split_bands()
+
+        # Check that the red band is not equal to the full RGB data.
+        assert red != img
+
+        assert red.nbands == 1
+        assert img.nbands == 3
+
+        # Test that the red band corresponds to the first band of the img
+        assert np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+
+        # Modify the red band and make sure it doesn't propagate to the original img (it's a copy)
+        red.data += 1
+        assert not np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))


### PR DESCRIPTION
As discussed with @adehecq, this functionality may have widespread use, and will be especially useful for a function in the making in `xdem`.

## Example:
```python
import geoutils as gu

rgb_img = gu.Raster(datasets.get_path('landsat_RGB'))

red, green, blue = img.split_bands()

# Do all kinds of analyses on each band separately
```
Maybe a `.stack()` method or similar should be added to reverse the functionality of `.split_bands()`?

Unfortunately, I wanted to add a `copy: bool =  False` kwarg to reduce copying, but this is not currently possible. `Raster.from_array()` always returns a copy, which is great in most cases, but maybe something can be done about that in the future? A `copy: bool = True` kwarg for `from_array()` which can be changed in case of memory-sensitive work?

