### PR TITLE
Add support to crop rasters with vectors, and minor other improvements

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -4,6 +4,7 @@ geoutils.georaster provides a toolset for working with raster data.
 from __future__ import annotations
 
 import collections
+import copy
 from numbers import Number
 import os
 import warnings
@@ -644,7 +645,7 @@ class Raster(object):
         self.is_loaded = True
         self.bands = bands
 
-    def crop(self, cropGeom, mode='match_pixel'):
+    def crop(self, cropGeom, mode='match_pixel', inplace=True) -> Raster:
         """
         Crop the Raster to a given extent.
 
@@ -656,21 +657,21 @@ class Raster(object):
             resolution, cropping to the extent that most closely aligns with the current coordinates. 'match_extent'
             will match the extent exactly, adjusting the pixel resolution to fit the extent.
         :type mode: str
-
+        :param inplace: Update the raster inplace or return copy.
+        :type inplace: bool
+        :returns: None if inplace=True and a new Raster if inplace=False
         """
         import geoutils.geovector as vt
 
         assert mode in ['match_extent', 'match_pixel'], "mode must be one of 'match_pixel', 'match_extent'"
-        if isinstance(cropGeom, Raster):
+        if isinstance(cropGeom, (Raster, vt.Vector)):
             xmin, ymin, xmax, ymax = cropGeom.bounds
-        elif isinstance(cropGeom, vt.Vector):
-            raise NotImplementedError
         elif isinstance(cropGeom, (list, tuple)):
             xmin, ymin, xmax, ymax = cropGeom
         else:
             raise ValueError("cropGeom must be a Raster, Vector, or list of coordinates.")
 
-        meta = self.ds.meta
+        meta = copy.copy(self.ds.meta)
 
         if mode == 'match_pixel':
             crop_bbox = Polygon([(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)])
@@ -700,7 +701,11 @@ class Raster(object):
                          'width': new_width,
                          'transform': tfm})
 
-        self._update(crop_img, meta)
+        if inplace:
+            self._update(crop_img, meta)
+
+        else:
+            return Raster.from_array(crop_img, meta["transform"], meta["crs"], meta["nodata"])
 
     def clip(self):
         pass

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -35,6 +35,8 @@ class Vector(object):
             self.name = None
         else:
             raise ValueError('filename argument not recognised.')
+        
+        self.crs = self.ds.crs
 
     def __repr__(self):
         return self.ds.__repr__()
@@ -60,6 +62,11 @@ class Vector(object):
             self.ds.__repr__()]
 
         return "".join(as_str)
+
+    @property
+    def bounds(self) -> rio.coords.BoundingBox:
+        """Get a bounding box of the total bounds of the Vector."""
+        return rio.coords.BoundingBox(*self.ds.total_bounds)
 
     def copy(self):
         """Return a copy of the Vector."""

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -304,7 +304,6 @@ class TestRaster:
 
         b = r.bounds
         b2 = r2.bounds
-        print(r.shape, r2.shape, b, b2, r.res, r2.res)
 
         b_minmax = (max(b[0], b2[0]), max(b[1], b2[1]),
                     min(b[2], b2[2]), min(b[3], b2[3]))

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -29,3 +29,11 @@ class TestVector:
         assert vector2 is not self.glacier_outlines
 
         assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]
+
+    def test_bounds(self):
+
+        bounds = self.glacier_outlines.bounds
+
+        assert bounds.left < bounds.right
+        assert bounds.bottom < bounds.top
+

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -37,3 +37,9 @@ class TestVector:
         assert bounds.left < bounds.right
         assert bounds.bottom < bounds.top
 
+        assert bounds.left == self.glacier_outlines.ds.total_bounds[0]
+        assert bounds.bottom == self.glacier_outlines.ds.total_bounds[1]
+        assert bounds.right == self.glacier_outlines.ds.total_bounds[2]
+        assert bounds.top == self.glacier_outlines.ds.total_bounds[3]
+
+


### PR DESCRIPTION
This branch started out with the aim to fix #176, but it turned out that `Raster.crop()` actually did work as expected!! I did however see that the Vector crop wasn't implemented and that some more fixes could be made:

* `Raster.crop(Vector)` now works.
* `Raster.crop` has an `inplace` argument which is True by default. If False, it will return a new separate Raster.
* `Vector.bounds` and `Vector.crs` now exist.