### PR TITLE
Separate dev-requirements and improve build workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: build-geoutils-dev
+name: build
 
 on:
   push:
@@ -23,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/pip install -r dev-requirements.txt
         $CONDA/bin/pip install .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,8 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/conda install -y -c conda-forge mamba
+        $CONDA/bin/mamba env update --file environment.yml --name base
         $CONDA/bin/pip install -r dev-requirements.txt
         $CONDA/bin/pip install .
     - name: Lint with flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+rasterio
+geopandas
+pyproj
+flake8
+pytest
+sphinx
+sphinx_rtd_theme

--- a/environment.yml
+++ b/environment.yml
@@ -9,11 +9,3 @@ dependencies:
   - rasterio
   - rioxarray
 
-  # code checks
-  - flake8
-
-  # testing
-  - pytest
-
-  # development
-  - pip


### PR DESCRIPTION
#163 proposed to only have the non-testing requirements in `environment.yml`. This is implemented with this PR.

Secondly, following the implementation in xdem, I changed the build workflow to use `mamba` instead of `conda` for dependency solving. This is much faster. Below is an example in my fork using mamba (top) and not mamba (bottom):
![image](https://user-images.githubusercontent.com/33550973/115427915-2b98ca80-a202-11eb-9fab-b20fa344ae63.png)

As you can see, builds should now take less than a third of the time it took before. This is because most of the build process was just conda being bad at resolving dependencies!

Finally, I changed the name of the build workflow from `build-geoutils-dev` to `build` in order to make a nice badge, like in xdem:

[![build](https://github.com/GlacioHack/xdem/actions/workflows/python-package.yml/badge.svg)](https://github.com/GlacioHack/xdem/actions/workflows/python-package.yml)
