### PR TITLE
Add a function to merge different bounds

### DIFF
--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -24,13 +24,13 @@ def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
     :returns: Output polygon
     :rtype: shapely Polygon
     """
-    # If boundsGeom is a rasterio or Raster object
-    if hasattr(boundsGeom, 'bounds'):
-        xmin, ymin, xmax, ymax = boundsGeom.bounds
-        in_crs = boundsGeom.crs
-    # If boundsGeom is a GeoPandas or Vector object
-    elif hasattr(boundsGeom, 'total_bounds'):
+    # If boundsGeom is a GeoPandas or Vector object (warning, has both total_bounds and bounds attributes)
+    if hasattr(boundsGeom, 'total_bounds'):
         xmin, ymin, xmax, ymax = boundsGeom.total_bounds
+        in_crs = boundsGeom.crs
+    # If boundsGeom is a rasterio or Raster object
+    elif hasattr(boundsGeom, 'bounds'):
+        xmin, ymin, xmax, ymax = boundsGeom.bounds
         in_crs = boundsGeom.crs
     # if a list of coordinates
     elif isinstance(boundsGeom, (list, tuple)):
@@ -46,6 +46,41 @@ def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
         raise NotImplementedError()
 
     return bbox
+
+
+def merge_bounds(bounds_list, merging_algorithm="union"):
+    """
+    Merge a list of bounds into single bounds, using either the union or intersection.
+
+    :param bounds_list: A list of geometries with bounds, i.e. a list of coordinates (xmin, ymin, xmax, ymax), \
+a rasterio/Raster object, a geoPandas/Vector object.
+    :type bounds_list: list, tuple
+    :param merging_algorithm: the algorithm to use for merging, either "union" or "intersection"
+    :type merging_algorithm: str
+
+    :returns: Output bounds (xmin, ymin, xmax, ymax)
+    :rtype: tuple
+    """
+    # Check that bounds_list is a list of bounds objects
+    assert isinstance(bounds_list, (list, tuple)), "bounds_list must be a list/tuple"
+    for bounds in bounds_list:
+        assert (hasattr(bounds, 'bounds') or hasattr(bounds, 'total_bounds') or isinstance(bounds, (list, tuple))), \
+            "bounds_list must be a list of lists/tuples of coordinates or an object with attributes bounds" \
+            " or total_bounds"
+
+    output_poly = bounds2poly(bounds_list[0])
+
+    for boundsGeom in bounds_list[1:]:
+        new_poly = bounds2poly(boundsGeom)
+
+        if merging_algorithm == "union":
+            output_poly = output_poly.union(new_poly)
+        elif merging_algorithm == "intersection":
+            output_poly = output_poly.intersection(new_poly)
+        else:
+            raise ValueError("merging_algorithm must be 'union' or 'intersection'")
+
+    return output_poly.bounds
 
 
 def reproject_points(pts, in_crs, out_crs):

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -3,9 +3,8 @@ Test projtools
 """
 import numpy as np
 
-import geoutils.georaster as gr
+import geoutils as gu
 import geoutils.projtools as pt
-from geoutils import datasets
 
 
 class TestProjTools:
@@ -15,7 +14,7 @@ class TestProjTools:
         Check that to and from latlon projections are self consistent within tolerated rounding errors
         """
 
-        img = gr.Raster(datasets.get_path('landsat_B4'))
+        img = gu.Raster(gu.datasets.get_path('landsat_B4'))
 
         # Test on random points
         nsample = 100
@@ -27,3 +26,42 @@ class TestProjTools:
 
         assert np.all(x == randx)
         assert np.all(y == randy)
+
+    def test_merge_bounds(self):
+        """
+        Check that merge_bounds and bounds2poly work as expected for all kinds of bounds objects.
+        """
+        img1 = gu.Raster(gu.datasets.get_path('landsat_B4'))
+        img2 = gu.Raster(gu.datasets.get_path('landsat_B4_crop'))
+
+        # Check union (default) - with Raster objects
+        out_bounds = pt.merge_bounds((img1, img2))
+        assert out_bounds[0] == min(img1.bounds.left, img2.bounds.left)
+        assert out_bounds[1] == min(img1.bounds.bottom, img2.bounds.bottom)
+        assert out_bounds[2] == max(img1.bounds.right, img2.bounds.right)
+        assert out_bounds[3] == max(img1.bounds.top, img2.bounds.top)
+
+        # Check intersection - with Raster objects
+        out_bounds = pt.merge_bounds((img1, img2), merging_algorithm="intersection")
+        assert out_bounds[0] == max(img1.bounds.left, img2.bounds.left)
+        assert out_bounds[1] == max(img1.bounds.bottom, img2.bounds.bottom)
+        assert out_bounds[2] == min(img1.bounds.right, img2.bounds.right)
+        assert out_bounds[3] == min(img1.bounds.top, img2.bounds.top)
+
+        # Check that the results is the same with rio.BoundingBoxes
+        out_bounds2 = pt.merge_bounds((img1.bounds, img2.bounds), merging_algorithm="intersection")
+        assert out_bounds2 == out_bounds
+
+        # Check that the results is the same with a list
+        out_bounds2 = pt.merge_bounds((list(img1.bounds), list(img2.bounds)), merging_algorithm="intersection")
+        assert out_bounds2 == out_bounds
+
+        # Check with gpd.GeoDataFrame
+        outlines = gu.Vector(gu.datasets.get_path("glacier_outlines"))
+        outlines = gu.Vector(outlines.ds.to_crs(img1.crs))   # reproject to img1's CRS
+        out_bounds = pt.merge_bounds((img1, outlines.ds))
+
+        assert out_bounds[0] == min(img1.bounds.left, outlines.ds.total_bounds[0])
+        assert out_bounds[1] == min(img1.bounds.bottom, outlines.ds.total_bounds[1])
+        assert out_bounds[2] == max(img1.bounds.right, outlines.ds.total_bounds[2])
+        assert out_bounds[3] == max(img1.bounds.top, outlines.ds.total_bounds[3])


### PR DESCRIPTION
This was a change that was waiting for a commit on my computer for some time...

The method merge_bounds takes any of the following: list/tuple of coordinates, Raster objects, rasterio BoundingBox or geopandas GeoDataFrame.
It merges the bounding boxes using either the union or intersection of all.