### PR TITLE
Fix `Raster.info(stats=True)` warning

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -574,7 +574,7 @@ class Raster(object):
                     as_str.append('[MINIMUM]:          {:.2f}\n'.format(
                         np.nanmin(self.data)))
                     as_str.append('[MEDIAN]:           {:.2f}\n'.format(
-                        np.nanmedian(self.data)))
+                        np.ma.median(self.data)))
                     as_str.append('[MEAN]:             {:.2f}\n'.format(
                         np.nanmean(self.data)))
                     as_str.append('[STD DEV]:          {:.2f}\n'.format(
@@ -588,7 +588,7 @@ class Raster(object):
                         as_str.append('[MINIMUM]:          {:.2f}\n'.format(
                             np.nanmin(self.data[b, :, :])))
                         as_str.append('[MEDIAN]:           {:.2f}\n'.format(
-                            np.nanmedian(self.data[b, :, :])))
+                            np.ma.median(self.data[b, :, :])))
                         as_str.append('[MEAN]:             {:.2f}\n'.format(
                             np.nanmean(self.data[b, :, :])))
                         as_str.append('[STD DEV]:          {:.2f}\n'.format(

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -72,12 +72,24 @@ class TestRaster:
             assert r.__getattribute__(attr) == r.ds.__getattribute__(attr)
 
         # Check summary matches that of RIO
-        assert print(r) == print(r.info())
+        assert str(r) == r.info()
 
         # Check that the stats=True flag doesn't trigger a warning
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            r.info(stats=True)
+            stats = r.info(stats=True)
+
+        r.data.ravel()[:1000] = 0
+        r.set_ndv(0)
+
+        new_stats = r.info(stats=True)
+
+        for i, line in enumerate(stats.splitlines()):
+            if "MAXIMUM" not in line:
+                continue
+            assert line == new_stats.splitlines()[i]
+
+
 
     def test_loading(self):
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -80,13 +80,13 @@ class TestRaster:
             warnings.simplefilter("error")
             stats = r.info(stats=True)
 
+        # Validate that the mask is respected by adding 0 values (there are none to begin with.)
         r.data.ravel()[:1000] = 0
+        # Set the nodata value to 0, then validate that they are excluded from the new minimum
         r.set_ndv(0)
-
         new_stats = r.info(stats=True)
-
         for i, line in enumerate(stats.splitlines()):
-            if "MAXIMUM" not in line:
+            if "MINIMUM" not in line:
                 continue
             assert line == new_stats.splitlines()[i]
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -4,6 +4,7 @@ Test functions for georaster
 import os
 import tempfile
 from tempfile import TemporaryFile
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -72,6 +73,11 @@ class TestRaster:
 
         # Check summary matches that of RIO
         assert print(r) == print(r.info())
+
+        # Check that the stats=True flag doesn't trigger a warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            r.info(stats=True)
 
     def test_loading(self):
         """


### PR DESCRIPTION
Solves #174.

A test is added to validate that no warnings occur in the future.