### PR TITLE
Add copy/no-copy functionality to `split_bands()` and `subset` argument

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1444,7 +1444,7 @@ to be cleared due to the setting of GCPs.")
 
         return rpts
 
-    def split_bands(self, copy=False, subset: Optional[Union[list[int], int]] = None):
+    def split_bands(self, copy: bool = False, subset: Optional[Union[list[int], int]] = None):
         """
         Split the bands into separate copied rasters.
 

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1446,10 +1446,10 @@ to be cleared due to the setting of GCPs.")
 
         :returns: A list of Rasters for each band.
         """
-        bands: list[Raster] = []
+        bands: list[self] = []
 
         for band_n in range(self.nbands):
-            bands.append(Raster.from_array(
+            bands.append(self.from_array(
                 self.data[band_n, :, :],
                 transform=self.transform,
                 crs=self.crs,

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1,8 +1,12 @@
 """
 geoutils.georaster provides a toolset for working with raster data.
 """
+from __future__ import annotations
+
 import os
 import warnings
+from typing import Optional, Union
+
 import numpy as np
 import collections
 import rasterio as rio
@@ -1440,20 +1444,43 @@ to be cleared due to the setting of GCPs.")
 
         return rpts
 
-    def split_bands(self):
+    def split_bands(self, copy=False, subset: Optional[Union[list[int], int]] = None):
         """
         Split the bands into separate copied rasters.
 
-        :returns: A list of Rasters for each band.
+        :param copy: Copy the bands or return slices of the original data.
+        :param subset: Optional. A subset of band indices to extract. Defaults to all.
+
+        :returns: A list of Rasters for each band, or one Raster if len(subset)==1.
         """
         bands: list[self] = []
 
-        for band_n in range(self.nbands):
-            bands.append(self.from_array(
-                self.data[band_n, :, :],
-                transform=self.transform,
-                crs=self.crs,
-                nodata=self.nodata
-            ))
+        if subset is None:
+            indices = list(range(self.nbands))
+        elif isinstance(subset, int):
+            indices = [subset]
+        elif isinstance(subset, list):
+            indices = subset
+        else:
+            raise ValueError(f"'subset' got invalid type: {type(subset)}. Expected list[int], int or None")
 
-        return bands
+        if copy:
+            for band_n in indices:
+                # Generate a new Raster from a copy of the band's data
+                bands.append(self.from_array(
+                    self.data[band_n, :, :],
+                    transform=self.transform,
+                    crs=self.crs,
+                    nodata=self.nodata
+                ))
+        else:
+            for band_n in indices:
+                # Generate a new instance with the same underlying values.
+                raster = Raster(self)
+                # Set the data to a slice of the original array
+                raster._data = self.data[band_n, :, :].reshape(((1,) + self.data.shape[1:]))
+                # Set the nbands
+                raster.nbands = 1
+                bands.append(raster)
+
+        return bands if len(bands) > 1 else bands[0]

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1439,3 +1439,21 @@ to be cleared due to the setting of GCPs.")
         rpts = np.array(rpts)
 
         return rpts
+
+    def split_bands(self):
+        """
+        Split the bands into separate copied rasters.
+
+        :returns: A list of Rasters for each band.
+        """
+        bands: list[Raster] = []
+
+        for band_n in range(self.nbands):
+            bands.append(Raster.from_array(
+                self.data[band_n, :, :],
+                transform=self.transform,
+                crs=self.crs,
+                nodata=self.nodata
+            ))
+
+        return bands

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -555,3 +555,22 @@ class TestRaster:
         img.data.mask[0, 0, 0] = True
         out_img = gr.Raster.from_array(img.data, img.transform, img.crs, nodata=0)
         assert out_img.data.mask[0, 0, 0]
+
+    def test_split_bands(self):
+
+        img = gr.Raster(datasets.get_path('landsat_RGB'))
+
+        red, green, blue = img.split_bands()
+
+        # Check that the red band is not equal to the full RGB data.
+        assert red != img
+
+        assert red.nbands == 1
+        assert img.nbands == 3
+
+        # Test that the red band corresponds to the first band of the img
+        assert np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+
+        # Modify the red band and make sure it doesn't propagate to the original img (it's a copy)
+        red.data += 1
+        assert not np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -592,7 +592,7 @@ class TestRaster:
         red.data += 1
         assert np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
 
-        # Copy the bands instead of
+        # Copy the bands instead of pointing to the same memory.
         red_c = img.split_bands(copy=True, subset=0)
 
         # Check that the red band data does not share memory with the rgb image (it's a copy)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -560,17 +560,44 @@ class TestRaster:
 
         img = gr.Raster(datasets.get_path('landsat_RGB'))
 
-        red, green, blue = img.split_bands()
+        red, green, blue = img.split_bands(copy=False)
 
-        # Check that the red band is not equal to the full RGB data.
-        assert red != img
-
+        # Check that the shapes are correct.
         assert red.nbands == 1
+        assert red.data.shape[0] == 1
         assert img.nbands == 3
+        assert img.data.shape[0] == 3
+
+        # Extract only one band (then it will not return a list)
+        red2 = img.split_bands(copy=False, subset=0)
+
+        # Extract a subset with a list in a weird direction
+        blue2, green2 = img.split_bands(copy=False, subset=[2, 1])
+
+        # Check that the subset functionality works as expected.
+        assert np.array_equal(red.data.astype("float32"), red2.data.astype("float32"))
+        assert np.array_equal(blue.data.astype("float32"), blue2.data.astype("float32"))
+        assert np.array_equal(green.data.astype("float32"), green2.data.astype("float32"))
+
+        # Check that the red channel and the rgb data shares memory
+        assert np.shares_memory(red.data, img.data)
+
+        # Check that the red band data is not equal to the full RGB data.
+        assert red != img
 
         # Test that the red band corresponds to the first band of the img
         assert np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
 
-        # Modify the red band and make sure it doesn't propagate to the original img (it's a copy)
+        # Modify the red band and make sure it propagates to the original img (it's not a copy)
         red.data += 1
-        assert not np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+        assert np.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+
+        # Copy the bands instead of
+        red_c = img.split_bands(copy=True, subset=0)
+
+        # Check that the red band data does not share memory with the rgb image (it's a copy)
+        assert not np.shares_memory(red_c, img)
+
+        # Modify the copy, and make sure the original data is not modifed.
+        red_c.data += 1
+        assert not np.array_equal(red_c.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))


### PR DESCRIPTION
I should have experimented a little more before my previous PR!

As shown in the test, `split_bands(copy=False)` now works as one would expect it to, and `.split_bands(copy=True, subset=0)` can for example be used to only return the red band (instead of copying every band)!

Solves the example in #159.