### PR TITLE
Fix several issues with reproject when dst_bounds is set

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -788,17 +788,19 @@ class Raster(object):
             # Determine target CRS
             dst_crs = CRS.from_user_input(dst_crs)
 
-        # If dst_ref is None, check other input arguments
-        if dst_size is not None and dst_res is not None:
-            raise ValueError(
-                'dst_size and dst_res both specified. Specify only one.')
-
+        # Set output dtype
         if dtype is None:
-            # CHECK CORRECT IMPLEMENTATION! (rasterio dtypes seems to be on a per-band basis)
+            # Warning: this will not work for multiple bands with different dtypes
             dtype = self.dtypes[0]
 
         if nodata is None:
             nodata = self.nodata
+            # If no data was set, need to set one by default, in case reprojection is done outside original bounds
+            # Otherwise, output nodata will be 99999 by default which will not work as expected for uint8 data.
+            if nodata is None:
+                if not silent:
+                    warnings.warn("No nodata set, will use 0")
+                nodata = 0
 
         # Basic reprojection options, needed in all cases.
         reproj_kwargs = {
@@ -808,6 +810,11 @@ class Raster(object):
             'resampling': resampling if isinstance(resampling, Resampling) else _resampling_from_str(resampling),
             'dst_nodata': nodata
         }
+
+        # If dst_ref is None, check other input arguments
+        if dst_size is not None and dst_res is not None:
+            raise ValueError(
+                'dst_size and dst_res both specified. Specify only one.')
 
         # Create a BoundingBox if required
         if dst_bounds is not None:
@@ -844,20 +851,30 @@ class Raster(object):
                 dst_bounds = rio.coords.BoundingBox(top=dst_bounds.top,
                                                     left=dst_bounds.left, bottom=y1, right=x1)
 
-        # Fix output shape (dst_size is (ncol, nrow))
+        # Set output shape (Note: dst_size is (ncol, nrow))
         if dst_size is not None:
             dst_shape = (self.count, dst_size[1], dst_size[0])
-            dst_data = np.ones(dst_shape)
+            dst_data = np.ones(dst_shape, dtype=dtype)
             reproj_kwargs.update({'destination': dst_data})
         else:
-            dst_shape = (self.count, self.width, self.height)
+            dst_shape = (self.count, self.height, self.width)
 
-        # Fix nx,ny with destination bounds requested.
+        # If dst_bounds is set, but not dst_res, will enforce dst_bounds
         if dst_bounds is not None:
-            dst_transform = rio.transform.from_bounds(*dst_bounds,
-                                                      width=dst_shape[2], height=dst_shape[1])
+
+            # Calculate new raster size which ensures that pixels resolution is as close as possible to original
+            # Raster size is increased by up to one pixel if needed
+            yres, xres = self.res
+            dst_width = int(np.ceil((dst_bounds.right - dst_bounds.left) / xres))
+            dst_height = int(np.ceil(np.abs(dst_bounds.bottom - dst_bounds.top) / yres))
+            dst_size = (dst_width, dst_height)
+
+            # Calculate associated transform
+            dst_transform = rio.transform.from_bounds(*dst_bounds, width=dst_width, height=dst_height)
+
+            # Specify the output bounds and shape, let rasterio handle the rest
             reproj_kwargs.update({'dst_transform': dst_transform})
-            dst_data = np.ones(dst_shape)
+            dst_data = np.ones((dst_height, dst_width), dtype=dtype)
             reproj_kwargs.update({'destination': dst_data})
 
         # Check that reprojection is actually needed

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -24,13 +24,13 @@ def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
     :returns: Output polygon
     :rtype: shapely Polygon
     """
-    # If boundsGeom is a rasterio or Raster object
-    if hasattr(boundsGeom, 'bounds'):
-        xmin, ymin, xmax, ymax = boundsGeom.bounds
-        in_crs = boundsGeom.crs
-    # If boundsGeom is a GeoPandas or Vector object
-    elif hasattr(boundsGeom, 'total_bounds'):
+    # If boundsGeom is a GeoPandas or Vector object (warning, has both total_bounds and bounds attributes)
+    if hasattr(boundsGeom, 'total_bounds'):
         xmin, ymin, xmax, ymax = boundsGeom.total_bounds
+        in_crs = boundsGeom.crs
+    # If boundsGeom is a rasterio or Raster object
+    elif hasattr(boundsGeom, 'bounds'):
+        xmin, ymin, xmax, ymax = boundsGeom.bounds
         in_crs = boundsGeom.crs
     # if a list of coordinates
     elif isinstance(boundsGeom, (list, tuple)):
@@ -46,6 +46,41 @@ def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
         raise NotImplementedError()
 
     return bbox
+
+
+def merge_bounds(bounds_list, merging_algorithm="union"):
+    """
+    Merge a list of bounds into single bounds, using either the union or intersection.
+
+    :param bounds_list: A list of geometries with bounds, i.e. a list of coordinates (xmin, ymin, xmax, ymax), \
+a rasterio/Raster object, a geoPandas/Vector object.
+    :type bounds_list: list, tuple
+    :param merging_algorithm: the algorithm to use for merging, either "union" or "intersection"
+    :type merging_algorithm: str
+
+    :returns: Output bounds (xmin, ymin, xmax, ymax)
+    :rtype: tuple
+    """
+    # Check that bounds_list is a list of bounds objects
+    assert isinstance(bounds_list, (list, tuple)), "bounds_list must be a list/tuple"
+    for bounds in bounds_list:
+        assert (hasattr(bounds, 'bounds') or hasattr(bounds, 'total_bounds') or isinstance(bounds, (list, tuple))), \
+            "bounds_list must be a list of lists/tuples of coordinates or an object with attributes bounds" \
+            " or total_bounds"
+
+    output_poly = bounds2poly(bounds_list[0])
+
+    for boundsGeom in bounds_list[1:]:
+        new_poly = bounds2poly(boundsGeom)
+
+        if merging_algorithm == "union":
+            output_poly = output_poly.union(new_poly)
+        elif merging_algorithm == "intersection":
+            output_poly = output_poly.intersection(new_poly)
+        else:
+            raise ValueError("merging_algorithm must be 'union' or 'intersection'")
+
+    return output_poly.bounds
 
 
 def reproject_points(pts, in_crs, out_crs):

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -3,9 +3,8 @@ Test projtools
 """
 import numpy as np
 
-import geoutils.georaster as gr
+import geoutils as gu
 import geoutils.projtools as pt
-from geoutils import datasets
 
 
 class TestProjTools:
@@ -15,7 +14,7 @@ class TestProjTools:
         Check that to and from latlon projections are self consistent within tolerated rounding errors
         """
 
-        img = gr.Raster(datasets.get_path('landsat_B4'))
+        img = gu.Raster(gu.datasets.get_path('landsat_B4'))
 
         # Test on random points
         nsample = 100
@@ -27,3 +26,42 @@ class TestProjTools:
 
         assert np.all(x == randx)
         assert np.all(y == randy)
+
+    def test_merge_bounds(self):
+        """
+        Check that merge_bounds and bounds2poly work as expected for all kinds of bounds objects.
+        """
+        img1 = gu.Raster(gu.datasets.get_path('landsat_B4'))
+        img2 = gu.Raster(gu.datasets.get_path('landsat_B4_crop'))
+
+        # Check union (default) - with Raster objects
+        out_bounds = pt.merge_bounds((img1, img2))
+        assert out_bounds[0] == min(img1.bounds.left, img2.bounds.left)
+        assert out_bounds[1] == min(img1.bounds.bottom, img2.bounds.bottom)
+        assert out_bounds[2] == max(img1.bounds.right, img2.bounds.right)
+        assert out_bounds[3] == max(img1.bounds.top, img2.bounds.top)
+
+        # Check intersection - with Raster objects
+        out_bounds = pt.merge_bounds((img1, img2), merging_algorithm="intersection")
+        assert out_bounds[0] == max(img1.bounds.left, img2.bounds.left)
+        assert out_bounds[1] == max(img1.bounds.bottom, img2.bounds.bottom)
+        assert out_bounds[2] == min(img1.bounds.right, img2.bounds.right)
+        assert out_bounds[3] == min(img1.bounds.top, img2.bounds.top)
+
+        # Check that the results is the same with rio.BoundingBoxes
+        out_bounds2 = pt.merge_bounds((img1.bounds, img2.bounds), merging_algorithm="intersection")
+        assert out_bounds2 == out_bounds
+
+        # Check that the results is the same with a list
+        out_bounds2 = pt.merge_bounds((list(img1.bounds), list(img2.bounds)), merging_algorithm="intersection")
+        assert out_bounds2 == out_bounds
+
+        # Check with gpd.GeoDataFrame
+        outlines = gu.Vector(gu.datasets.get_path("glacier_outlines"))
+        outlines = gu.Vector(outlines.ds.to_crs(img1.crs))   # reproject to img1's CRS
+        out_bounds = pt.merge_bounds((img1, outlines.ds))
+
+        assert out_bounds[0] == min(img1.bounds.left, outlines.ds.total_bounds[0])
+        assert out_bounds[1] == min(img1.bounds.bottom, outlines.ds.total_bounds[1])
+        assert out_bounds[2] == max(img1.bounds.right, outlines.ds.total_bounds[2])
+        assert out_bounds[3] == max(img1.bounds.top, outlines.ds.total_bounds[3])


### PR DESCRIPTION
Now, Raster.reproject should be closer (if not equivalent) to what gdalwarp would do, when dst_bounds is set i.e.:
- if dst_bounds is set but nothing else, the dst_res and shape are modified to fit dst_bounds
- if dst_bounds and dst_res are set, will enforce dst_res and will adjust dst_bounds accordinly (by up to one pixel)

I think it would be tough to get a complete test suite for all the possible cases, but I did my best! 
I compared the outputs with gdalwarp on a few tests cases and it's the same. Ideally we would compare with gdal for a million cases!

P.S: I don't know what I did wrong again, but my previous PR is also included here...