### PR TITLE
Simplify reproject resampling argument to accept strings

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -36,6 +36,29 @@ else:
 default_attrs = ['bounds', 'count', 'crs', 'dataset_mask', 'driver', 'dtypes', 'height', 'indexes', 'name', 'nodata',
                  'res', 'shape', 'transform', 'width']
 
+
+def _resampling_from_str(resampling: str) -> Resampling:
+    """
+    Match a rio.warp.Resampling enum from a string representation.
+
+    :param resampling: A case-sensitive string matching the resampling enum (e.g. 'cubic_spline')
+    :raises ValueError: If no matching Resampling enum was found.
+    :returns: A rio.warp.Resampling enum that matches the given string.
+    """
+    # Try to match the string version of the resampling method with a rio Resampling enum name
+    for method in rio.warp.Resampling:
+        if str(method).replace("Resampling.", "") == resampling:
+            resampling_method = method
+            break
+    # If no match was found, raise an error.
+    else:
+        raise ValueError(
+            f"'{resampling}' is not a valid rasterio.warp.Resampling method. "
+            f"Valid methods: {[str(method).replace('Resampling.', '') for method in rio.warp.Resampling]}"
+        )
+    return resampling_method
+
+
 class Raster(object):
     """
     Create a Raster object from a rasterio-supported raster dataset.
@@ -605,7 +628,7 @@ class Raster(object):
         :param nodata: nodata value in reprojected data.
         :type nodata: int, float, None
         :param resampling: A rasterio Resampling method
-        :type resampling: rio.warp.Resampling object
+        :type resampling: rio.warp or a matching string representation.
         :param silent: If True, will not print warning statements
         :type silent: bool
         :param kwargs: additional keywords are passed to rasterio.warp.reproject. Use with caution.
@@ -666,7 +689,7 @@ class Raster(object):
             'src_transform': self.transform,
             'src_crs': self.crs,
             'dst_crs': dst_crs,
-            'resampling': resampling,
+            'resampling': resampling if isinstance(resampling, Resampling) else _resampling_from_str(resampling),
             'dst_nodata': nodata
         }
 


### PR DESCRIPTION
Something that bugs me about rasterio is that a resampling method cannot be given as a string, but must be given as their enums, which are not even imported by the base rio. This means that cubic spline resampling has to be made with:

```python
import geoutils as gu
import rasterio as rio
import rasterio.warp

img1 = gr.Raster(datasets.get_path("landsat_B4"))
img2 = gr.Raster(datasets.get_path("landsat_B4_crop"))

img1_reproj = img1.reproject(img2, resampling=rio.warp.Resampling.cubic_spline)
```

In this PR, I've added parsing functionality for strings as an alternative to the enums:
```python
import geoutils as gu

img1 = gu.Raster(gu.datasets.get_path("landsat_B4"))
img2 = gu.Raster(gu.datasets.get_path("landsat_B4_crop"))

img1_reproj = img1.reproject(img2, resampling="cubic_spline")
```
The `"cubic_spline"` string is matched with the `rio.warp.Resampling.cubic_spline` enum automatically.

If an incorrect string is given, it returns an error showing every valid string:
```python
>>> img1.reproject(img2, resampling="whatever's on the menu")
ValueError: 'whatever's on the menu' is not a valid rasterio.warp.Resampling method. Valid methods: ['nearest', 'bilinear', 'cubic', 'cubic_spline', 'lanczos', 'average', 'mode', 'gauss', 'max', 'min', 'med', 'q1', 'q3', 'rms']
```