### PR TITLE
Refactor code to adhere to a number of standards

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Linting and formatting (pre-commit)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: ${{ matrix.os }}, python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup environment
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,13 @@ repos:
                 - id: end-of-file-fixer
                   exclude: \.txt$
                 - id: trailing-whitespace  # Remove trailing whitespaces
+                - id: check-merge-conflict
         # Fix common spelling mistakes
         - repo: https://github.com/codespell-project/codespell
           rev: v2.0.0
           hooks:
                 - id: codespell
+                  args: [--ignore-words-list=alos]
                   types_or: [python, rst, markdown]
                   files: ^(geoutils|doc|tests)/
 
@@ -31,17 +33,30 @@ repos:
           rev: 3.9.2
           hooks:
                 - id: flake8
-                  args: [--max-line-length=120]
+                  args: [
+                          --max-line-length=120,
+                          --extend-ignore=PDF001,
+                  ]
                   additional_dependencies:
                           - flake8-comprehensions==3.1.0
                           - flake8-bugbear==21.3.2
                           - pandas-dev-flaker==0.2.0
+                  files: ^(geoutils|tests)
         # Lint the code using mypy
         - repo: https://github.com/pre-commit/mirrors-mypy
           rev: v0.812
           hooks:
                 - id: mypy
-                  args: [--strict, --ignore-missing-imports, --allow-untyped-calls]
+                  args: [
+                        --strict,
+                        --ignore-missing-imports,  # Don't warn about stubs since pre-commit runs in a limited env
+                        --allow-untyped-calls,  # Dynamic function/method calls are okay. Untyped function definitions are not okay.
+                        --show-error-codes,
+                        --no-warn-unused-ignores,  # Ignore 'type: ignore' comments that are not used.
+                        --disable-error-code=attr-defined,  # "Module has no attribute 'XXX'" occurs because of the pre-commit env.
+                        --disable-error-code=name-defined  # "Name 'XXX' is not defined" occurs because of the pre-commit env.
+
+                  ]
                   additional_dependencies: [tokenize-rt==3.2.0]
 
 
@@ -77,16 +92,9 @@ repos:
                 - id: python-no-eval
                 # Enforce the use of type annotations instead of docstring type comments
                 - id: python-use-type-annotations
-        
-        # Remove unneeded #noqa comments (in case the line conforms to standards already)
-        - repo: https://github.com/asottile/yesqa
-          rev: v1.2.3
+
+        # Add custom regex lints (see .relint.yml)
+        - repo: https://github.com/codingjoe/relint
+          rev: 1.2.0
           hooks:
-                - id: yesqa
-                  additional_dependencies:
-                          - flake8==3.9.2
-                          - flake8-comprehensions==3.1.0
-                          - flake8-bugbear==21.3.2
-
-                        
-
+                - id: relint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,92 @@
+repos:
+        - repo: https://github.com/pre-commit/pre-commit-hooks
+          rev: v4.0.1
+          hooks:
+                - id: check-yaml
+                - id: end-of-file-fixer
+                  exclude: \.txt$
+                - id: trailing-whitespace  # Remove trailing whitespaces
+        # Fix common spelling mistakes
+        - repo: https://github.com/codespell-project/codespell
+          rev: v2.0.0
+          hooks:
+                - id: codespell
+                  types_or: [python, rst, markdown]
+                  files: ^(geoutils|doc|tests)/
+
+        # Replace relative imports (e.g. 'from . import georaster' -> 'from geoutils import georaster')
+        - repo: https://github.com/MarcoGorelli/absolufy-imports
+          rev: v0.3.0
+          hooks:
+                - id: absolufy-imports
+
+        # Format the code aggressively using black
+        - repo: https://github.com/psf/black
+          rev: 20.8b1
+          hooks:
+                  - id: black
+                    args: [--line-length=120]
+        # Lint the code using flake8
+        - repo: https://gitlab.com/pycqa/flake8
+          rev: 3.9.2
+          hooks:
+                - id: flake8
+                  args: [--max-line-length=120]
+                  additional_dependencies:
+                          - flake8-comprehensions==3.1.0
+                          - flake8-bugbear==21.3.2
+                          - pandas-dev-flaker==0.2.0
+        # Lint the code using mypy
+        - repo: https://github.com/pre-commit/mirrors-mypy
+          rev: v0.812
+          hooks:
+                - id: mypy
+                  args: [--strict, --ignore-missing-imports, --allow-untyped-calls]
+                  additional_dependencies: [tokenize-rt==3.2.0]
+
+
+
+        # Sort imports using isort
+        - repo: https://github.com/PyCQA/isort
+          rev: 5.8.0
+          hooks:
+                  - id: isort
+
+        # Automatically upgrade syntax to a minimum version
+        - repo: https://github.com/asottile/pyupgrade
+          rev: v2.18.3
+          hooks:
+                - id: pyupgrade
+                  args: [--py37-plus]
+
+        # Various formattings
+        - repo: https://github.com/pre-commit/pygrep-hooks
+          rev: v1.8.0
+          hooks:
+                # Single backticks should apparently not be used
+                - id: rst-backticks
+                # Check that all directives end with double colon
+                - id: rst-directive-colons
+                  types: [text]
+                  types_or: [python, rst]
+                # Inline code should not touch normal text
+                - id: rst-inline-touching-normal
+                  types: [text]
+                  types_or: [python, rst]
+                # Eval should never be used (can do arbitrary code execution)
+                - id: python-no-eval
+                # Enforce the use of type annotations instead of docstring type comments
+                - id: python-use-type-annotations
+        
+        # Remove unneeded #noqa comments (in case the line conforms to standards already)
+        - repo: https://github.com/asottile/yesqa
+          rev: v1.2.3
+          hooks:
+                - id: yesqa
+                  additional_dependencies:
+                          - flake8==3.9.2
+                          - flake8-comprehensions==3.1.0
+                          - flake8-bugbear==21.3.2
+
+                        
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
                 - id: flake8
                   args: [
                           --max-line-length=120,
-                          --extend-ignore=PDF001,
+                          --extend-ignore=E203,   # flake8 disagrees with black, so this should be ignored.
                   ]
                   additional_dependencies:
                           - flake8-comprehensions==3.1.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,3 @@ python:
     - requirements: dev-requirements.txt
     - method: pip
       path: .
-  

--- a/.relint.yml
+++ b/.relint.yml
@@ -1,0 +1,3 @@
+- name: Type hint in docstring
+  pattern: ':[r]?type '
+  filePattern: .*\.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,3 @@ It can also be run as a separate tool:
 ```bash
 pre-commit run --all-files
 ```
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,23 @@ It is also recommended to try the tests from the parent directory, to validate t
 cd ../  # Change to the parent directory
 pytest geoutils
 ```
+
+### Formatting and linting
+To merge a PR in geoutils, the code has to adhere to the standards set in place.
+We use a number of tools to validate contributions, triggered using `pre-commit` (see `.pre-commit-config.yaml` for the exact tools).
+
+To validate your code automatically, install `pre-commit`:
+```bash
+pip install pre-commit
+```
+`pre-commit` is made to be installed as a "pre-commit hook" for git, so the checks have to pass before committing.
+The hook is automatically installed using:
+```bash
+pre-commit install
+```
+
+It can also be run as a separate tool:
+```bash
+pre-commit run --all-files
+```
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install https://github.com/GlacioHack/GeoUtils/tarball/main
 See the full documentation at https://geoutils.readthedocs.io.
 
 
-## Structure 
+## Structure
 
 GeoUtils are composed of three libraries:
 - `georaster.py` to handle raster data set. In particular, a Raster class to load a raster file along with metadata.
@@ -43,7 +43,7 @@ You can find ways to improve the libraries in the [issues](https://github.com/Gl
 1. Fork the repository to your personal GitHub account, clone to your computer.
 2. (Optional but preferred:) Make a feature branch.
 3. Push to your feature branch.
-4. When ready, submit a Pull Request from your feature branch to `GlacioHack/geoutils:master`. 
+4. When ready, submit a Pull Request from your feature branch to `GlacioHack/geoutils:master`.
 5. The PR will be reviewed by at least one other person. Usually your PR will be merged via 'squash and merge'.
 
 Direct pushing to the GlacioHack repository is not permitted.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,3 +10,4 @@ sphinxcontrib_programoutput
 sphinx_autodoc_typehints
 matplotlib
 scipy
+pre-commit

--- a/doc/source/code/raster-basics_open_file.py
+++ b/doc/source/code/raster-basics_open_file.py
@@ -11,5 +11,5 @@ information = image.info()
 #### TEXT
 information = image.info(stats=True)
 #### TEXT
-with open('file.txt', 'w') as fh:
-        fh.writelines(information)
+with open("file.txt", "w") as fh:
+    fh.writelines(information)

--- a/doc/source/code/vector-basics_open_file.py
+++ b/doc/source/code/vector-basics_open_file.py
@@ -1,4 +1,7 @@
-"""Example script to load a vector file."""; import warnings; warnings.simplefilter("ignore")  # Temporarily filter warnings since something's up with GeoPandas (2021-05-20).
+"""Example script to load a vector file."""
+import warnings
+
+warnings.simplefilter("ignore")  # Temporarily filter warnings since something's up with GeoPandas (2021-05-20).
 import geoutils as gu
 
 filename = gu.datasets.get_path("glacier_outlines")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
-import sys
 import os
+import sys
 
-sys.path.insert(0, os.path.abspath('../geoutils/'))
+sys.path.insert(0, os.path.abspath("../geoutils/"))
 
 
-project = 'GeoUtils'
-copyright = '2020, GeoUtils Developers'
-author = 'GeoUtils Developers'
+project = "GeoUtils"
+copyright = "2020, GeoUtils Developers"
+author = "GeoUtils Developers"
 
 
 # Set the python environment variable for programoutput to find it.
@@ -20,8 +19,8 @@ os.environ["PYTHON"] = sys.executable
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-#needs_sphinx = '3.3.1'
-master_doc = 'index'
+# needs_sphinx = '3.3.1'
+master_doc = "index"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -29,25 +28,26 @@ master_doc = 'index'
 extensions = [
     "sphinx.ext.autodoc",  # Create the API documentation automatically
     "sphinx.ext.viewcode",  # Create the "[source]" button in the API to show the source code.
-    'matplotlib.sphinxext.plot_directive',  # Render matplotlib figures from code.
+    "matplotlib.sphinxext.plot_directive",  # Render matplotlib figures from code.
     "sphinx.ext.autosummary",  # Create API doc summary texts from the docstrings.
     "sphinx.ext.inheritance_diagram",  # For class inheritance diagrams (see coregistration.rst).
     "sphinx_autodoc_typehints",  # Include type hints in the API documentation.
-    "sphinxcontrib.programoutput"  # Run scripts and show the output.
+    "sphinxcontrib.programoutput",  # Run scripts and show the output.
 ]
 
-extlinks = {'issue': ('https://github.com/GlacioHack/GeoUtils/issues/%s',
-                      'GH'),
-            'pull': ('https://github.com/GlacioHack/GeoUtils/pull/%s', 'PR'),
-            }
+extlinks = {
+    "issue": ("https://github.com/GlacioHack/GeoUtils/issues/%s", "GH"),
+    "pull": ("https://github.com/GlacioHack/GeoUtils/pull/%s", "PR"),
+}
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 
 import geoutils
+
 # The short X.Y version
-version = geoutils.__version__.split('+')[0]
+version = geoutils.__version__.split("+")[0]
 # The full version, including alpha/beta/rc tags.
 release = geoutils.__version__
 
@@ -55,7 +55,7 @@ release = geoutils.__version__
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -63,10 +63,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,7 @@ Our functionalities are mostly based on `rasterio <https://rasterio.readthedocs.
 
 .. literalinclude:: code/index_example.py
 
-.. program-output:: $PYTHON code/index_example.py 
+.. program-output:: $PYTHON code/index_example.py
         :shell:
 
 .. toctree::
@@ -25,7 +25,7 @@ Our functionalities are mostly based on `rasterio <https://rasterio.readthedocs.
     satimg-basics
     vector-basics
     api
-    
+
 
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. GeoUtils documentation master file, created by
    sphinx-quickstart on Fri Nov 13 17:43:16 2020.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root 'toctree' directive.
 
 Welcome to GeoUtils's documentation!
 ================================

--- a/doc/source/raster-basics.rst
+++ b/doc/source/raster-basics.rst
@@ -44,7 +44,7 @@ Or just print nicely to console:
 
         print(information)
 
-.. program-output:: $PYTHON -c "exec(open('code/raster-basics_open_file.py').read()); print(information)" 
+.. program-output:: $PYTHON -c "exec(open('code/raster-basics_open_file.py').read()); print(information)"
         :shell:
 
 Resampling a Raster to fit another
@@ -112,5 +112,3 @@ It is therefore recommended to choose the method that fits the purpose best, usi
 3) ``resampling="cubic_spline"``: Often considered the best approach. Not as performant as simpler methods.
 
 All valid resampling methods can be seen in the `Rasterio documentation <https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html#rasterio.enums.Resampling>`_.
-
-

--- a/doc/source/vector-basics.rst
+++ b/doc/source/vector-basics.rst
@@ -17,7 +17,7 @@ Opening a Vector file
 Printing the Vector shows the underlying ``GeoDataFrame`` and some extra statistics:
 
 .. code:: python
-        
+
         print(outlines)
 
 .. program-output:: $PYTHON -c "exec(open('code/vector-basics_open_file.py').read()); print(outlines)"
@@ -32,7 +32,7 @@ Masks can easily be generated for use with Rasters:
 We can prove that glaciers are bright (who could have known!?) by masking the values outside and inside of the glaciers:
 
 .. code:: python
-        
+
         print(f"Inside: {image.data[mask].mean():.1f}, outside: {image.data[~mask].mean():.1f}")
 
 .. program-output:: $PYTHON -c "exec(open('code/vector-basics_open_file.py').read()); print(f'Inside: {image.data[mask].mean():.1f}, outside: {image.data[~mask].mean():.1f}')"

--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -2,13 +2,13 @@
 GeoUtils is a python package of raster and vector tools.
 """
 
-from geoutils import datasets, georaster, geovector, satimg
-from geoutils.georaster import Raster
-from geoutils.geovector import Vector
-from geoutils.satimg import SatelliteImage
+from geoutils import datasets, georaster, geovector, satimg  # noqa
+from geoutils.georaster import Raster  # noqa
+from geoutils.geovector import Vector  # noqa
+from geoutils.satimg import SatelliteImage  # noqa
 
 try:
-    from geoutils.version import version as __version__
+    from geoutils.version import version as __version__  # noqa
 except ImportError:  # pragma: no cover
     raise ImportError(
         "geoutils is not properly installed. If you are "

--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -2,20 +2,18 @@
 GeoUtils is a python package of raster and vector tools.
 """
 
-from . import georaster
-from . import geovector
-from . import datasets
-from . import satimg
-
-from .georaster import Raster
-from .geovector import Vector
-from .satimg import SatelliteImage
+from geoutils import datasets, georaster, geovector, satimg
+from geoutils.georaster import Raster
+from geoutils.geovector import Vector
+from geoutils.satimg import SatelliteImage
 
 try:
     from geoutils.version import version as __version__
 except ImportError:  # pragma: no cover
-    raise ImportError('geoutils is not properly installed. If you are '
-                      'running from the source directory, please instead '
-                      'create a new virtual environment (using conda or '
-                      'virtualenv) and then install it in-place by running: '
-                      'pip install -e .')
+    raise ImportError(
+        "geoutils is not properly installed. If you are "
+        "running from the source directory, please instead "
+        "create a new virtual environment (using conda or "
+        "virtualenv) and then install it in-place by running: "
+        "pip install -e ."
+    )

--- a/geoutils/datasets/__init__.py
+++ b/geoutils/datasets/__init__.py
@@ -12,7 +12,7 @@ available = {
 }
 
 
-def get_path(dset=None):
+def get_path(dset: str) -> str:
     """
     Get the path to the data file.
     Parameters
@@ -26,7 +26,7 @@ def get_path(dset=None):
     """
     if dset in list(available.keys()):
         return os.path.abspath(os.path.join(_module_path, available[dset]))
-    else:
-        msg = f"The dataset '{dset}' is not available. "
-        msg += "Available datasets are {}".format(", ".join(list(available.keys())))
-        raise ValueError(msg)
+
+    msg = f"The dataset '{dset}' is not available. "
+    msg += "Available datasets are {}".format(", ".join(list(available.keys())))
+    raise ValueError(msg)

--- a/geoutils/datasets/__init__.py
+++ b/geoutils/datasets/__init__.py
@@ -4,10 +4,12 @@ __all__ = ["available", "get_path"]
 
 _module_path = os.path.dirname(__file__)
 
-available = {"landsat_B4": "LE71400412000304SGS00_B4_crop.TIF",
-            "landsat_B4_crop": "LE71400412000304SGS00_B4_crop2.TIF",
-            "landsat_RGB": "LE71400412000304SGS00_RGB.TIF",
-            "glacier_outlines": "glacier_outlines.gpkg"}
+available = {
+    "landsat_B4": "LE71400412000304SGS00_B4_crop.TIF",
+    "landsat_B4_crop": "LE71400412000304SGS00_B4_crop2.TIF",
+    "landsat_RGB": "LE71400412000304SGS00_RGB.TIF",
+    "glacier_outlines": "glacier_outlines.gpkg",
+}
 
 
 def get_path(dset=None):
@@ -25,7 +27,6 @@ def get_path(dset=None):
     if dset in list(available.keys()):
         return os.path.abspath(os.path.join(_module_path, available[dset]))
     else:
-        msg = "The dataset '{}' is not available. ".format(dset)
-        msg += "Available datasets are {}".format(
-            ", ".join(list(available.keys())))
+        msg = f"The dataset '{dset}' is not available. "
+        msg += "Available datasets are {}".format(", ".join(list(available.keys())))
         raise ValueError(msg)

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -3,11 +3,10 @@ geoutils.georaster provides a toolset for working with raster data.
 """
 from __future__ import annotations
 
-import collections
 import copy
 import os
 import warnings
-from collections.abc import Iterable
+from collections import abc
 from numbers import Number
 from typing import IO, Any, Callable, TypeVar
 
@@ -211,7 +210,7 @@ class Raster:
             nbands = self.count
         elif isinstance(bands, int):
             nbands = 1
-        elif isinstance(bands, collections.abc.Iterable):
+        elif isinstance(bands, abc.Iterable):
             nbands = len(bands)
 
         # Downsampled image size
@@ -730,7 +729,7 @@ class Raster:
         dst_crs: CRS | str | None = None,
         dst_size: tuple[int, int] | None = None,
         dst_bounds: dict[str, float] | rio.coords.BoundingBox | None = None,
-        dst_res: float | Iterable[float] | None = None,
+        dst_res: float | abc.Iterable[float] | None = None,
         nodata: int | float | None = None,
         dtype: np.dtype | None = None,
         resampling: Resampling | str = Resampling.nearest,
@@ -959,7 +958,7 @@ class Raster:
         meta.update({"transform": rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)})
         self._update(metadata=meta)
 
-    def set_ndv(self, ndv: Iterable[int | float] | int | float, update_array: bool = False) -> None:
+    def set_ndv(self, ndv: abc.Iterable[int | float] | int | float, update_array: bool = False) -> None:
         """
         Set new nodata values for bands (and possibly update arrays)
 
@@ -968,14 +967,14 @@ class Raster:
 
         """
 
-        if not isinstance(ndv, (Iterable, int, float, np.integer, np.floating)):
+        if not isinstance(ndv, (abc.Iterable, int, float, np.integer, np.floating)):
             raise ValueError("Type of ndv not understood, must be list or float or int")
 
         elif (isinstance(ndv, (int, float, np.integer, np.floating))) and self.count > 1:
             print("Several raster band: using nodata value for all bands")
             ndv = [ndv] * self.count
 
-        elif isinstance(ndv, Iterable) and self.count == 1:
+        elif isinstance(ndv, abc.Iterable) and self.count == 1:
             print("Only one raster band: using first nodata value provided")
             ndv = list(ndv)[0]
 
@@ -1008,7 +1007,7 @@ class Raster:
 
         self._update(metadata=meta, imgdata=imgdata)
 
-    def set_dtypes(self, dtypes: Iterable[np.dtype | str] | np.dtype | str, update_array: bool = True) -> None:
+    def set_dtypes(self, dtypes: abc.Iterable[np.dtype | str] | np.dtype | str, update_array: bool = True) -> None:
         """
         Set new dtypes for bands (and possibly update arrays)
 
@@ -1016,12 +1015,12 @@ class Raster:
         :param update_array: change the existing dtype in arrays
 
         """
-        if not (isinstance(dtypes, Iterable) or isinstance(dtypes, type) or isinstance(dtypes, str)):
+        if not (isinstance(dtypes, abc.Iterable) or isinstance(dtypes, type) or isinstance(dtypes, str)):
             raise ValueError("Type of dtypes not understood, must be list or type or str")
         elif isinstance(dtypes, type) or isinstance(dtypes, str):
             print("Several raster band: using data type for all bands")
             dtypes = (dtypes,) * self.count
-        elif isinstance(dtypes, Iterable) and self.count == 1:
+        elif isinstance(dtypes, abc.Iterable) and self.count == 1:
             print("Only one raster band: using first data type provided")
             dtypes = tuple(dtypes)
 
@@ -1286,7 +1285,7 @@ to be cleared due to the setting of GCPs."
             raise ValueError("band must be int or None")
 
         # If multiple bands (RGB), cbar does not make sense
-        if isinstance(band, collections.abc.Iterable):
+        if isinstance(band, abc.Iterable):
             if len(band) > 1:
                 add_cb = False
 
@@ -1566,8 +1565,8 @@ to be cleared due to the setting of GCPs."
 
         i, j = self.ds.index(x, y, op=op, precision=precision)
 
-        # # necessary because rio.Dataset.index does not return Iterable for a single point
-        if not isinstance(i, collections.abc.Iterable):
+        # # necessary because rio.Dataset.index does not return abc.Iterable for a single point
+        if not isinstance(i, abc.Iterable):
             i, j = (
                 np.asarray(
                     [

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -438,7 +438,7 @@ class Raster:
     def _get_rio_attrs(self) -> list[str]:
         """Get the attributes that have the same name in rio.DatasetReader and Raster."""
         rio_attrs: list[str] = []
-        for attr in self.__annotations__.keys():
+        for attr in Raster.__annotations__.keys():
             if "__" in attr or attr not in dir(self.ds):
                 continue
             rio_attrs.append(attr)

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -9,7 +9,7 @@ import os
 import warnings
 from collections.abc import Iterable
 from numbers import Number
-from typing import Any, Callable, TypeVar
+from typing import IO, Any, Callable, TypeVar
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -151,21 +151,19 @@ class Raster:
         Load a rasterio-supported dataset, given a filename.
 
         :param filename_or_dataset: The filename of the dataset.
-        :type filename_or_dataset: str, Raster, rio.io.Dataset, rio.io.MemoryFile
+
         :param bands: The band(s) to load into the object. Default is to load all bands.
-        :type bands: int, or list of ints
+
         :param load_data: Load the raster data into the object. Default is True.
-        :type load_data: bool
+
         :param downsample: Reduce the size of the image loaded by this factor. Default is 1
-        :type downsample: int, float
+
         :param masked: the data is loaded as a masked array, with no data values masked. Default is True.
-        :type masked: bool
         :param attrs: Additional attributes from rasterio's DataReader class to add to the Raster object.
             Default list is ['bounds', 'count', 'crs', 'dataset_mask', 'driver', 'dtypes', 'height', 'indexes',
             'name', 'nodata', 'res', 'shape', 'transform', 'width'] - if no attrs are specified, these will be added.
-        :type attrs: list of strings
+
         :param as_memfile: open the dataset via a rio.MemoryFile.
-        :type as_memfile: bool
 
         :return: A Raster object
         """
@@ -266,19 +264,19 @@ class Raster:
         """Create a Raster from a numpy array and some geo-referencing information.
 
         :param data: data array
-        :type data: np.ndarray
+
         :param transform: the 2-D affine transform for the image mapping.
             Either a tuple(x_res, 0.0, top_left_x, 0.0, y_res, top_left_y) or
             an affine.Affine object.
-        :type transform: tuple, affine.Affine.
+
         :param crs: Coordinate Reference System for image. Either a rasterio CRS,
             or the EPSG integer.
-        :type crs: rasterio.crs.CRS or int
+
         :param nodata: nodata value
-        :type nodata: int or float
+
 
         :returns: A Raster object containing the provided data.
-        :rtype: Raster.
+
 
         Example:
 
@@ -472,7 +470,7 @@ class Raster:
         """Check whether file has been modified since it was created/opened.
 
         :returns: True if Raster has been modified.
-        :rtype: bool
+
         """
         if not self._is_modified:
             new_hash = hash((self._data.tobytes(), self.transform, self.crs, self.nodata))
@@ -486,7 +484,7 @@ class Raster:
         Get data.
 
         :returns: data array.
-        :rtype: np.ndarray
+
         """
         return self._data
 
@@ -497,10 +495,8 @@ class Raster:
 
         new_data must have the same shape as existing data! (bands dimension included)
 
-        new_data must have the same shape as existing data! (bands dimension included)
-
         :param new_data: New data to assign to this instance of Raster
-        :type new_data: np.ndarray
+
         """
         # Check that new_data is a Numpy array
         if not isinstance(new_data, np.ndarray):
@@ -536,12 +532,9 @@ class Raster:
         Update the object with a new image or metadata.
 
         :param imgdata: image data to update with.
-        :type imgdata: None or np.array
         :param metadata: metadata to update with.
-        :type metadata: dict
         :param vrt_to_driver: name of driver to coerce a VRT to. This is required
         because rasterio does not support writing to to a VRTSourcedRasterBand.
-        :type vrt_to_driver: str
         """
         memfile = MemoryFile()
         if imgdata is None:
@@ -568,10 +561,10 @@ class Raster:
 
         :param stats: Add statistics for each band of the dataset (max, min, median, mean, std. dev.). Default is to
             not calculate statistics.
-        :type stats: bool
+
 
         :returns: text information about Raster attributes.
-        :rtype: str
+
         """
         as_str = [
             f"Driver:               {self.driver} \n",
@@ -613,7 +606,7 @@ class Raster:
         Copy the Raster object in memory
 
         :param new_array: New array to use for the copied Raster
-        :type new_array: np.ndarray
+
         :return:
         """
         if new_array is not None:
@@ -625,13 +618,13 @@ class Raster:
 
         return cp
 
-    def load(self, bands: int | list[int] | None = None, **kwargs) -> None:
+    def load(self, bands: int | list[int] | None = None, **kwargs: Any) -> None:
         r"""
         Load specific bands of the dataset, using rasterio.read().
         Ensure that self.data.ndim = 3 for ease of use (needed e.g. in show)
 
         :param bands: The band(s) to load. Note that rasterio begins counting at 1, not 0.
-        :type bands: int, or list of ints
+
 
         \*\*kwargs: any additional arguments to rasterio.io.DatasetReader.read.
         Useful ones are:
@@ -659,8 +652,8 @@ class Raster:
     def crop(
         self: RasterType,
         cropGeom: Raster | Vector | list[float] | tuple[float, ...],
-        mode="match_pixel",
-        inplace=True,
+        mode: str = "match_pixel",
+        inplace: bool = True,
     ) -> RasterType | None:
         """
         Crop the Raster to a given extent.
@@ -672,9 +665,8 @@ class Raster:
         :param mode: one of 'match_pixel' (default) or 'match_extent'. 'match_pixel' will preserve the original pixel
             resolution, cropping to the extent that most closely aligns with the current coordinates. 'match_extent'
             will match the extent exactly, adjusting the pixel resolution to fit the extent.
-        :type mode: str
         :param inplace: Update the raster inplace or return copy.
-        :type inplace: bool
+
         :returns: None if inplace=True and a new Raster if inplace=False
         """
         assert mode in [
@@ -738,7 +730,7 @@ class Raster:
         dst_crs: CRS | str | None = None,
         dst_size: tuple[int, int] | None = None,
         dst_bounds: dict[str, float] | rio.coords.BoundingBox | None = None,
-        dst_res: float | tuple[float, float] | None = None,
+        dst_res: float | Iterable[float] | None = None,
         nodata: int | float | None = None,
         dtype: np.dtype | None = None,
         resampling: Resampling | str = Resampling.nearest,
@@ -761,29 +753,19 @@ class Raster:
 
         :param dst_ref: a reference raster. If set will use the attributes of this
             raster for the output grid. Can be provided as Raster/rasterio data set or as path to the file.
-        :type dst_ref: Raster object, rasterio data set or a str.
         :param crs: Specify the Coordinate Reference System to reproject to. If dst_ref not set, defaults to self.crs.
-        :type crs: int, dict, str, CRS
         :param dst_size: Raster size to write to (x, y). Do not use with dst_res.
-        :type dst_size: tuple(int, int)
         :param dst_bounds: a BoundingBox object or a dictionary containing\
                 left, bottom, right, top bounds in the source CRS.
-        :type dst_bounds: dict or rio.coords.BoundingBox
         :param dst_res: Pixel size in units of target CRS. Either 1 value or (xres, yres). Do not use with dst_size.
-        :type dst_res: float or tuple(float, float)
         :param nodata: nodata value in reprojected data.
-        :type nodata: int, float, None
         :param resampling: A rasterio Resampling method
-        :type resampling: rio.warp or a matching string representation.
         :param silent: If True, will not print warning statements
-        :type silent: bool
         :param n_threads: The number of worker threads. Defaults to (os.cpu_count() - 1).
-        :type n_threads: int
         :param memory_limit: The warp operation memory limit in MB. Larger values may perform better.
-        :type memory_limit: int
 
         :returns: Raster
-        :rtype: Raster
+
         """
 
         # Check that either dst_ref or dst_crs is provided
@@ -964,9 +946,8 @@ class Raster:
         Translate the Raster by a given x,y offset.
 
         :param xoff: Translation x offset.
-        :type xoff: float
         :param yoff: Translation y offset.
-        :type yoff: float
+
 
         """
         # Check that data is loaded, as it is necessary for this method
@@ -983,9 +964,8 @@ class Raster:
         Set new nodata values for bands (and possibly update arrays)
 
         :param ndv: nodata values
-        :type ndv: collections.abc.Iterable or int or float
         :param update_array: change the existing nodata in array
-        :type update_array: bool
+
         """
 
         if not isinstance(ndv, (Iterable, int, float, np.integer, np.floating)):
@@ -1028,21 +1008,20 @@ class Raster:
 
         self._update(metadata=meta, imgdata=imgdata)
 
-    def set_dtypes(self, dtypes: Iterable | np.dtype | str, update_array: bool = True) -> None:
+    def set_dtypes(self, dtypes: Iterable[np.dtype | str] | np.dtype | str, update_array: bool = True) -> None:
         """
         Set new dtypes for bands (and possibly update arrays)
 
         :param dtypes: data types
-        :type dtypes: collections.abc.Iterable or type or str
         :param update_array: change the existing dtype in arrays
-        :type: update_array: bool
+
         """
-        if not (isinstance(dtypes, collections.abc.Iterable) or isinstance(dtypes, type) or isinstance(dtypes, str)):
+        if not (isinstance(dtypes, Iterable) or isinstance(dtypes, type) or isinstance(dtypes, str)):
             raise ValueError("Type of dtypes not understood, must be list or type or str")
         elif isinstance(dtypes, type) or isinstance(dtypes, str):
             print("Several raster band: using data type for all bands")
             dtypes = (dtypes,) * self.count
-        elif isinstance(dtypes, collections.abc.Iterable) and self.count == 1:
+        elif isinstance(dtypes, Iterable) and self.count == 1:
             print("Only one raster band: using first data type provided")
             dtypes = tuple(dtypes)
 
@@ -1069,7 +1048,7 @@ class Raster:
 
     def save(
         self,
-        filename: str,
+        filename: str | IO[bytes],
         driver: str = "GTiff",
         dtype: np.dtype | None = None,
         compress: str = "deflate",
@@ -1090,28 +1069,19 @@ class Raster:
         pixel instead.
 
         :param filename: Filename to write the file to.
-        :type filename: str
         :param driver: the 'GDAL' driver to use to write the file as.
-        :type driver: str
         :param dtype: Data Type to write the image as (defaults to dtype of image data)
-        :type dtype: np.dtype
         :param compress: Compression type. Defaults to 'deflate' (equal to GDALs: COMPRESS=DEFLATE)
-        :type compress: str, None
         :param tiled: Whether to write blocks in tiles instead of strips. Improves read performance on large files,
                       but increases file size.
-        :type tiled: bool
         :param blank_value: Use to write an image out with every pixel's value
             corresponding to this value, instead of writing the image data to disk.
-        :type blank_value: None, int, float.
         :param co_opts: GDAL creation options provided as a dictionary,
             e.g. {'TILED':'YES', 'COMPRESS':'LZW'}
-        :type co_opts: dict
         :param metadata: pairs of metadata key, value
-        :type metadata: dict
         :param gcps: list of gcps, each gcp being [row, col, x, y, (z)]
-        :type gcps: list
         :param gcps_crs: the CRS of the GCPS (Default is None)
-        :type gcps_crs: rasterio.crs.CRS
+
 
         :returns: None.
         """
@@ -1184,9 +1154,8 @@ to be cleared due to the setting of GCPs."
         the methods and attributes of the resulting DataArray.
 
         :param name: Set the name of the DataArray.
-        :type name: str
+
         :returns: xarray DataArray
-        :rtype: xr.DataArray
         """
         if not _has_rioxarray:
             raise ImportError("rioxarray is required for this functionality.")
@@ -1205,7 +1174,7 @@ to be cleared due to the setting of GCPs."
         :param densify_pts_max: Maximum points to be added between image corners to account for non linear edges.
                                 Reduce if time computation is really critical (ms) or increase if extent is \
                                         not accurate enough.
-        :type densify_pts_max: int
+
         """
         # Max points to be added between image corners to account for non linear edges
         # rasterio's default is a bit low for very large images
@@ -1225,11 +1194,10 @@ to be cleared due to the setting of GCPs."
         If the rasters have different projections, the intersection extent is given in self's projection system.
 
         :param rst : path to the second image (or another Raster instance)
-        :type rst: str, Raster
 
         :returns: extent of the intersection between the 2 images \
         (xmin, ymin, xmax, ymax) in self's coordinate system.
-        :rtype: tuple
+
         """
         from geoutils import projtools
 
@@ -1255,14 +1223,14 @@ to be cleared due to the setting of GCPs."
 
         # Compute intersection envelope
         intersect = poly1.intersection(poly2)
-        extent = intersect.envelope.bounds
+        extent: tuple[float, float, float, float] = intersect.envelope.bounds
 
         # check that intersection is not void
         if intersect.area == 0:
             warnings.warn("Warning: Intersection is void")
             return (0.0, 0.0, 0.0, 0.0)
-        else:
-            return extent
+
+        return extent
 
     def show(
         self,
@@ -1273,30 +1241,24 @@ to be cleared due to the setting of GCPs."
         cb_title: str | None = None,
         add_cb: bool = True,
         ax: matplotlib.axes.Axes | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None | tuple[matplotlib.axes.Axes, matplotlib.colors.Colormap]:
         r"""Show/display the image, with axes in projection of image.
 
         This method is a wrapper to rasterio.plot.show. Any \*\*kwargs which
         you give this method will be passed to rasterio.plot.show.
 
         :param band: which band to plot, from 0 to self.count-1 (default is all)
-        :type band: int
         :param cmap: The figure's colormap. Default is plt.rcParams['image.cmap']
-        :type cmap: matplotlib.colors.Colormap, str
         :param vmin: Colorbar minimum value. Default is data min.
-        :type vmin: int, float
         :param vmax: Colorbar maximum value. Default is data min.
-        :type vmax: int, float
         :param cb_title: Colorbar label. Default is None.
-        :type cb_title: str
         :param add_cb: Set to True to display a colorbar. Default is True.
-        :type add_cb: bool
         :param ax: A figure ax to be used for plotting. If None, will create default figure and axes,\
                 and plot figure directly.
-        :type ax: matplotlib.axes.Axes
+
         :returns: if ax is not None, returns (ax, cbar) where cbar is the colorbar (None if add_cb is False)
-        :rtype: (matplotlib.axes.Axes, matplotlib.colors.Colormap)
+
 
         You can also pass in \*\*kwargs to be used by the underlying imshow or
         contour methods of matplotlib. The example below shows provision of
@@ -1386,13 +1348,14 @@ to be cleared due to the setting of GCPs."
         # If ax not set, figure should be plotted directly
         if ax is None:
             plt.show()
-        else:
-            return ax0, cbar
+            return None
+
+        return ax0, cbar
 
     def value_at_coords(
         self,
-        x: float,
-        y: float,
+        x: float | list[float],
+        y: float | list[float],
         latlon: bool = False,
         band: int | None = None,
         masked: bool = False,
@@ -1400,7 +1363,7 @@ to be cleared due to the setting of GCPs."
         return_window: bool = False,
         boundless: bool = True,
         reducer_function: Callable[[np.ndarray], float] = np.ma.mean,
-    ) -> tuple[Number, ...]:
+    ) -> Any:
         """ Extract the pixel value(s) at the nearest pixel(s) from the specified coordinates.
 
         Extract pixel value of each band in dataset at the specified
@@ -1410,39 +1373,27 @@ to be cleared due to the setting of GCPs."
         Optionally, return mean of pixels within a square window.
 
         :param x: x (or longitude) coordinate.
-        :type x: float
         :param y: y (or latitude) coordinate.
-        :type y: float
         :param latlon: Set to True if coordinates provided as longitude/latitude.
-        :type latlon: boolean
         :param band: the band number to extract from.
-        :type band: int
         :param masked: If `masked` is `True` the return value will be a masked
             array. Otherwise (the default) the return value will be a
             regular array.
-        :type masked: bool, optional (default False)
         :param window: expand area around coordinate to dimensions \
                   window * window. window must be odd.
-        :type window: None, int
         :param return_window: If True when window=int, returns (mean,array) \
             where array is the dataset extracted via the specified window size.
-        :type return_window: boolean
         :param boundless: If `True`, windows that extend beyond the dataset's extent
             are permitted and partially or completely filled arrays (with self.nodata) will
             be returned as appropriate.
-        :type boundless: bool, optional (default False)
         :param reducer_function: a function to apply to the values in window.
-        :type reducer_function: function, optional (Default is np.ma.mean)
 
         :returns: When called on a Raster or with a specific band \
             set, return value of pixel.
-        :rtype: float
         :returns: If multiple band Raster and the band is not specified, a \
             dictionary containing the value of the pixel in each band.
-        :rtype: dict
         :returns: In addition, if return_window=True, return tuple of \
             (values, arrays)
-        :rtype: tuple
 
         :examples:
 
@@ -1454,6 +1405,7 @@ to be cleared due to the setting of GCPs."
         (c = provided coordinate, v= value of surrounding coordinate)
 
         """
+        value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], np.ndarray] | Any]
         if window is not None:
             if window % 2 != 1:
                 raise ValueError("Window must be an odd number.")
@@ -1555,9 +1507,8 @@ to be cleared due to the setting of GCPs."
 
         :param offset: coordinate type. If 'corner', returns corner coordinates of pixels.
             If 'center', returns center coordinates. Default is corner.
-        :type offset: str
         :param grid: Return grid
-        :type grid: bool
+
         :returns x,y: numpy arrays corresponding to the x,y coordinates of each pixel.
         """
         assert offset in [
@@ -1575,7 +1526,8 @@ to be cleared due to the setting of GCPs."
             xx += dx / 2  # shift by half a pixel
             yy += dy / 2
         if grid:
-            return np.meshgrid(xx[:-1], yy[:-1])  # drop the last element
+            meshgrid: tuple[np.ndarray, np.ndarray] = np.meshgrid(xx[:-1], yy[:-1])  # drop the last element
+            return meshgrid
         else:
             return xx[:-1], yy[:-1]
 
@@ -1591,20 +1543,15 @@ to be cleared due to the setting of GCPs."
         Return row, column indices for a given x,y coordinate pair.
 
         :param x: x coordinates
-        :type x: array-like
         :param y: y coordinates
-        :type y: array-like
         :param op: operator to calculate index
-        :type op: Any
         :param precision: precision for rio.Dataset.index
-        :type precision: Any
         :param area_or_point: shift index according to GDAL AREA_OR_POINT attribute (None) or \
                 force position ('Point' or 'Area') of the interpretation of where the raster value \
                 corresponds to in the pixel ('Area' = lower left or 'Point' = center)
-        :type area_or_point: str, None
 
         :returns i, j: indices of x,y in the image.
-        :rtype i, j: array-like
+
 
         """
         if op not in [np.float32, np.float64, float]:
@@ -1663,11 +1610,8 @@ to be cleared due to the setting of GCPs."
         Return x,y coordinates for a given row, column index pair.
 
         :param i: row (i) index of pixel.
-        :type i: array-like
         :param j: column (j) index of pixel.
-        :type j: array-like
         :param offset: return coordinates as "corner" or "center" of pixel
-        :type offset: str
 
         :returns x, y: x,y coordinates of i,j in reference system.
         """
@@ -1681,11 +1625,8 @@ to be cleared due to the setting of GCPs."
         Check whether a given point falls outside of the raster.
 
         :param xi: Indices (or coordinates) of x direction to check.
-        :type xi: array-like
         :param yj: Indices (or coordinates) of y direction to check.
-        :type yj: array-like
         :param index: Interpret ij as raster indices (default is True). If False, assumes ij is coordinates.
-        :type index: bool
 
         :returns is_outside: True if ij is outside of the image.
         """
@@ -1706,7 +1647,7 @@ to be cleared due to the setting of GCPs."
         mode: str = "linear",
         band: int = 1,
         area_or_point: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> np.ndarray:
 
         """
@@ -1714,22 +1655,16 @@ to be cleared due to the setting of GCPs."
 
         :param pts: Point(s) at which to interpolate raster value. If points fall outside of image,
         value returned is nan. Shape should be (N,2)'
-        :type pts: array-like
         :param input_latlon: Whether the input is in latlon, unregarding of Raster CRS
-        :type input_latlon: bool
         :param mode: One of 'linear', 'cubic', or 'quintic'. Determines what type of spline is
              used to interpolate the raster value at each point. For more information, see
              scipy.interpolate.interp2d. Default is linear.
-        :type mode: str
         :param band: Raster band to use
-        :type band: int
         :param area_or_point: shift index according to GDAL AREA_OR_POINT attribute (None) or force position\
                 ('Point' or 'Area') of the interpretation of where the raster value corresponds to in the pixel\
                 ('Area' = lower left or 'Point' = center)
-        :type area_or_point: str, None
 
         :returns rpts: Array of raster value(s) for the given points.
-        :rtype rpts: array-like
         """
         assert mode in [
             "mean",
@@ -1790,16 +1725,14 @@ to be cleared due to the setting of GCPs."
         #         rpts.append(zint)
         # rpts = np.array(rpts)
 
-    def split_bands(
-        self: RasterType, copy: bool = False, subset: list[int] | int | None = None
-    ) -> Raster | list[Raster]:
+    def split_bands(self: RasterType, copy: bool = False, subset: list[int] | int | None = None) -> list[Raster]:
         """
         Split the bands into separate copied rasters.
 
         :param copy: Copy the bands or return slices of the original data.
         :param subset: Optional. A subset of band indices to extract. Defaults to all.
 
-        :returns: A list of Rasters for each band, or one Raster if len(subset)==1.
+        :returns: A list of Rasters for each band.
         """
         bands: list[Raster] = []
 
@@ -1833,4 +1766,4 @@ to be cleared due to the setting of GCPs."
                 raster.nbands = 1
                 bands.append(raster)
 
-        return bands if len(bands) > 1 else bands[0]
+        return bands

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -3,9 +3,8 @@ geoutils.vectortools provides a toolset for working with vector data.
 """
 from __future__ import annotations
 
-import collections
 import warnings
-from collections.abc import Iterable
+from collections import abc
 from numbers import Number
 from typing import TypeVar
 
@@ -190,7 +189,7 @@ the provided raster file.
         xres: float | None = None,
         yres: float | None = None,
         bounds: tuple[float, float, float, float] | None = None,
-        in_value: int | float | Iterable[int | float] | None = None,
+        in_value: int | float | abc.Iterable[int | float] | None = None,
         out_value: int | float = 0,
     ) -> np.ndarray:
         """
@@ -262,7 +261,7 @@ the provided raster file.
             in_value = self.ds.index + 1
 
         # Rasterize geometry
-        if isinstance(in_value, collections.abc.Iterable):
+        if isinstance(in_value, abc.Iterable):
             if len(in_value) != len(vect.geometry):  # type: ignore
                 raise ValueError(
                     "in_value must have same length as self.ds.geometry, currently {} != {}".format(

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -1,8 +1,8 @@
 """
 geoutils.vectortools provides a toolset for working with vector data.
 """
-import warnings
 import collections
+import warnings
 from numbers import Number
 
 import geopandas as gpd
@@ -11,7 +11,7 @@ import rasterio as rio
 from rasterio import features, warp
 
 
-class Vector(object):
+class Vector:
     """
     Create a Vector object from a fiona-supported vector dataset.
     """
@@ -34,8 +34,8 @@ class Vector(object):
             self.ds = filename
             self.name = None
         else:
-            raise ValueError('filename argument not recognised.')
-        
+            raise ValueError("filename argument not recognised.")
+
         self.crs = self.ds.crs
 
     def __repr__(self):
@@ -53,13 +53,13 @@ class Vector(object):
         :rtype: str
         """
         as_str = [  # 'Driver:             {} \n'.format(self.driver),
-            'Filename:           {} \n'.format(self.name),
-            'Coordinate System:  EPSG:{}\n'.format(
-                self.ds.crs.to_epsg()),
-            'Number of features: {} \n'.format(len(self.ds)),
-            'Extent:             {} \n'.format(self.ds.total_bounds.tolist()),
-            'Attributes:         {} \n'.format(self.ds.columns.tolist()),
-            self.ds.__repr__()]
+            f"Filename:           {self.name} \n",
+            f"Coordinate System:  EPSG:{self.ds.crs.to_epsg()}\n",
+            f"Number of features: {len(self.ds)} \n",
+            f"Extent:             {self.ds.total_bounds.tolist()} \n",
+            f"Attributes:         {self.ds.columns.tolist()} \n",
+            self.ds.__repr__(),
+        ]
 
         return "".join(as_str)
 
@@ -75,7 +75,9 @@ class Vector(object):
 
     def crop2raster(self, rst):
         """
-        Update self so that features outside the extent of a raster file are cropped. Reprojection is done on the fly if both data set have different projections.
+        Update self so that features outside the extent of a raster file are cropped.
+
+        Reprojection is done on the fly if both data set have different projections.
 
         :param rst: A Raster object or string to filename
         :type rst: Raster object or str
@@ -83,14 +85,14 @@ class Vector(object):
         # If input is string, open as Raster
         if isinstance(rst, str):
             from geoutils.georaster import Raster
+
             rst = Raster(rst)
 
         # Convert raster extent into self CRS
         # Note: could skip this if we could test if rojections are same
         # Note: should include a method in Raster to get extent in other projections, not only using corners
         left, bottom, right, top = rst.bounds
-        x1, y1, x2, y2 = warp.transform_bounds(
-            rst.crs, self.ds.crs, left, bottom, right, top)
+        x1, y1, x2, y2 = warp.transform_bounds(rst.crs, self.ds.crs, left, bottom, right, top)
         self.ds = self.ds.cx[x1:x2, y1:y2]
 
     def create_mask(self, rst=None, crs=None, xres=None, yres=None, bounds=None):
@@ -98,7 +100,9 @@ class Vector(object):
         Rasterize the vector features into a boolean raster which has the extent/dimensions of \
 the provided raster file.
 
-        Alternatively, user can specify a grid to rasterize on using xres, yres, bounds and crs. Only xres is mandatory, by default yres=xres and bounds/crs are set to self's.
+        Alternatively, user can specify a grid to rasterize on using xres, yres, bounds and crs.
+        Only xres is mandatory, by default yres=xres and bounds/crs are set to self's.
+
         Vector features which fall outside the bounds of the raster file are not written to the new mask file.
 
         :param rst: A Raster object or string to filename
@@ -118,6 +122,7 @@ the provided raster file.
         # If input rst is string, open as Raster
         if isinstance(rst, str):
             from geoutils.georaster import Raster
+
             rst = Raster(rst)
 
         # If no rst given, use provided dimensions
@@ -125,7 +130,7 @@ the provided raster file.
 
             # At minimum, xres must be set
             if xres is None:
-                raise ValueError('at least rst or xres must be set')
+                raise ValueError("at least rst or xres must be set")
             if yres is None:
                 yres = xres
 
@@ -137,20 +142,18 @@ the provided raster file.
 
             # Calculate raster shape
             left, bottom, right, top = bounds
-            height = abs((right-left)/xres)
-            width = abs((top-bottom)/yres)
+            height = abs((right - left) / xres)
+            width = abs((top - bottom) / yres)
 
             if width % 1 != 0 or height % 1 != 0:
-                warnings.warn(
-                    "Bounds not a multiple of xres/yres, use rounded bounds")
+                warnings.warn("Bounds not a multiple of xres/yres, use rounded bounds")
 
             width = int(np.round(width))
             height = int(np.round(height))
             out_shape = (height, width)
 
             # Calculate raster transform
-            transform = rio.transform.from_bounds(
-                left, bottom, right, top, width, height)
+            transform = rio.transform.from_bounds(left, bottom, right, top, width, height)
 
         # otherwise use directly rst's dimensions
         else:
@@ -163,9 +166,9 @@ the provided raster file.
         vect = self.ds.to_crs(crs)
 
         # Rasterize geomtry
-        mask = features.rasterize(shapes=vect.geometry,
-                                  fill=0, out_shape=out_shape,
-                                  transform=transform, default_value=1, dtype='uint8').astype('bool')
+        mask = features.rasterize(
+            shapes=vect.geometry, fill=0, out_shape=out_shape, transform=transform, default_value=1, dtype="uint8"
+        ).astype("bool")
 
         # Force output mask to be of same dimension as input rst
         if rst is not None:
@@ -205,6 +208,7 @@ the provided raster file.
         # If input rst is string, open as Raster
         if isinstance(rst, str):
             from geoutils.georaster import Raster
+
             rst = Raster(rst)
 
         # If no rst given, use provided dimensions
@@ -212,7 +216,7 @@ the provided raster file.
 
             # At minimum, xres must be set
             if xres is None:
-                raise ValueError('at least rst or xres must be set')
+                raise ValueError("at least rst or xres must be set")
             if yres is None:
                 yres = xres
 
@@ -224,20 +228,18 @@ the provided raster file.
 
             # Calculate raster shape
             left, bottom, right, top = bounds
-            height = abs((right-left)/xres)
-            width = abs((top-bottom)/yres)
+            height = abs((right - left) / xres)
+            width = abs((top - bottom) / yres)
 
             if width % 1 != 0 or height % 1 != 0:
-                warnings.warn(
-                    "Bounds not a multiple of xres/yres, use rounded bounds")
+                warnings.warn("Bounds not a multiple of xres/yres, use rounded bounds")
 
             width = int(np.round(width))
             height = int(np.round(height))
             out_shape = (height, width)
 
             # Calculate raster transform
-            transform = rio.transform.from_bounds(
-                left, bottom, right, top, width, height)
+            transform = rio.transform.from_bounds(left, bottom, right, top, width, height)
 
         # otherwise use directly rst's dimensions
         else:
@@ -258,21 +260,20 @@ the provided raster file.
             if len(in_value) != len(vect.geometry):
                 raise ValueError(
                     "in_value must have same length as self.ds.geometry, currently {} != {}".format(
-                        len(in_value), len(vect.geometry))
+                        len(in_value), len(vect.geometry)
+                    )
                 )
 
             out_geom = ((geom, value) for geom, value in zip(vect.geometry, in_value))
 
-            mask = features.rasterize(shapes=out_geom, fill=out_value, out_shape=out_shape,
-                                      transform=transform)
+            mask = features.rasterize(shapes=out_geom, fill=out_value, out_shape=out_shape, transform=transform)
 
         elif isinstance(in_value, Number):
-            mask = features.rasterize(shapes=vect.geometry, fill=out_value, out_shape=out_shape,
-                                      transform=transform, default_value=in_value)
-        else:
-            raise ValueError(
-                "in_value must be a single number or an iterable with same length as self.ds.geometry"
+            mask = features.rasterize(
+                shapes=vect.geometry, fill=out_value, out_shape=out_shape, transform=transform, default_value=in_value
             )
+        else:
+            raise ValueError("in_value must be a single number or an iterable with same length as self.ds.geometry")
 
         return mask
 

--- a/geoutils/geoviewer.py
+++ b/geoutils/geoviewer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-#coding=utf-8
 """
 geoutils.geoviewer provides a toolset for plotting raster and vector data
 
@@ -8,11 +7,11 @@ TO DO:
 - include some options from imviewer: https://github.com/dshean/imview/blob/master/imview/imviewer.py
 """
 
+import argparse
 import sys
 
-import argparse
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from geoutils.georaster import Raster
 from geoutils.geovector import Vector
@@ -21,25 +20,92 @@ from geoutils.geovector import Vector
 def getparser():
 
     # Set up description
-    parser = argparse.ArgumentParser(description='Visualisation tool for any image supported by GDAL.')
+    parser = argparse.ArgumentParser(description="Visualisation tool for any image supported by GDAL.")
 
-    #Positional arguments
-    parser.add_argument('filename', type=str, help='str, path to the image')
+    # Positional arguments
+    parser.add_argument("filename", type=str, help="str, path to the image")
 
-    #optional arguments
-    parser.add_argument('-cmap', dest='cmap', type=str, default='default', help='str, a matplotlib colormap string (default is from rcParams).')
-    parser.add_argument('-vmin', dest='vmin', type=str, default=None, help='float, the minimum value for colorscale, or can be expressed as a percentile e.g. 5%% (default is calculated min value).')
-    parser.add_argument('-vmax', dest='vmax', type=str, default=None, help='float, the maximum value for colorscale, or can be expressed as a percentile e.g. 95%% (default is calculated max value).')
-    parser.add_argument('-band', dest='band', type=int, default=None, help='int, which band to display (start at 0) for multiband images (Default is 0).')
-    parser.add_argument('-nocb', dest='nocb', help='If set, will not display a colorbar (Default is to display the colorbar).',action='store_false')
-    parser.add_argument('-clabel', dest='clabel', type=str, default='', help='str, the label for the colorscale (Default is empty).')
-    parser.add_argument('-title', dest='title', type=str, default='', help='str, figure title (Default is empty).')
-    parser.add_argument('-figsize', dest='figsize', type=str, default='default', help='str, figure size, must be a tuple of size 2, either written with quotes, or two numbers seperated by coma, no space (Default is from rcParams).')
-    parser.add_argument('-max_size', dest='max_size', type=int, default=2000, help='int, image size is limited to max_size**2 for faster reading/displaying (Default is 2000).')
-    parser.add_argument('-save', dest='save', type=str, default='', help='str, filename to the output filename to save to disk (Default is displayed on screen).')
-    parser.add_argument('-dpi', dest='dpi', type=str, default='default', help='int, dpi value to use when saving figure (Default is from rcParams).')
-    parser.add_argument('-nodata', dest='nodata', type=str, default='default', help='float, no data value (Default is read from file metadata).')
-    parser.add_argument('-noresampl', dest='noresampl', default=False, action='store_true', help='True or False, if False then allow dynamic image downscaling, if True, prevent it.')
+    # optional arguments
+    parser.add_argument(
+        "-cmap",
+        dest="cmap",
+        type=str,
+        default="default",
+        help="str, a matplotlib colormap string (default is from rcParams).",
+    )
+    parser.add_argument(
+        "-vmin",
+        dest="vmin",
+        type=str,
+        default=None,
+        help="float, the minimum value for colorscale, or can be expressed as a percentile e.g. 5%% (default is calculated min value).",
+    )
+    parser.add_argument(
+        "-vmax",
+        dest="vmax",
+        type=str,
+        default=None,
+        help="float, the maximum value for colorscale, or can be expressed as a percentile e.g. 95%% (default is calculated max value).",
+    )
+    parser.add_argument(
+        "-band",
+        dest="band",
+        type=int,
+        default=None,
+        help="int, which band to display (start at 0) for multiband images (Default is 0).",
+    )
+    parser.add_argument(
+        "-nocb",
+        dest="nocb",
+        help="If set, will not display a colorbar (Default is to display the colorbar).",
+        action="store_false",
+    )
+    parser.add_argument(
+        "-clabel", dest="clabel", type=str, default="", help="str, the label for the colorscale (Default is empty)."
+    )
+    parser.add_argument("-title", dest="title", type=str, default="", help="str, figure title (Default is empty).")
+    parser.add_argument(
+        "-figsize",
+        dest="figsize",
+        type=str,
+        default="default",
+        help="str, figure size, must be a tuple of size 2, either written with quotes, or two numbers seperated by coma, no space (Default is from rcParams).",
+    )
+    parser.add_argument(
+        "-max_size",
+        dest="max_size",
+        type=int,
+        default=2000,
+        help="int, image size is limited to max_size**2 for faster reading/displaying (Default is 2000).",
+    )
+    parser.add_argument(
+        "-save",
+        dest="save",
+        type=str,
+        default="",
+        help="str, filename to the output filename to save to disk (Default is displayed on screen).",
+    )
+    parser.add_argument(
+        "-dpi",
+        dest="dpi",
+        type=str,
+        default="default",
+        help="int, dpi value to use when saving figure (Default is from rcParams).",
+    )
+    parser.add_argument(
+        "-nodata",
+        dest="nodata",
+        type=str,
+        default="default",
+        help="float, no data value (Default is read from file metadata).",
+    )
+    parser.add_argument(
+        "-noresampl",
+        dest="noresampl",
+        default=False,
+        action="store_true",
+        help="True or False, if False then allow dynamic image downscaling, if True, prevent it.",
+    )
 
     args = parser.parse_args()
 
@@ -56,14 +122,10 @@ def main():
     xmin, xmax, ymin, ymax = img.bounds
 
     ## Resample if image is too large ##
-    if ((img.width > args.max_size) or (img.height > args.max_size)) \
-       & (not args.noresampl):
-        dfact = max(
-            int(img.width/args.max_size),
-            int(img.height/args.max_size)
-        )
-        print("Image will be downsampled by a factor {}.".format(dfact))
-        new_shape = (img.count, int(img.height/dfact), int(img.width/dfact))
+    if ((img.width > args.max_size) or (img.height > args.max_size)) & (not args.noresampl):
+        dfact = max(int(img.width / args.max_size), int(img.height / args.max_size))
+        print(f"Image will be downsampled by a factor {dfact}.")
+        new_shape = (img.count, int(img.height / dfact), int(img.width / dfact))
     else:
         new_shape = None
 
@@ -71,13 +133,13 @@ def main():
     img.load(out_shape=new_shape)
 
     # Set no data value
-    if args.nodata == 'default':
+    if args.nodata == "default":
         nodata = img.nodata
     else:
         try:
             nodata = float(args.nodata)
         except ValueError:
-            raise ValueError("ERROR: nodata must be a float, currently set to %s" %args.nodata)
+            raise ValueError("ERROR: nodata must be a float, currently set to %s" % args.nodata)
 
         img.set_ndv(nodata)
 
@@ -87,12 +149,12 @@ def main():
     if args.vmin is not None:
         try:
             vmin = float(args.vmin)
-        except ValueError:   # Case is not a number
-            perc, _ = args.vmin.split('%')
+        except ValueError:  # Case is not a number
+            perc, _ = args.vmin.split("%")
             try:
                 perc = float(perc)
                 vmin = np.percentile(img.data, perc)
-            except ValueError:   # Case no % sign
+            except ValueError:  # Case no % sign
                 raise ValueError("vmin must be a float or percentage, currently set to %s" % args.vmin)
 
     else:
@@ -102,48 +164,47 @@ def main():
     if args.vmax is not None:
         try:
             vmax = float(args.vmax)
-        except ValueError:   # Case is not a number
-            perc, _ = args.vmax.split('%')
+        except ValueError:  # Case is not a number
+            perc, _ = args.vmax.split("%")
             try:
                 perc = float(perc)
                 vmax = np.percentile(img.data, perc)
-            except ValueError:   # Case no % sign
+            except ValueError:  # Case no % sign
                 raise ValueError("vmax must be a float or percentage, currently set to %s" % args.vmax)
 
     else:
         vmax = None
 
     # color map
-    if args.cmap == 'default':
-        cmap = plt.rcParams['image.cmap']
+    if args.cmap == "default":
+        cmap = plt.rcParams["image.cmap"]
     elif args.cmap in plt.cm.datad.keys():
         cmap = args.cmap
     else:
-        print("ERROR: cmap set to %s, must be in:" %args.cmap)
+        print("ERROR: cmap set to %s, must be in:" % args.cmap)
         for i, elem in enumerate(plt.cm.datad.keys(), 1):
-            print(str(elem), end='\n' if i % 10 == 0 else ', ')
+            print(str(elem), end="\n" if i % 10 == 0 else ", ")
         sys.exit(1)
 
     # Figsize
-    if args.figsize == 'default':
-        figsize = plt.rcParams['figure.figsize']
+    if args.figsize == "default":
+        figsize = plt.rcParams["figure.figsize"]
     else:
         try:
             figsize = tuple(eval(args.figsize))
             xfigsize, yfigsize = figsize
         except:
-            print("ERROR: figsize must be a tuple of size 2, currently set to %s" %args.figsize)
+            print("ERROR: figsize must be a tuple of size 2, currently set to %s" % args.figsize)
             sys.exit(1)
 
     # dpi
-    if args.dpi == 'default':
-        dpi = plt.rcParams['figure.dpi']
+    if args.dpi == "default":
+        dpi = plt.rcParams["figure.dpi"]
     else:
         try:
             dpi = int(args.dpi)
         except ValueError:
-            raise ValueError("ERROR: dpi must be an integer, currently set to %s" %args.dpi)
-
+            raise ValueError("ERROR: dpi must be an integer, currently set to %s" % args.dpi)
 
     ## Plot data ##
 
@@ -151,19 +212,27 @@ def main():
     ax = fig.add_subplot(111)
 
     # plot
-    img.show(ax=ax, band=args.band, cmap=cmap, interpolation='nearest',
-             vmin=vmin, vmax=vmax, add_cb=args.nocb, cb_title=args.clabel,
-             title=args.title)
+    img.show(
+        ax=ax,
+        band=args.band,
+        cmap=cmap,
+        interpolation="nearest",
+        vmin=vmin,
+        vmax=vmax,
+        add_cb=args.nocb,
+        cb_title=args.clabel,
+        title=args.title,
+    )
 
     plt.tight_layout()
 
     # Save
-    if args.save != '':
+    if args.save != "":
         plt.savefig(args.save, dpi=dpi)
         print("Figure saved to file %s." % args.save)
     else:
         plt.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -3,7 +3,7 @@ GeoUtils.projtools provides a toolset for dealing with different coordinate refe
 """
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections import abc
 
 import geopandas as gpd
 import numpy as np
@@ -61,7 +61,7 @@ def bounds2poly(
 
 
 def merge_bounds(
-    bounds_list: Iterable[list[float] | Raster | rio.io.DatasetReader | Vector | gpd.GeoDataFrame],
+    bounds_list: abc.Iterable[list[float] | Raster | rio.io.DatasetReader | Vector | gpd.GeoDataFrame],
     merging_algorithm: str = "union",
 ) -> tuple[float, ...]:
     """

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -1,37 +1,49 @@
 """
 GeoUtils.projtools provides a toolset for dealing with different coordinate reference systems (CRS).
 """
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import geopandas as gpd
 import numpy as np
 import pyproj
 import rasterio as rio
 import shapely.ops
 from rasterio.crs import CRS
+from shapely.geometry.base import BaseGeometry
 from shapely.geometry.polygon import Polygon
 
+from geoutils.georaster import Raster
+from geoutils.geovector import Vector
 
-def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
+
+def bounds2poly(
+    boundsGeom: list[float] | rio.io.DatasetReader | Raster | Vector,
+    in_crs: CRS | None = None,
+    out_crs: CRS | None = None,
+) -> Polygon:
     """
     Converts self's bounds into a shapely Polygon. Optionally, returns it into a different CRS.
 
     :param boundsGeom: A geometry with bounds. Can be either a list of coordinates (xmin, ymin, xmax, ymax),\
             a rasterio/Raster object, a geoPandas/Vector object
-    :type boundsGeom: list, tuple, object with attributes bounds or total_bounds
     :param in_crs: Input CRS
-    :type in_crs: rasterio.crs.CRS
     :param out_crs: Output CRS
-    :type out_crs: rasterio.crs.CRS
 
     :returns: Output polygon
-    :rtype: shapely Polygon
     """
+    if in_crs is not None:
+        raise NotImplementedError
+
     # If boundsGeom is a GeoPandas or Vector object (warning, has both total_bounds and bounds attributes)
     if hasattr(boundsGeom, "total_bounds"):
-        xmin, ymin, xmax, ymax = boundsGeom.total_bounds
-        in_crs = boundsGeom.crs
+        xmin, ymin, xmax, ymax = boundsGeom.total_bounds  # type: ignore
+        in_crs = boundsGeom.crs  # type: ignore
     # If boundsGeom is a rasterio or Raster object
     elif hasattr(boundsGeom, "bounds"):
-        xmin, ymin, xmax, ymax = boundsGeom.bounds
-        in_crs = boundsGeom.crs
+        xmin, ymin, xmax, ymax = boundsGeom.bounds  # type: ignore
+        in_crs = boundsGeom.crs  # type: ignore
     # if a list of coordinates
     elif isinstance(boundsGeom, (list, tuple)):
         xmin, ymin, xmax, ymax = boundsGeom
@@ -48,18 +60,18 @@ def bounds2poly(boundsGeom, in_crs=None, out_crs=None):
     return bbox
 
 
-def merge_bounds(bounds_list, merging_algorithm="union"):
+def merge_bounds(
+    bounds_list: Iterable[list[float] | Raster | rio.io.DatasetReader | Vector | gpd.GeoDataFrame],
+    merging_algorithm: str = "union",
+) -> tuple[float, ...]:
     """
     Merge a list of bounds into single bounds, using either the union or intersection.
 
     :param bounds_list: A list of geometries with bounds, i.e. a list of coordinates (xmin, ymin, xmax, ymax), \
 a rasterio/Raster object, a geoPandas/Vector object.
-    :type bounds_list: list, tuple
     :param merging_algorithm: the algorithm to use for merging, either "union" or "intersection"
-    :type merging_algorithm: str
 
     :returns: Output bounds (xmin, ymin, xmax, ymax)
-    :rtype: tuple
     """
     # Check that bounds_list is a list of bounds objects
     assert isinstance(bounds_list, (list, tuple)), "bounds_list must be a list/tuple"
@@ -69,7 +81,7 @@ a rasterio/Raster object, a geoPandas/Vector object.
             "or total_bounds"
         )
 
-    output_poly = bounds2poly(boundsGeom=bounds_list[0], in_crs=None)
+    output_poly = bounds2poly(boundsGeom=bounds_list[0])
 
     for boundsGeom in bounds_list[1:]:
         new_poly = bounds2poly(boundsGeom)
@@ -81,22 +93,19 @@ a rasterio/Raster object, a geoPandas/Vector object.
         else:
             raise ValueError("merging_algorithm must be 'union' or 'intersection'")
 
-    return output_poly.bounds
+    new_bounds: tuple[float] = output_poly.bounds
+    return new_bounds
 
 
-def reproject_points(pts, in_crs, out_crs):
+def reproject_points(pts: list[list[float]] | np.ndarray, in_crs: CRS, out_crs: CRS) -> tuple[list[float], list[float]]:
     """
     Reproject a set of point from input_crs to output_crs.
 
     :param pts: Input points to be reprojected. Must be of shape (2, N), i.e (x coords, y coords)
-    :type pts: list, tuple, np.ndarray'
     :param in_crs: Input CRS
-    :type in_crs: rasterio.crs.CRS
     :param out_crs: Output CRS
-    :type out_crs: rasterio.crs.CRS
 
     :returns: Reprojected points, of same shape as pts.
-    :rtype: list
     """
     assert np.shape(pts)[0] == 2, "pts must be of shape (2, N)"
 
@@ -111,70 +120,60 @@ def reproject_points(pts, in_crs, out_crs):
 crs_4326 = rio.crs.CRS.from_epsg(4326)
 
 
-def reproject_to_latlon(pts, in_crs, round_: int = 8):
+def reproject_to_latlon(
+    pts: list[list[float]] | np.ndarray, in_crs: CRS, round_: int = 8
+) -> tuple[list[float], list[float]]:
     """
     Reproject a set of point from in_crs to lat/lon.
 
     :param pts: Input points to be reprojected. Must be of shape (2, N), i.e (x coords, y coords)
-    :type pts: list, tuple, np.ndarray'
     :param in_crs: Input CRS
-    :type in_crs: rasterio.crs.CRS
     :param round_: Output rounding. Default of 8 ensures cm accuracy
-    :type round_: int
 
     :returns: Reprojected points, of same shape as pts.
-    :rtype: list
     """
     proj_pts = reproject_points(pts, in_crs, crs_4326)
     proj_pts = np.round(proj_pts, round_)
     return proj_pts
 
 
-def reproject_from_latlon(pts, out_crs, round_: int = 2):
+def reproject_from_latlon(
+    pts: list[list[float]] | tuple[list[float], list[float]] | np.ndarray, out_crs: CRS, round_: int = 2
+) -> tuple[list[float], list[float]]:
     """
     Reproject a set of point from lat/lon to out_crs.
 
     :param pts: Input points to be reprojected. Must be of shape (2, N), i.e (x coords, y coords)
-    :type pts: list, tuple, np.ndarray'
     :param out_crs: Output CRS
-    :type out_crs: rasterio.crs.CRS
     :param round_: Output rounding. Default of 2 ensures cm accuracy
-    :type round_: int
 
     :returns: Reprojected points, of same shape as pts.
-    :rtype: list
     """
     proj_pts = reproject_points(pts, crs_4326, out_crs)
     proj_pts = np.round(proj_pts, round_)
     return proj_pts
 
 
-def reproject_shape(inshape, in_crs, out_crs):
+def reproject_shape(inshape: BaseGeometry, in_crs: CRS, out_crs: CRS) -> BaseGeometry:
     """
     Reproject a shapely geometry from one CRS into another CRS.
 
     :param inshape: Shapely geometry to be reprojected.
-    :type inshape: shapely geometry
     :param in_crs: Input CRS
-    :type in_crs: rasterio.crs.CRS
     :param out_crs: Output CRS
-    :type out_crs: rasterio.crs.CRS
 
     :returns: Reprojected geometry
-    :rtype: shapely geometry
     """
     reproj = pyproj.Transformer.from_crs(in_crs, out_crs, always_xy=True, skip_equivalent=True).transform
     return shapely.ops.transform(reproj, inshape)
 
 
-def compare_proj(proj1, proj2):
+def compare_proj(proj1: CRS, proj2: CRS) -> bool:
     """
     Compare two projections to see if they are the same, using pyproj.CRS.is_exact_same.
 
     :param proj1: The first projection to compare.
-    :type proj1: pyproj.CRS, rasterio.crs.CRS
     :param proj2: The first projection to compare.
-    :type proj2: pyproj.CRS, rasterio.crs.CRS
 
     :returns: True if the two projections are the same.
     """
@@ -184,4 +183,5 @@ def compare_proj(proj1, proj2):
     proj1 = pyproj.CRS(proj1.to_string())
     proj2 = pyproj.CRS(proj2.to_string())
 
-    return proj1.is_exact_same(proj2)
+    same: bool = proj1.is_exact_same(proj2)
+    return same

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import datetime as dt
 import os
 import re
+import warnings
 from collections.abc import Iterable
 from typing import Any
 
@@ -351,7 +352,9 @@ class SatelliteImage(Raster):
                     )
 
     def __parse_metadata_from_file(self, fn_meta: str | None) -> None:
-        raise NotImplementedError(fn_meta)
+        warnings.warn(f"Parse metadata from file not implemented. {fn_meta}")
+
+        return None
 
     def copy(self, new_array: np.ndarray | None = None) -> SatelliteImage:
         new_satimg = super().copy(new_array=new_array)  # type: ignore

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -1,20 +1,21 @@
 """
 geoutils.satimg provides a toolset for working with satellite data.
 """
+import datetime as dt
 import os
 import re
-import datetime as dt
-import numpy as np
-from geoutils.georaster import Raster
-import collections
-import rasterio as rio
 
-lsat_sensor = {'C': 'OLI/TIRS', 'E': 'ETM+', 'T': 'TM', 'M': 'MSS', 'O': 'OLI', 'TI': 'TIRS'}
+import numpy as np
+
+from geoutils.georaster import Raster
+
+lsat_sensor = {"C": "OLI/TIRS", "E": "ETM+", "T": "TM", "M": "MSS", "O": "OLI", "TI": "TIRS"}
+
 
 def parse_landsat(gname):
     attrs = []
-    if len(gname.split('_')[0])>15:
-        attrs.append('Landsat {}'.format(int(gname[2])))
+    if len(gname.split("_")[0]) > 15:
+        attrs.append(f"Landsat {int(gname[2])}")
         attrs.append(lsat_sensor[gname[1]])
         attrs.append(None)
         attrs.append(None)
@@ -22,66 +23,80 @@ def parse_landsat(gname):
         year = int(gname[9:13])
         doy = int(gname[13:16])
         attrs.append(dt.datetime.fromordinal(dt.date(year - 1, 12, 31).toordinal() + doy))
-    elif re.match('L[COTEM][0-9]{2}', gname.split('_')[0]):
-        split_name = gname.split('_')
-        attrs.append('Landsat {}'.format(int(split_name[0][2:4])))
+    elif re.match("L[COTEM][0-9]{2}", gname.split("_")[0]):
+        split_name = gname.split("_")
+        attrs.append(f"Landsat {int(split_name[0][2:4])}")
         attrs.append(lsat_sensor[split_name[0][1]])
         attrs.append(None)
         attrs.append(None)
         attrs.append((int(split_name[2][0:3]), int(split_name[2][3:6])))
-        attrs.append(dt.datetime.strptime(split_name[3], '%Y%m%d'))
+        attrs.append(dt.datetime.strptime(split_name[3], "%Y%m%d"))
         attrs.append(attrs[3].date())
     return attrs
+
 
 def parse_metadata_from_fn(fname):
 
     bname = os.path.splitext(os.path.basename(fname))[0]
 
     # assumes that the filename has a form XX_YY.ext
-    if '_' in bname:
+    if "_" in bname:
 
-        spl = bname.split('_')
+        spl = bname.split("_")
 
         # attrs corresponds to: satellite, sensor, product, version, tile_name, datetime
-        if re.match('L[COTEM][0-9]{2}', spl[0]):
+        if re.match("L[COTEM][0-9]{2}", spl[0]):
             attrs = parse_landsat(bname)
-        elif spl[0][0] == 'L' and len(spl) == 1:
+        elif spl[0][0] == "L" and len(spl) == 1:
             attrs = parse_landsat(bname)
-        elif re.match('T[0-9]{2}[A-Z]{3}', spl[0]):
-            attrs = ('Sentinel-2', 'MSI', None, None, spl[0][1:], dt.datetime.strptime(spl[1], '%Y%m%dT%H%M%S'))
-        elif spl[0] == 'SETSM':
-            attrs = ('WorldView',spl[1], 'ArcticDEM/REMA', spl[7], None, dt.datetime.strptime(spl[2], '%Y%m%d'))
-        elif spl[0] == 'SPOT':
-            attrs = ('HFS', 'SPOT5', None, None, None, dt.datetime.strptime(spl[2], '%Y%m%d'))
-        elif spl[0] == 'IODEM3':
-            attrs = ('IceBridge', 'DMS', 'IODEM3', None, None, dt.datetime.strptime(spl[1] + spl[2], '%Y%m%d%H%M%S'))
-        elif spl[0] == 'ILAKS1B':
-            attrs = ('IceBridge', 'UAF-LS', 'ILAKS1B', None, None, dt.datetime.strptime(spl[1], '%Y%m%d'))
-        elif spl[0] == 'AST' and spl[1] == 'L1A':
+        elif re.match("T[0-9]{2}[A-Z]{3}", spl[0]):
+            attrs = ("Sentinel-2", "MSI", None, None, spl[0][1:], dt.datetime.strptime(spl[1], "%Y%m%dT%H%M%S"))
+        elif spl[0] == "SETSM":
+            attrs = ("WorldView", spl[1], "ArcticDEM/REMA", spl[7], None, dt.datetime.strptime(spl[2], "%Y%m%d"))
+        elif spl[0] == "SPOT":
+            attrs = ("HFS", "SPOT5", None, None, None, dt.datetime.strptime(spl[2], "%Y%m%d"))
+        elif spl[0] == "IODEM3":
+            attrs = ("IceBridge", "DMS", "IODEM3", None, None, dt.datetime.strptime(spl[1] + spl[2], "%Y%m%d%H%M%S"))
+        elif spl[0] == "ILAKS1B":
+            attrs = ("IceBridge", "UAF-LS", "ILAKS1B", None, None, dt.datetime.strptime(spl[1], "%Y%m%d"))
+        elif spl[0] == "AST" and spl[1] == "L1A":
             attrs = (
-            'Terra', 'ASTER', 'L1A', spl[2][2], None, dt.datetime.strptime(bname.split('_')[2][3:], '%m%d%Y%H%M%S'))
-        elif spl[0] == 'ASTGTM2':
-            attrs = ('Terra', 'ASTER', 'ASTGTM2', '2', spl[1], None)
-        elif spl[0] == 'NASADEM':
-            attrs = ('SRTM', 'SRTM', 'NASADEM-' + spl[1], '1', spl[2], dt.datetime(year=2000, month=2, day=15))
-        elif spl[0] == 'TDM1' and spl[1] == 'DEM':
-            attrs = ('TanDEM-X', 'TanDEM-X', 'TDM1', '1', spl[4], None)
-        elif spl[0] == 'srtm':
-            attrs = ('SRTM', 'SRTM', 'SRTMv4.1', None, '_'.join(spl[1:]), dt.datetime(year=2000, month=2, day=15))
+                "Terra",
+                "ASTER",
+                "L1A",
+                spl[2][2],
+                None,
+                dt.datetime.strptime(bname.split("_")[2][3:], "%m%d%Y%H%M%S"),
+            )
+        elif spl[0] == "ASTGTM2":
+            attrs = ("Terra", "ASTER", "ASTGTM2", "2", spl[1], None)
+        elif spl[0] == "NASADEM":
+            attrs = ("SRTM", "SRTM", "NASADEM-" + spl[1], "1", spl[2], dt.datetime(year=2000, month=2, day=15))
+        elif spl[0] == "TDM1" and spl[1] == "DEM":
+            attrs = ("TanDEM-X", "TanDEM-X", "TDM1", "1", spl[4], None)
+        elif spl[0] == "srtm":
+            attrs = ("SRTM", "SRTM", "SRTMv4.1", None, "_".join(spl[1:]), dt.datetime(year=2000, month=2, day=15))
         else:
-            attrs = (None,)*6
+            attrs = (None,) * 6
 
     # if the form is only XX.ext (only the first versions of SRTM had a naming that... bad (simplfied?))
-    elif os.path.splitext(os.path.basename(fname))[1] == '.hgt':
-        attrs = ('SRTM', 'SRTM', 'SRTMGL1', '3', os.path.splitext(os.path.basename(fname))[0],
-                 dt.datetime(year=2000, month=2, day=15))
+    elif os.path.splitext(os.path.basename(fname))[1] == ".hgt":
+        attrs = (
+            "SRTM",
+            "SRTM",
+            "SRTMGL1",
+            "3",
+            os.path.splitext(os.path.basename(fname))[0],
+            dt.datetime(year=2000, month=2, day=15),
+        )
 
     else:
-        attrs = (None,)*6
+        attrs = (None,) * 6
 
     return attrs
 
-def parse_tile_attr_from_name(tile_name,product=None):
+
+def parse_tile_attr_from_name(tile_name, product=None):
     """
     Convert tile naming to metadata coordinates based on sensor and product
     by default the SRTMGL1 1x1° tile naming convention to lat, lon (originally SRTMGL1)
@@ -94,31 +109,33 @@ def parse_tile_attr_from_name(tile_name,product=None):
     :returns: lat, lon of southwestern corner
     """
 
-    if product is None or product in ['ASTGTM2','SRTMGL1','NASADEM']:
+    if product is None or product in ["ASTGTM2", "SRTMGL1", "NASADEM"]:
         ymin, xmin = sw_naming_to_latlon(tile_name)
-        yx_sizes = (1,1)
+        yx_sizes = (1, 1)
         epsg = 4326
-    elif product in ['TDM1']:
+    elif product in ["TDM1"]:
         ymin, xmin = sw_naming_to_latlon(tile_name)
-        #TDX tiling
+        # TDX tiling
         if ymin >= 80 or ymin < -80:
-            yx_sizes = (1,4)
+            yx_sizes = (1, 4)
         elif ymin >= 60 or ymin < -60:
-            yx_sizes = (1,2)
+            yx_sizes = (1, 2)
         else:
-            yx_sizes = (1,1)
+            yx_sizes = (1, 1)
         epsg = 4326
     else:
-        raise ValueError('Tile naming '+tile_name+' not recognized for product '+str(product))
+        raise ValueError("Tile naming " + tile_name + " not recognized for product " + str(product))
 
     return ymin, xmin, yx_sizes, epsg
+
 
 def sw_naming_to_latlon(tile_name):
 
     """
     Get latitude and longitude corresponding to southwestern corner of tile naming (originally SRTMGL1 convention)
-    parsing is robust to lower/upper letters to formats with 2 or 3 digits for latitude (NXXWYYY for most existing products,
-    but for example it is NXXXWYYY for ALOS) and to reverted formats (WXXXNYY).
+
+    Parsing is robust to lower/upper letters to formats with 2 or 3 digits for latitude (NXXWYYY for
+    most existing products, but for example it is NXXXWYYY for ALOS) and to reverted formats (WXXXNYY).
 
     :param tile_name: name of tile
     :type tile_name: str
@@ -128,42 +145,43 @@ def sw_naming_to_latlon(tile_name):
     """
 
     tile_name = tile_name.upper()
-    if tile_name[0] in ['S','N']:
-        if 'W' in tile_name:
-            lon = -int(tile_name[1:].split('W')[1])
-            lat_unsigned = int(tile_name[1:].split('W')[0])
-        elif 'E' in tile_name:
-            lon = int(tile_name[1:].split('E')[1])
-            lat_unsigned = int(tile_name[1:].split('E')[0])
+    if tile_name[0] in ["S", "N"]:
+        if "W" in tile_name:
+            lon = -int(tile_name[1:].split("W")[1])
+            lat_unsigned = int(tile_name[1:].split("W")[0])
+        elif "E" in tile_name:
+            lon = int(tile_name[1:].split("E")[1])
+            lat_unsigned = int(tile_name[1:].split("E")[0])
         else:
-            raise ValueError('No west (W) or east (E) in the tile name')
+            raise ValueError("No west (W) or east (E) in the tile name")
 
-        if tile_name[0] == 'S':
+        if tile_name[0] == "S":
             lat = -lat_unsigned
         else:
             lat = lat_unsigned
 
-    elif tile_name[0] in ['W','E']:
-        if 'S' in tile_name:
-            lon_unsigned = int(tile_name[1:].split('S')[0])
-            lat = -int(tile_name[1:].split('S')[1])
-        elif 'N' in tile_name:
-            lon_unsigned = int(tile_name[1:].split('N')[0])
-            lat = int(tile_name[1:].split('N')[1])
+    elif tile_name[0] in ["W", "E"]:
+        if "S" in tile_name:
+            lon_unsigned = int(tile_name[1:].split("S")[0])
+            lat = -int(tile_name[1:].split("S")[1])
+        elif "N" in tile_name:
+            lon_unsigned = int(tile_name[1:].split("N")[0])
+            lat = int(tile_name[1:].split("N")[1])
         else:
-            raise ValueError('No south (S) or north (N) in the tile name')
+            raise ValueError("No south (S) or north (N) in the tile name")
 
-        if tile_name[0] == 'W':
+        if tile_name[0] == "W":
             lon = -lon_unsigned
         else:
             lon = lon_unsigned
 
     else:
-        raise ValueError('Tile not recognized: should start with south (S), north (N), east (E) or west(W)')
+        raise ValueError("Tile not recognized: should start with south (S), north (N), east (E) or west(W)")
 
     return lat, lon
 
-def latlon_to_sw_naming(latlon,latlon_sizes=((1,1),),lat_lims=((0,90.1),)):
+
+def latlon_to_sw_naming(latlon, latlon_sizes=((1, 1),), lat_lims=((0, 90.1),)):
     """
     Convert latitude and longitude to widely used southwestern corner tile naming (originally for SRTMGL1)
     Can account for varying tile sizes, and a dependency with the latitude (e.g., TDX global DEM)
@@ -184,38 +202,52 @@ def latlon_to_sw_naming(latlon,latlon_sizes=((1,1),),lat_lims=((0,90.1),)):
     lat = latlon[0]
     lat = ((lat + 90) % 180) - 90
 
-    if lat<0:
-        str_lat = 'S'
+    if lat < 0:
+        str_lat = "S"
     else:
-        str_lat = 'N'
+        str_lat = "N"
 
-    if lon<0:
-        str_lon = 'W'
+    if lon < 0:
+        str_lon = "W"
     else:
-        str_lon = 'E'
-
+        str_lon = "E"
 
     tile_name = None
     for latlim in lat_lims:
         if latlim[0] <= np.abs(lat) < latlim[1]:
             ind = lat_lims.index(latlim)
-            lat_corner = np.floor(lat/latlon_sizes[ind][0])*latlon_sizes[ind][0]
-            lon_corner = np.floor(lon/latlon_sizes[ind][1])*latlon_sizes[ind][1]
-            tile_name = str_lat+str(int(abs(lat_corner))).zfill(2)+str_lon+str(int(abs(lon_corner))).zfill(3)
+            lat_corner = np.floor(lat / latlon_sizes[ind][0]) * latlon_sizes[ind][0]
+            lon_corner = np.floor(lon / latlon_sizes[ind][1]) * latlon_sizes[ind][1]
+            tile_name = str_lat + str(int(abs(lat_corner))).zfill(2) + str_lon + str(int(abs(lon_corner))).zfill(3)
 
     if tile_name is None:
-        raise ValueError('Latitude intervals provided do not contain the lat/lon coordinates')
+        raise ValueError("Latitude intervals provided do not contain the lat/lon coordinates")
 
     return tile_name
 
 
-satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime']
+satimg_attrs = ["satellite", "sensor", "product", "version", "tile_name", "datetime"]
+
 
 class SatelliteImage(Raster):
-
-    def __init__(self, filename_or_dataset, attrs=None, load_data=True, bands=None,
-                 as_memfile=False, read_from_fn=True, datetime=None, tile_name=None, satellite=None, sensor=None, product=None,
-                 version=None, read_from_meta=True,fn_meta=None,silent=False):
+    def __init__(
+        self,
+        filename_or_dataset,
+        attrs=None,
+        load_data=True,
+        bands=None,
+        as_memfile=False,
+        read_from_fn=True,
+        datetime=None,
+        tile_name=None,
+        satellite=None,
+        sensor=None,
+        product=None,
+        version=None,
+        read_from_meta=True,
+        fn_meta=None,
+        silent=False,
+    ):
 
         """
         Load satellite data through the Raster class and parse additional attributes from filename or metadata.
@@ -257,7 +289,7 @@ class SatelliteImage(Raster):
         """
 
         # If SatelliteImage is passed, simply point back to SatelliteImage
-        if isinstance(filename_or_dataset,SatelliteImage):
+        if isinstance(filename_or_dataset, SatelliteImage):
             for key in filename_or_dataset.__dict__:
                 setattr(self, key, filename_or_dataset.__dict__[key])
             return
@@ -294,7 +326,7 @@ class SatelliteImage(Raster):
         else:
             self.date = None
 
-    def __parse_metadata_from_fn(self,silent=False):
+    def __parse_metadata_from_fn(self, silent=False):
 
         """
         Attempts to pull metadata (e.g., sensor, date information) from fname, setting sensor, satellite,
@@ -302,37 +334,42 @@ class SatelliteImage(Raster):
         """
 
         fname = self.filename
-        name_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime']
+        name_attrs = ["satellite", "sensor", "product", "version", "tile_name", "datetime"]
         attrs = parse_metadata_from_fn(fname)
 
-        if all([att is None for att in attrs]):
+        if all(att is None for att in attrs):
             if not silent:
                 print("No metadata could be read from filename.")
             return
 
         for n in name_attrs:
             a = self.__getattribute__(n)
-            a_fn =  attrs[name_attrs.index(n)]
+            a_fn = attrs[name_attrs.index(n)]
             if a is None and a_fn is not None:
                 if not silent:
-                    print('From filename: setting '+n+ ' as '+str(a_fn))
-                setattr(self,n,a_fn)
+                    print("From filename: setting " + n + " as " + str(a_fn))
+                setattr(self, n, a_fn)
             elif a is not None and attrs[name_attrs.index(n)] is not None:
                 if not silent:
-                    print('Leaving user input of '+str(a)+' for attribute '+n+' despite reading '+str(attrs[name_attrs.index(n)])+ 'from filename')
+                    print(
+                        "Leaving user input of "
+                        + str(a)
+                        + " for attribute "
+                        + n
+                        + " despite reading "
+                        + str(attrs[name_attrs.index(n)])
+                        + "from filename"
+                    )
 
-    def __parse_metadata_from_file(self,fn_meta):
+    def __parse_metadata_from_file(self, fn_meta):
         pass
 
-    def copy(self,new_array=None):
+    def copy(self, new_array=None):
 
         new_satimg = super().copy(new_array=new_array)
         # all objects here are immutable so no need for a copy method (string and datetime)
         # satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime'] #taken outside of class
         for attrs in satimg_attrs:
-            setattr(new_satimg,attrs,getattr(self,attrs))
+            setattr(new_satimg, attrs, getattr(self, attrs))
 
         return new_satimg
-
-
-

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -7,7 +7,7 @@ import datetime as dt
 import os
 import re
 import warnings
-from collections.abc import Iterable
+from collections import abc
 from typing import Any
 
 import numpy as np
@@ -184,8 +184,8 @@ def sw_naming_to_latlon(tile_name: str) -> tuple[float, float]:
 
 def latlon_to_sw_naming(
     latlon: tuple[float, float],
-    latlon_sizes: Iterable[tuple[float, float]] = ((1.0, 1.0),),
-    lat_lims: Iterable[tuple[float, float]] = ((0.0, 90.1),),
+    latlon_sizes: abc.Iterable[tuple[float, float]] = ((1.0, 1.0),),
+    lat_lims: abc.Iterable[tuple[float, float]] = ((0.0, 90.1),),
 ) -> str:
     """
     Convert latitude and longitude to widely used southwestern corner tile naming (originally for SRTMGL1)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-from setuptools import setup
-from os import path
 from glob import glob
+from os import path
 
-FULLVERSION = '0.0.1'
+from setuptools import setup
+
+FULLVERSION = "0.0.1"
 VERSION = FULLVERSION
 
 write_version = True
@@ -14,10 +15,9 @@ version = '%s'
 short_version = '%s'
 """
     if not filename:
-        filename = path.join(path.dirname(__file__), 'geoutils',
-                             'version.py')
+        filename = path.join(path.dirname(__file__), "geoutils", "version.py")
 
-    a = open(filename, 'w')
+    a = open(filename, "w")
     try:
         a.write(cnt % (FULLVERSION, VERSION))
     finally:
@@ -37,15 +37,17 @@ for item in glob("geoutils/datasets/*"):
         data_files.append(path.join("datasets", bname))
 
 
-setup(name='geoutils',
-      version=FULLVERSION,
-      description='Tools for working with geospatial data',
-      url='https://www.github.com/GlacioHack/geoutils/',
-      author='The GlacioHack Team',
-      license='BSD-3',
-      packages=['geoutils', 'geoutils.datasets'],
-      package_data={"geoutils": data_files},
-      install_requires=['rasterio', 'geopandas', 'pyproj','scipy'],
-      extras_require={'rioxarray': ['rioxarray']},
-      scripts=['geoutils/geoviewer.py'],
-      zip_safe=False)
+setup(
+    name="geoutils",
+    version=FULLVERSION,
+    description="Tools for working with geospatial data",
+    url="https://www.github.com/GlacioHack/geoutils/",
+    author="The GlacioHack Team",
+    license="BSD-3",
+    packages=["geoutils", "geoutils.datasets"],
+    package_data={"geoutils": data_files},
+    install_requires=["rasterio", "geopandas", "pyproj", "scipy"],
+    extras_require={"rioxarray": ["rioxarray"]},
+    scripts=["geoutils/geoviewer.py"],
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from glob import glob
 from os import path
+from typing import Optional
 
 from setuptools import setup
 
@@ -9,12 +10,12 @@ VERSION = FULLVERSION
 write_version = True
 
 
-def write_version_py(filename=None):
+def write_version_py(filename: Optional[str] = None) -> None:
     cnt = """\
 version = '%s'
 short_version = '%s'
 """
-    if not filename:
+    if filename is None:
         filename = path.join(path.dirname(__file__), "geoutils", "version.py")
 
     a = open(filename, "w")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -10,12 +10,12 @@ from geoutils import datasets
 
 
 @pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB"])
-def test_read_paths_raster(test_dataset):
+def test_read_paths_raster(test_dataset: str) -> None:
     assert isinstance(gu.Raster(datasets.get_path(test_dataset)), gu.Raster)
 
 
 @pytest.mark.parametrize("test_dataset", ["glacier_outlines"])
-def test_read_paths_vector(test_dataset):
+def test_read_paths_vector(test_dataset: str) -> None:
     assert isinstance(gu.Vector(datasets.get_path(test_dataset)), gu.Vector)
 
 
@@ -29,7 +29,7 @@ original_sha256 = {
 
 
 @pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB", "glacier_outlines"])
-def test_data_integrity(test_dataset):
+def test_data_integrity(test_dataset: str) -> None:
     """
     Test that input data is not corrupted by checking sha265 sum
     """

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,48 +1,40 @@
 """
 Test datasets
 """
-import pytest
 import hashlib
+
+import pytest
 
 import geoutils as gu
 from geoutils import datasets
 
 
-@pytest.mark.parametrize(
-    "test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB"]
-)
+@pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB"])
 def test_read_paths_raster(test_dataset):
     assert isinstance(gu.Raster(datasets.get_path(test_dataset)), gu.Raster)
 
 
-@pytest.mark.parametrize(
-    "test_dataset", ["glacier_outlines"]
-)
+@pytest.mark.parametrize("test_dataset", ["glacier_outlines"])
 def test_read_paths_vector(test_dataset):
     assert isinstance(gu.Vector(datasets.get_path(test_dataset)), gu.Vector)
 
 
 # Original sha256 obtained with `sha256sum filename`
 original_sha256 = {
-    "landsat_B4":
-        "271fa34e248f016f87109c8e81960caaa737558fbae110ec9e0d9e2d30d80c26",
-    "landsat_B4_crop":
-        "21b514a627571296eb26690b041f863b9fce4f98037c58a5f6f61deefd639541",
-    "landsat_RGB":
-        "7d0505a8610fd7784cb71c03e5b242715cd1574e978c2c86553d60fd82372c30",
-    "glacier_outlines": "d1a5bcd4bd4731a24c2398c016a6f5a8064160fedd5bab10609adacda9ba41ef"
+    "landsat_B4": "271fa34e248f016f87109c8e81960caaa737558fbae110ec9e0d9e2d30d80c26",
+    "landsat_B4_crop": "21b514a627571296eb26690b041f863b9fce4f98037c58a5f6f61deefd639541",
+    "landsat_RGB": "7d0505a8610fd7784cb71c03e5b242715cd1574e978c2c86553d60fd82372c30",
+    "glacier_outlines": "d1a5bcd4bd4731a24c2398c016a6f5a8064160fedd5bab10609adacda9ba41ef",
 }
 
 
-@pytest.mark.parametrize(
-    "test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB", "glacier_outlines"]
-)
+@pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB", "glacier_outlines"])
 def test_data_integrity(test_dataset):
     """
     Test that input data is not corrupted by checking sha265 sum
     """
     # Read file as bytes
-    fbytes = open(datasets.get_path(test_dataset), 'rb').read()
+    fbytes = open(datasets.get_path(test_dataset), "rb").read()
 
     # Get sha256
     file_sha256 = hashlib.sha256(fbytes).hexdigest()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -9,12 +9,12 @@ import geoutils as gu
 from geoutils import datasets
 
 
-@pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB"])
+@pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB"])  # type: ignore
 def test_read_paths_raster(test_dataset: str) -> None:
     assert isinstance(gu.Raster(datasets.get_path(test_dataset)), gu.Raster)
 
 
-@pytest.mark.parametrize("test_dataset", ["glacier_outlines"])
+@pytest.mark.parametrize("test_dataset", ["glacier_outlines"])  # type: ignore
 def test_read_paths_vector(test_dataset: str) -> None:
     assert isinstance(gu.Vector(datasets.get_path(test_dataset)), gu.Vector)
 
@@ -28,7 +28,9 @@ original_sha256 = {
 }
 
 
-@pytest.mark.parametrize("test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB", "glacier_outlines"])
+@pytest.mark.parametrize(
+    "test_dataset", ["landsat_B4", "landsat_B4_crop", "landsat_RGB", "glacier_outlines"]
+)  # type: ignore
 def test_data_integrity(test_dataset: str) -> None:
     """
     Test that input data is not corrupted by checking sha265 sum

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import sys
-import warnings
 
 from sphinx.cmd.build import main
 
@@ -10,7 +9,7 @@ from sphinx.cmd.build import main
 class TestDocs:
     docs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../", "doc/")
 
-    def test_example_code(self):
+    def test_example_code(self) -> None:
         """Try running each python script in the docs/source/code\
                 directory and check that it doesn't raise an error."""
         current_dir = os.getcwd()
@@ -28,7 +27,7 @@ class TestDocs:
 
         os.chdir(current_dir)
 
-    def test_build(self):
+    def test_build(self) -> None:
         """Try building the docs and see if it works."""
 
         # Remove the build directory if it exists.
@@ -40,33 +39,5 @@ class TestDocs:
         env = os.environ.copy()
         env["SPHINXBUILD"] = f"{sys.executable} -m sphinx"
 
-        # Run the makefile
-        build_commands = ["make", "-C", self.docs_dir, "html"]
-        build_commands = [
-            sys.executable,
-            "-m",
-            "sphinx",
-            os.path.join(self.docs_dir, "source"),
-            os.path.join(self.docs_dir, "build"),
-        ]
+        # Run sphinx-buil
         main([os.path.join(self.docs_dir, "source"), os.path.join(self.docs_dir, "build")])
-        """
-        result = subprocess.run(
-            build_commands,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            env=env
-        )
-        """
-
-        """
-        # Raise an error if the string "error" is in the stderr.
-        if "error" in str(result.stderr).lower():
-            raise RuntimeError(result.stderr)
-
-        # If "error" is not in the stderr string but it exists, show it as a warning.
-        if len(result.stderr) > 0:
-            warnings.warn(result.stderr)
-        """

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import warnings
 
-from sphinx.cmd.build import main; 
+from sphinx.cmd.build import main
 
 
 class TestDocs:
@@ -42,7 +42,13 @@ class TestDocs:
 
         # Run the makefile
         build_commands = ["make", "-C", self.docs_dir, "html"]
-        build_commands = [sys.executable, "-m", "sphinx", os.path.join(self.docs_dir, "source"), os.path.join(self.docs_dir, "build")]
+        build_commands = [
+            sys.executable,
+            "-m",
+            "sphinx",
+            os.path.join(self.docs_dir, "source"),
+            os.path.join(self.docs_dir, "build"),
+        ]
         main([os.path.join(self.docs_dir, "source"), os.path.join(self.docs_dir, "build")])
         """
         result = subprocess.run(
@@ -64,4 +70,3 @@ class TestDocs:
         if len(result.stderr) > 0:
             warnings.warn(result.stderr)
         """
-

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -124,9 +124,9 @@ class TestRaster:
         assert r.shape == (r.height, r.width)
         assert r.count == 1
         assert r.nbands is None
-        assert r.dtypes == ["uint8"]
+        assert np.array_equal(r.dtypes, ["uint8"])
         assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
-        assert r.res == [30.0, 30.0]
+        assert np.array_equal(r.res, [30.0, 30.0])
         assert r.bounds == rio.coords.BoundingBox(left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0)
         assert r.crs == rio.crs.CRS.from_epsg(32645)
         assert not r.is_loaded
@@ -146,15 +146,15 @@ class TestRaster:
         # Test 4 - multiple bands, load all bands
         r = gr.Raster(datasets.get_path("landsat_RGB"), load_data=True)
         assert r.count == 3
-        assert r.indexes == [1, 2, 3]
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 3
-        assert r.bands == (1, 2, 3)
+        assert np.array_equal(r.bands, [1, 2, 3])
         assert r.data.shape == (r.count, r.height, r.width)
 
         # Test 5 - multiple bands, load one band only
         r = gr.Raster(datasets.get_path("landsat_RGB"), load_data=True, bands=1)
         assert r.count == 3
-        assert r.indexes == [1, 2, 3]
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 1
         assert r.bands == (1)
         assert r.data.shape == (r.nbands, r.height, r.width)
@@ -162,9 +162,9 @@ class TestRaster:
         # Test 6 - multiple bands, load a list of bands
         r = gr.Raster(datasets.get_path("landsat_RGB"), load_data=True, bands=[2, 3])
         assert r.count == 3
-        assert r.indexes == [1, 2, 3]
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 2
-        assert r.bands == (2, 3)
+        assert np.array_equal(r.bands, (2, 3))
         assert r.data.shape == (r.nbands, r.height, r.width)
 
     def test_downsampling(self) -> None:
@@ -208,23 +208,17 @@ class TestRaster:
         # Test negation
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert r3.dtypes == [
-            "uint8",
-        ]
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test addition
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert r3.dtypes == [
-            "uint8",
-        ]
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test subtraction
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert r3.dtypes == [
-            "uint8",
-        ]
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test with dtype Float32
         r1 = gr.Raster.from_array(
@@ -232,21 +226,15 @@ class TestRaster:
         )
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert r3.dtypes == [
-            "float32",
-        ]
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert r3.dtypes == [
-            "float32",
-        ]
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert r3.dtypes == [
-            "float32",
-        ]
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         # Check that errors are properly raised
         # different shapes
@@ -829,7 +817,7 @@ class TestRaster:
         assert img.data.shape[0] == 3
 
         # Extract only one band (then it will not return a list)
-        red2 = img.split_bands(copy=False, subset=0)
+        red2 = img.split_bands(copy=False, subset=0)[0]
 
         # Extract a subset with a list in a weird direction
         blue2, green2 = img.split_bands(copy=False, subset=[2, 1])

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -3,8 +3,8 @@ Test functions for georaster
 """
 import os
 import tempfile
-from tempfile import TemporaryFile
 import warnings
+from tempfile import TemporaryFile
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,8 +12,8 @@ import pytest
 import rasterio as rio
 from pylint import epylint
 
-import geoutils.georaster as gr
 import geoutils as gu
+import geoutils.georaster as gr
 import geoutils.projtools as pt
 from geoutils import datasets
 
@@ -21,7 +21,6 @@ DO_PLOT = False
 
 
 class TestRaster:
-
     def test_init(self):
         """
         Test that all possible inputs work properly in Raster class init
@@ -42,17 +41,25 @@ class TestRaster:
         assert r3.filename is not None
 
         # finally, as memoryfile
-        memfile = rio.MemoryFile(open(datasets.get_path("landsat_B4"), 'rb'))
+        memfile = rio.MemoryFile(open(datasets.get_path("landsat_B4"), "rb"))
         r4 = gr.Raster(memfile)
         assert isinstance(r4, gr.Raster)
 
-        assert np.logical_and.reduce((np.array_equal(r.data, r2.data, equal_nan=True),
-                                      np.array_equal(r2.data, r3.data, equal_nan=True),
-                                      np.array_equal(r3.data, r4.data, equal_nan=True)))
+        assert np.logical_and.reduce(
+            (
+                np.array_equal(r.data, r2.data, equal_nan=True),
+                np.array_equal(r2.data, r3.data, equal_nan=True),
+                np.array_equal(r3.data, r4.data, equal_nan=True),
+            )
+        )
 
-        assert np.logical_and.reduce((np.all(r.data.mask == r2.data.mask),
-                                      np.all(r2.data.mask == r3.data.mask),
-                                      np.all(r3.data.mask == r4.data.mask)))
+        assert np.logical_and.reduce(
+            (
+                np.all(r.data.mask == r2.data.mask),
+                np.all(r2.data.mask == r3.data.mask),
+                np.all(r3.data.mask == r4.data.mask),
+            )
+        )
 
         # the data will not be copied, immutable objects will
         r.data[0, 0, 0] += 5
@@ -66,9 +73,22 @@ class TestRaster:
         r = gr.Raster(datasets.get_path("landsat_B4"))
 
         # Check all is good with passing attributes
-        default_attrs = ['bounds', 'count', 'crs', 'dataset_mask', 'driver',
-                         'dtypes', 'height', 'indexes', 'name',
-                         'nodata', 'res', 'shape', 'transform', 'width']
+        default_attrs = [
+            "bounds",
+            "count",
+            "crs",
+            "dataset_mask",
+            "driver",
+            "dtypes",
+            "height",
+            "indexes",
+            "name",
+            "nodata",
+            "res",
+            "shape",
+            "transform",
+            "width",
+        ]
         for attr in default_attrs:
             assert r.__getattribute__(attr) == r.ds.__getattribute__(attr)
 
@@ -90,8 +110,6 @@ class TestRaster:
                 continue
             assert line == new_stats.splitlines()[i]
 
-
-
     def test_loading(self):
         """
         Test that loading metadata and data works for all possible cases.
@@ -100,20 +118,16 @@ class TestRaster:
         r = gr.Raster(datasets.get_path("landsat_B4"), load_data=False)
 
         assert isinstance(r.ds, rio.DatasetReader)
-        assert r.driver == 'GTiff'
+        assert r.driver == "GTiff"
         assert r.width == 800
         assert r.height == 655
         assert r.shape == (r.height, r.width)
         assert r.count == 1
         assert r.nbands is None
-        assert r.dtypes == ('uint8',)
-        assert r.transform == rio.transform.Affine(
-            30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0
-        )
+        assert r.dtypes == ("uint8",)
+        assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
         assert r.res == (30.0, 30.0)
-        assert r.bounds == rio.coords.BoundingBox(
-            left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0
-        )
+        assert r.bounds == rio.coords.BoundingBox(left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0)
         assert r.crs == rio.crs.CRS.from_epsg(32645)
         assert not r.is_loaded
 
@@ -171,9 +185,9 @@ class TestRaster:
         # Upper left
         assert r.xy2ij(r.bounds.left, r.bounds.top) == (0, 0)
         # Upper right
-        assert r.xy2ij(r.bounds.right+r.res[0], r.bounds.top) == (0, r.width+1)
+        assert r.xy2ij(r.bounds.right + r.res[0], r.bounds.top) == (0, r.width + 1)
         # Bottom right
-        assert r.xy2ij(r.bounds.right+r.res[0], r.bounds.bottom) == (r.height, r.width+1)
+        assert r.xy2ij(r.bounds.right + r.res[0], r.bounds.bottom) == (r.height, r.width + 1)
         # One pixel right and down
         assert r.xy2ij(r.bounds.left + r.res[0], r.bounds.top - r.res[1]) == (1, 1)
 
@@ -184,58 +198,66 @@ class TestRaster:
         # Create fake rasters with random values in 0-255 and dtype uint8
         width = height = 5
         transform = rio.transform.from_bounds(0, 0, 1, 1, width, height)
-        r1 = gr.Raster.from_array(np.random.randint(0, 255, (height, width), dtype='uint8'),
-                                  transform=transform, crs=None)
-        r2 = gr.Raster.from_array(np.random.randint(0, 255, (height, width), dtype='uint8'),
-                                  transform=transform, crs=None)
+        r1 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height, width), dtype="uint8"), transform=transform, crs=None
+        )
+        r2 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height, width), dtype="uint8"), transform=transform, crs=None
+        )
 
         # Test negation
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert r3.dtypes == ('uint8',)
+        assert r3.dtypes == ("uint8",)
 
         # Test addition
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert r3.dtypes == ('uint8',)
+        assert r3.dtypes == ("uint8",)
 
         # Test subtraction
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert r3.dtypes == ('uint8',)
+        assert r3.dtypes == ("uint8",)
 
         # Test with dtype Float32
-        r1 = gr.Raster.from_array(np.random.randint(0, 255, (height, width)).astype('float32'),
-                                  transform=transform, crs=None)
+        r1 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height, width)).astype("float32"), transform=transform, crs=None
+        )
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert r3.dtypes == ('float32',)
+        assert r3.dtypes == ("float32",)
 
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert r3.dtypes == ('float32',)
+        assert r3.dtypes == ("float32",)
 
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert r3.dtypes == ('float32',)
+        assert r3.dtypes == ("float32",)
 
         # Check that errors are properly raised
         # different shapes
-        r1 = gr.Raster.from_array(np.random.randint(0, 255, (height + 1, width)).astype('float32'),
-                                  transform=transform, crs=None)
+        r1 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height + 1, width)).astype("float32"), transform=transform, crs=None
+        )
         pytest.raises(ValueError, r1.__add__, r2)
         pytest.raises(ValueError, r1.__sub__, r2)
 
         # different CRS
-        r1 = gr.Raster.from_array(np.random.randint(0, 255, (height, width)).astype('float32'),
-                                  transform=transform, crs=rio.crs.CRS.from_epsg(4326))
+        r1 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height, width)).astype("float32"),
+            transform=transform,
+            crs=rio.crs.CRS.from_epsg(4326),
+        )
         pytest.raises(ValueError, r1.__add__, r2)
         pytest.raises(ValueError, r1.__sub__, r2)
 
         # different transform
         transform2 = rio.transform.from_bounds(0, 0, 2, 2, width, height)
-        r1 = gr.Raster.from_array(np.random.randint(0, 255, (height, width)).astype('float32'),
-                                  transform=transform2, crs=None)
+        r1 = gr.Raster.from_array(
+            np.random.randint(0, 255, (height, width)).astype("float32"), transform=transform2, crs=None
+        )
         pytest.raises(ValueError, r1.__add__, r2)
         pytest.raises(ValueError, r1.__sub__, r2)
 
@@ -268,7 +290,7 @@ class TestRaster:
         # default_attrs = ['bounds', 'count', 'crs', 'dtypes', 'height', 'indexes','nodata',
         #                  'res', 'shape', 'transform', 'width']
         # using list directly available in Class
-        attrs = [at for at in r._get_rio_attrs() if at not in ['name', 'dataset_mask', 'driver']]
+        attrs = [at for at in r._get_rio_attrs() if at not in ["name", "dataset_mask", "driver"]]
         for attr in attrs:
             print(attr)
             assert r.__getattribute__(attr) == r2.__getattribute__(attr)
@@ -322,8 +344,7 @@ class TestRaster:
         b = r.bounds
         b2 = r2.bounds
 
-        b_minmax = (max(b[0], b2[0]), max(b[1], b2[1]),
-                    min(b[2], b2[2]), min(b[3], b2[3]))
+        b_minmax = (max(b[0], b2[0]), max(b[1], b2[1]), min(b[2], b2[2]), min(b[3], b2[3]))
 
         r_init = r.copy()
 
@@ -333,13 +354,13 @@ class TestRaster:
 
         if DO_PLOT:
             fig1, ax1 = plt.subplots()
-            r_init.show(ax=ax1, title='Raster 1')
+            r_init.show(ax=ax1, title="Raster 1")
 
             fig2, ax2 = plt.subplots()
-            r2.show(ax=ax2, title='Raster 2')
+            r2.show(ax=ax2, title="Raster 2")
 
             fig3, ax3 = plt.subplots()
-            r.show(ax=ax3, title='Raster 1 cropped to Raster 2')
+            r.show(ax=ax3, title="Raster 1 cropped to Raster 2")
             plt.show()
 
         assert b_minmax == b_crop
@@ -354,13 +375,13 @@ class TestRaster:
 
         if DO_PLOT:
             fig1, ax1 = plt.subplots()
-            r.show(ax=ax1, title='Raster 1')
+            r.show(ax=ax1, title="Raster 1")
 
             fig2, ax2 = plt.subplots()
-            r2.show(ax=ax2, title='Raster 2')
+            r2.show(ax=ax2, title="Raster 2")
 
             fig3, ax3 = plt.subplots()
-            r3.show(ax=ax3, title='Raster 1 reprojected to Raster 2')
+            r3.show(ax=ax3, title="Raster 1 reprojected to Raster 2")
 
             plt.show()
 
@@ -380,7 +401,7 @@ class TestRaster:
         assert r.nodata == r3.nodata
 
         # Test dst_size - this should modify the shape, and hence resolution, but not the bounds
-        out_size = (r.shape[1]//2, r.shape[0]//2)  # Outsize is (ncol, nrow)
+        out_size = (r.shape[1] // 2, r.shape[0] // 2)  # Outsize is (ncol, nrow)
         r3 = r.reproject(dst_size=out_size)
         assert r3.shape == (out_size[1], out_size[0])
         assert r3.bounds == r.bounds
@@ -389,7 +410,7 @@ class TestRaster:
         # if bounds is a multiple of res, outptut res should be preserved
         bounds = np.copy(r.bounds)
         dst_bounds = rio.coords.BoundingBox(
-            left=bounds[0], bottom=bounds[1] + r.res[0], right=bounds[2] - 2*r.res[1], top=bounds[3]
+            left=bounds[0], bottom=bounds[1] + r.res[0], right=bounds[2] - 2 * r.res[1], top=bounds[3]
         )
         r3 = r.reproject(dst_bounds=dst_bounds)
         assert r3.bounds == dst_bounds
@@ -398,7 +419,7 @@ class TestRaster:
         # Create bounds with 1/2 and 1/3 pixel extra on the right/bottom.
         bounds = np.copy(r.bounds)
         dst_bounds = rio.coords.BoundingBox(
-            left=bounds[0], bottom=bounds[1] - r.res[0]/3., right=bounds[2] + r.res[1]/2., top=bounds[3]
+            left=bounds[0], bottom=bounds[1] - r.res[0] / 3.0, right=bounds[2] + r.res[1] / 2.0, top=bounds[3]
         )
 
         # if bounds are not a multiple of res, the latter will be updated accordingly
@@ -433,31 +454,28 @@ class TestRaster:
         # FIRST, we try on a Raster with a Point interpretation in its "AREA_OR_POINT" metadata: values interpolated
         # at the center of pixel
         r = gr.Raster(datasets.get_path("landsat_B4"))
-        assert r.ds.tags()['AREA_OR_POINT'] == 'Point'
+        assert r.ds.tags()["AREA_OR_POINT"] == "Point"
 
         xmin, ymin, xmax, ymax = r.ds.bounds
 
         # We generate random points within the boundaries of the image
 
-
-        xrand = np.random.randint(low=0, high=r.ds.width, size=(10,)) \
-                * list(r.ds.transform)[0] + xmin
-        yrand = ymax + np.random.randint(low=0, high=r.ds.height, size=(10,)) \
-                 * list(r.ds.transform)[4]
+        xrand = np.random.randint(low=0, high=r.ds.width, size=(10,)) * list(r.ds.transform)[0] + xmin
+        yrand = ymax + np.random.randint(low=0, high=r.ds.height, size=(10,)) * list(r.ds.transform)[4]
         pts = list(zip(xrand, yrand))
         # Get decimal indexes based on Point GDAL METADATA
         # Those should all be .5 because values refer to the center
-        i, j = r.xy2ij(xrand, yrand,area_or_point=None)
+        i, j = r.xy2ij(xrand, yrand, area_or_point=None)
         assert np.all(i % 1 == 0.5)
         assert np.all(j % 1 == 0.5)
 
         # Force point
-        i, j = r.xy2ij(xrand, yrand,area_or_point='Point')
+        i, j = r.xy2ij(xrand, yrand, area_or_point="Point")
         assert np.all(i % 1 == 0.5)
         assert np.all(j % 1 == 0.5)
 
         # Force area
-        i, j = r.xy2ij(xrand, yrand,area_or_point='Area')
+        i, j = r.xy2ij(xrand, yrand, area_or_point="Area")
         assert np.all(i % 1 == 0)
         assert np.all(j % 1 == 0)
 
@@ -466,13 +484,19 @@ class TestRaster:
         img = r.data
         for k in range(len(xrand)):
             # 2x2 slices
-            z_ind = np.mean(img[0, slice(int(np.floor(i[k])),int(np.ceil(i[k]))+1), slice(int(np.floor(j[k])),int(np.ceil(j[k]))+1)])
+            z_ind = np.mean(
+                img[
+                    0,
+                    slice(int(np.floor(i[k])), int(np.ceil(i[k])) + 1),
+                    slice(int(np.floor(j[k])), int(np.ceil(j[k])) + 1),
+                ]
+            )
             list_z_ind.append(z_ind)
 
         # order 1 interpolation
-        rpts = r.interp_points(pts,order=1,area_or_point='Area')
+        rpts = r.interp_points(pts, order=1, area_or_point="Area")
         # the values interpolated should be equal
-        assert np.array_equal(np.array(list_z_ind,dtype=np.float32),rpts,equal_nan=True)
+        assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
         # Test there is no failure with random coordinates (edge effects, etc)
         xrand = np.random.uniform(low=xmin, high=xmax, size=(1000,))
@@ -484,19 +508,17 @@ class TestRaster:
         # pixel indexes
         r2 = gr.Raster(datasets.get_path("landsat_B4_crop"))
         r.crop(r2)
-        assert r.ds.tags()['AREA_OR_POINT'] == 'Area'
+        assert r.ds.tags()["AREA_OR_POINT"] == "Area"
 
         xmin, ymin, xmax, ymax = r.bounds
 
         # We can test with several method for the exact indexes: interp, value_at_coords, and simple read should
         # give back the same values that fall right on the coordinates
-        xrand = np.random.randint(low=0, high=r.ds.width, size=(10,)) \
-                 * list(r.ds.transform)[0] + xmin
-        yrand = ymax + np.random.randint(low=0, high=r.ds.height, size=(10,)) \
-                 * list(r.ds.transform)[4]
+        xrand = np.random.randint(low=0, high=r.ds.width, size=(10,)) * list(r.ds.transform)[0] + xmin
+        yrand = ymax + np.random.randint(low=0, high=r.ds.height, size=(10,)) * list(r.ds.transform)[4]
         pts = list(zip(xrand, yrand))
         # by default, i and j are returned as integers
-        i, j = r.xy2ij(xrand, yrand,op=np.float32,area_or_point='Area')
+        i, j = r.xy2ij(xrand, yrand, op=np.float32, area_or_point="Area")
         list_z_ind = []
         img = r.data
         for k in range(len(xrand)):
@@ -505,18 +527,17 @@ class TestRaster:
             # we can also compare with the value_at_coords() functionality
             list_z_ind.append(z_ind)
 
-
-        rpts = r.interp_points(pts,order=1)
+        rpts = r.interp_points(pts, order=1)
 
         assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
         # test for an invidiual point (shape can be tricky at 1 dimension)
         x = 493120.0
         y = 3101000.0
-        i, j = r.xy2ij(x, y,area_or_point='Area')
-        assert img[0, int(i), int(j)] == r.interp_points([(x, y)],order=1)[0]
+        i, j = r.xy2ij(x, y, area_or_point="Area")
+        assert img[0, int(i), int(j)] == r.interp_points([(x, y)], order=1)[0]
 
-        #TODO: understand why there is this:
+        # TODO: understand why there is this:
         # r.ds.index(x, y)
         # Out[33]: (75, 301)
         # r.ds.index(x, y, op=np.float32)
@@ -529,17 +550,17 @@ class TestRaster:
         r.crop(r2)
 
         # random test point that raised an error
-        itest=118
-        jtest=516
-        xtest=499540
-        ytest=3099710
+        itest = 118
+        jtest = 516
+        xtest = 499540
+        ytest = 3099710
 
-        z = r.data[0,itest,jtest]
-        x_out, y_out = r.ij2xy(itest,jtest,offset='ul')
+        z = r.data[0, itest, jtest]
+        x_out, y_out = r.ij2xy(itest, jtest, offset="ul")
         assert x_out == xtest
         assert y_out == ytest
 
-        #TODO: this fails, don't know why
+        # TODO: this fails, don't know why
         # z_val = r.value_at_coords(xtest,ytest)
         # assert z == z_val
 
@@ -562,11 +583,11 @@ class TestRaster:
         if DO_PLOT:
             plt.figure(figsize=(12, 6))
             plt.subplot(121)
-            plt.imshow(ndv_index[0], interpolation='nearest')
-            plt.title('Mask 1')
+            plt.imshow(ndv_index[0], interpolation="nearest")
+            plt.title("Mask 1")
             plt.subplot(122)
-            plt.imshow(ndv_index_2[0], interpolation='nearest')
-            plt.title('Mask 2 (should be identical)')
+            plt.imshow(ndv_index_2[0], interpolation="nearest")
+            plt.title("Mask 2 (should be identical)")
             plt.show()
 
         # Check both masks are identical
@@ -614,8 +635,7 @@ class TestRaster:
 
         # Test plotting single band B/W, add_cb
         ax = plt.subplot(111)
-        img_RGB.show(band=0, cmap='gray', ax=ax, add_cb=False,
-                     title="Plotting one band B/W")
+        img_RGB.show(band=0, cmap="gray", ax=ax, add_cb=False, title="Plotting one band B/W")
         if DO_PLOT:
             plt.show()
         else:
@@ -624,8 +644,7 @@ class TestRaster:
 
         # Test vmin, vmax and cb_title
         ax = plt.subplot(111)
-        img.show(cmap='gray', vmin=40, vmax=220, cb_title='Custom cbar',
-                 ax=ax, title="Testing vmin, vmax and cb_title")
+        img.show(cmap="gray", vmin=40, vmax=220, cb_title="Custom cbar", ax=ax, title="Testing vmin, vmax and cb_title")
         if DO_PLOT:
             plt.show()
         else:
@@ -648,7 +667,7 @@ class TestRaster:
     def test_coords(self):
 
         img = gr.Raster(datasets.get_path("landsat_B4"))
-        xx, yy = img.coords(offset='corner')
+        xx, yy = img.coords(offset="corner")
         assert xx.min() == pytest.approx(img.bounds.left)
         assert xx.max() == pytest.approx(img.bounds.right - img.res[0])
         if img.res[1] > 0:
@@ -659,7 +678,7 @@ class TestRaster:
             assert yy.min() == pytest.approx(img.bounds.top)
             assert yy.max() == pytest.approx(img.bounds.bottom + img.res[1])
 
-        xx, yy = img.coords(offset='center')
+        xx, yy = img.coords(offset="center")
         hx = img.res[0] / 2
         hy = img.res[1] / 2
         assert xx.min() == pytest.approx(img.bounds.left + hx)
@@ -696,40 +715,25 @@ class TestRaster:
         img = gr.Raster(datasets.get_path("landsat_B4"))
 
         # Lower right pixel
-        x, y = [
-            img.bounds.right - img.res[0],
-            img.bounds.bottom + img.res[1]
-        ]
+        x, y = [img.bounds.right - img.res[0], img.bounds.bottom + img.res[1]]
         lat, lon = pt.reproject_to_latlon([x, y], img.crs)
-        assert img.value_at_coords(x, y) == \
-            img.value_at_coords(lon, lat, latlon=True) == \
-            img.data[0, -1, -1]
+        assert img.value_at_coords(x, y) == img.value_at_coords(lon, lat, latlon=True) == img.data[0, -1, -1]
 
         # One pixel above
-        x, y = [
-            img.bounds.right - img.res[0],
-            img.bounds.bottom + 2 * img.res[1]
-        ]
+        x, y = [img.bounds.right - img.res[0], img.bounds.bottom + 2 * img.res[1]]
         lat, lon = pt.reproject_to_latlon([x, y], img.crs)
-        assert img.value_at_coords(x, y) == \
-            img.value_at_coords(lon, lat, latlon=True) == \
-            img.data[0, -2, -1]
+        assert img.value_at_coords(x, y) == img.value_at_coords(lon, lat, latlon=True) == img.data[0, -2, -1]
 
         # One pixel left
-        x, y = [
-            img.bounds.right - 2 * img.res[0],
-            img.bounds.bottom + img.res[1]
-        ]
+        x, y = [img.bounds.right - 2 * img.res[0], img.bounds.bottom + img.res[1]]
         lat, lon = pt.reproject_to_latlon([x, y], img.crs)
-        assert img.value_at_coords(x, y) == \
-            img.value_at_coords(lon, lat, latlon=True) == \
-            img.data[0, -1, -2]
+        assert img.value_at_coords(x, y) == img.value_at_coords(lon, lat, latlon=True) == img.data[0, -1, -2]
 
     def test_from_array(self):
 
         # Test that from_array works if nothing is changed
         # -> most tests already performed in test_copy, no need for more
-        img = gr.Raster(datasets.get_path('landsat_B4'))
+        img = gr.Raster(datasets.get_path("landsat_B4"))
         out_img = gr.Raster.from_array(img.data, img.transform, img.crs, nodata=img.nodata)
         assert out_img == img
 
@@ -743,7 +747,7 @@ class TestRaster:
         assert out_img.nodata == 0
 
         # Test that data mask is taken into account
-        img.data.mask = np.zeros((img.shape), dtype='bool')
+        img.data.mask = np.zeros((img.shape), dtype="bool")
         img.data.mask[0, 0, 0] = True
         out_img = gr.Raster.from_array(img.data, img.transform, img.crs, nodata=0)
         assert out_img.data.mask[0, 0, 0]
@@ -760,15 +764,16 @@ class TestRaster:
         attributes = r._get_rio_attrs() + ["is_loaded", "filename", "nbands", "filename"]
 
         # Create some sample code that should be correct
-        sample_code = "\n".join([
-            "'''Sample code that should conform to pylint's standards.'''",  # Add docstring
-            "import geoutils as gu",  # Import geoutils
-            "raster = gu.Raster(gu.datasets.get_path('landsat_B4'))",  # Load a raster
-        ] + \
-            # The below statements should not raise a 'no-member' (E1101) error.
-            [f"{attribute.upper()} = raster.{attribute}" for attribute in attributes] + \
-            # Add a newline to the end.
-            [""]
+        sample_code = "\n".join(
+            [
+                "'''Sample code that should conform to pylint's standards.'''",  # Add docstring
+                "import geoutils as gu",  # Import geoutils
+                "raster = gu.Raster(gu.datasets.get_path('landsat_B4'))",  # Load a raster
+            ]
+            + [  # The below statements should not raise a 'no-member' (E1101) error.
+                f"{attribute.upper()} = raster.{attribute}" for attribute in attributes
+            ]
+            + [""]  # Add a newline to the end.
         )
 
         # Write the code to the temporary file
@@ -789,7 +794,7 @@ class TestRaster:
 
     def test_split_bands(self):
 
-        img = gr.Raster(datasets.get_path('landsat_RGB'))
+        img = gr.Raster(datasets.get_path("landsat_RGB"))
 
         red, green, blue = img.split_bands(copy=False)
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -41,5 +41,3 @@ class TestVector:
         assert bounds.bottom == self.glacier_outlines.ds.total_bounds[1]
         assert bounds.right == self.glacier_outlines.ds.total_bounds[2]
         assert bounds.top == self.glacier_outlines.ds.total_bounds[3]
-
-

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -6,13 +6,13 @@ GLACIER_OUTLINES_URL = "http://public.data.npolar.no/cryoclim/CryoClim_GAO_SJ_19
 class TestVector:
     glacier_outlines = gu.Vector(GLACIER_OUTLINES_URL)
 
-    def test_init(self):
+    def test_init(self) -> None:
 
         vector = gu.Vector(GLACIER_OUTLINES_URL)
 
         assert isinstance(vector, gu.Vector)
 
-    def test_copy(self):
+    def test_copy(self) -> None:
 
         vector2 = self.glacier_outlines.copy()
 
@@ -22,7 +22,7 @@ class TestVector:
 
         assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]
 
-    def test_query(self):
+    def test_query(self) -> None:
 
         vector2 = self.glacier_outlines.query("NAME == 'Ayerbreen'")
 
@@ -30,7 +30,7 @@ class TestVector:
 
         assert vector2.ds.shape[0] < self.glacier_outlines.ds.shape[0]
 
-    def test_bounds(self):
+    def test_bounds(self) -> None:
 
         bounds = self.glacier_outlines.bounds
 

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -8,13 +8,12 @@ import geoutils.projtools as pt
 
 
 class TestProjTools:
-
     def test_latlon_reproject(self):
         """
         Check that to and from latlon projections are self consistent within tolerated rounding errors
         """
 
-        img = gu.Raster(gu.datasets.get_path('landsat_B4'))
+        img = gu.Raster(gu.datasets.get_path("landsat_B4"))
 
         # Test on random points
         nsample = 100
@@ -31,8 +30,8 @@ class TestProjTools:
         """
         Check that merge_bounds and bounds2poly work as expected for all kinds of bounds objects.
         """
-        img1 = gu.Raster(gu.datasets.get_path('landsat_B4'))
-        img2 = gu.Raster(gu.datasets.get_path('landsat_B4_crop'))
+        img1 = gu.Raster(gu.datasets.get_path("landsat_B4"))
+        img2 = gu.Raster(gu.datasets.get_path("landsat_B4_crop"))
 
         # Check union (default) - with Raster objects
         out_bounds = pt.merge_bounds((img1, img2))
@@ -58,7 +57,7 @@ class TestProjTools:
 
         # Check with gpd.GeoDataFrame
         outlines = gu.Vector(gu.datasets.get_path("glacier_outlines"))
-        outlines = gu.Vector(outlines.ds.to_crs(img1.crs))   # reproject to img1's CRS
+        outlines = gu.Vector(outlines.ds.to_crs(img1.crs))  # reproject to img1's CRS
         out_bounds = pt.merge_bounds((img1, outlines.ds))
 
         assert out_bounds[0] == min(img1.bounds.left, outlines.ds.total_bounds[0])

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -8,7 +8,7 @@ import geoutils.projtools as pt
 
 
 class TestProjTools:
-    def test_latlon_reproject(self):
+    def test_latlon_reproject(self) -> None:
         """
         Check that to and from latlon projections are self consistent within tolerated rounding errors
         """
@@ -26,7 +26,7 @@ class TestProjTools:
         assert np.all(x == randx)
         assert np.all(y == randy)
 
-    def test_merge_bounds(self):
+    def test_merge_bounds(self) -> None:
         """
         Check that merge_bounds and bounds2poly work as expected for all kinds of bounds objects.
         """

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -2,12 +2,10 @@
 Test functions for SatelliteImage class
 """
 import datetime as dt
-import os
 import sys
 from io import StringIO
 
 import numpy as np
-import pytest
 import rasterio as rio
 
 import geoutils
@@ -19,7 +17,7 @@ DO_PLOT = False
 
 
 class TestSatelliteImage:
-    def test_init(self):
+    def test_init(self) -> None:
         """
         Test that inputs work properly in SatelliteImage class init
         """
@@ -48,7 +46,7 @@ class TestSatelliteImage:
             (np.all(img.data.mask == img2.data.mask), np.all(img2.data.mask == img3.data.mask))
         )
 
-    def test_silent(self):
+    def test_silent(self) -> None:
         """
         Test that the silent method does not return any output in console
         """
@@ -56,30 +54,30 @@ class TestSatelliteImage:
 
         # let's capture stdout
         # cf https://stackoverflow.com/questions/16571150/how-to-capture-stdout-output-from-a-python-function-call
-        class Capturing(list):
-            def __enter__(self):
+        class Capturing(list):  # type: ignore
+            def __enter__(self):  # type: ignore
                 self._stdout = sys.stdout
                 sys.stdout = self._stringio = StringIO()
                 return self
 
-            def __exit__(self, *args):
+            def __exit__(self, *args) -> None:  # type: ignore
                 self.extend(self._stringio.getvalue().splitlines())
                 del self._stringio  # free up some memory
                 sys.stdout = self._stdout
 
         with Capturing() as output1:
-            img = si.SatelliteImage(fn_img)
+            si.SatelliteImage(fn_img)
 
         # check the metadata reading outputs to console
         assert len(output1) > 0
 
         with Capturing() as output2:
-            img = si.SatelliteImage(fn_img, silent=True)
+            si.SatelliteImage(fn_img, silent=True)
 
         # check nothing outputs to console
         assert len(output2) == 0
 
-    def test_add_sub(self):
+    def test_add_sub(self) -> None:
         """
         Test that overloading of addition, subtraction and negation works for child classes as well.
         """
@@ -100,10 +98,10 @@ class TestSatelliteImage:
         sat_out = satimg1 + satimg2
         assert isinstance(sat_out, si.SatelliteImage)
 
-        sat_out = satimg1 - satimg2
+        sat_out = satimg1 - satimg2  # type: ignore
         assert isinstance(sat_out, si.SatelliteImage)
 
-    def test_copy(self):
+    def test_copy(self) -> None:
         """
         Test that the copy method works as expected for SatelliteImage. In particular
         when copying r to r2:
@@ -141,7 +139,7 @@ class TestSatelliteImage:
         r.data += 5
         assert not np.array_equal(r.data, r2.data, equal_nan=True)
 
-    def test_filename_parsing(self):
+    def test_filename_parsing(self) -> None:
 
         copied_names = [
             "TDM1_DEM__30_N00E104_DEM.tif",
@@ -179,7 +177,7 @@ class TestSatelliteImage:
             assert tiles[i] == attrs[4]
             assert datetimes[i] == attrs[5]
 
-    def test_sw_tile_naming_parsing(self):
+    def test_sw_tile_naming_parsing(self) -> None:
 
         # normal examples
         test_tiles = ["N14W065", "S14E065", "N014W065", "W065N014", "W065N14", "N00E000"]

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -1,24 +1,24 @@
 """
 Test functions for SatelliteImage class
 """
+import datetime as dt
 import os
 import sys
-import pytest
-import datetime as dt
+from io import StringIO
+
 import numpy as np
+import pytest
+import rasterio as rio
+
+import geoutils
 import geoutils.georaster as gr
 import geoutils.satimg as si
 from geoutils import datasets
-import geoutils
-from io import StringIO
-import numpy as np
-import rasterio as rio
 
 DO_PLOT = False
 
 
 class TestSatelliteImage:
-
     def test_init(self):
         """
         Test that inputs work properly in SatelliteImage class init
@@ -40,11 +40,13 @@ class TestSatelliteImage:
         img3 = si.SatelliteImage(r)
         assert isinstance(img3, si.SatelliteImage)
 
-        assert np.logical_and.reduce((np.array_equal(img.data, img2.data, equal_nan=True),
-                                      np.array_equal(img2.data, img3.data, equal_nan=True)))
+        assert np.logical_and.reduce(
+            (np.array_equal(img.data, img2.data, equal_nan=True), np.array_equal(img2.data, img3.data, equal_nan=True))
+        )
 
-        assert np.logical_and.reduce((np.all(img.data.mask == img2.data.mask),
-                                      np.all(img2.data.mask == img3.data.mask)))
+        assert np.logical_and.reduce(
+            (np.all(img.data.mask == img2.data.mask), np.all(img2.data.mask == img3.data.mask))
+        )
 
     def test_silent(self):
         """
@@ -79,15 +81,17 @@ class TestSatelliteImage:
 
     def test_add_sub(self):
         """
-        Test that overloading of addition, subtraction and negation works for child classes as well. 
+        Test that overloading of addition, subtraction and negation works for child classes as well.
         """
         # Create fake rasters with random values in 0-255 and dtype uint8
         width = height = 5
         transform = rio.transform.from_bounds(0, 0, 1, 1, width, height)
-        satimg1 = si.SatelliteImage.from_array(np.random.randint(0, 255, (height, width), dtype='uint8'),
-                                               transform=transform, crs=None)
-        satimg2 = si.SatelliteImage.from_array(np.random.randint(0, 255, (height, width), dtype='uint8'),
-                                               transform=transform, crs=None)
+        satimg1 = si.SatelliteImage.from_array(
+            np.random.randint(0, 255, (height, width), dtype="uint8"), transform=transform, crs=None
+        )
+        satimg2 = si.SatelliteImage.from_array(
+            np.random.randint(0, 255, (height, width), dtype="uint8"), transform=transform, crs=None
+        )
 
         # Check that output type is same - other tests are in test_georaster.py
         sat_out = -satimg1
@@ -122,7 +126,7 @@ class TestSatelliteImage:
         #                    'res', 'shape', 'transform', 'width']
         # satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime']
         # using list directly available in Class
-        attrs = [at for at in r._get_rio_attrs() if at not in ['name', 'dataset_mask', 'driver']]
+        attrs = [at for at in r._get_rio_attrs() if at not in ["name", "dataset_mask", "driver"]]
         all_attrs = attrs + si.satimg_attrs
         for attr in all_attrs:
             assert r.__getattribute__(attr) == r2.__getattribute__(attr)
@@ -139,28 +143,32 @@ class TestSatelliteImage:
 
     def test_filename_parsing(self):
 
-        copied_names = ['TDM1_DEM__30_N00E104_DEM.tif',
-                        'SETSM_WV02_20141026_1030010037D17F00_10300100380B4000_mosaic5_2m_v3.0_dem.tif',
-                        'AST_L1A_00303132015224418_final.tif',
-                        'ILAKS1B_20190928_271_Gilkey-DEM.tif',
-                        'srtm_06_01.tif',
-                        'ASTGTM2_N00E108_dem.tif',
-                        'N00E015.hgt',
-                        'NASADEM_HGT_n00e041.hgt']
+        copied_names = [
+            "TDM1_DEM__30_N00E104_DEM.tif",
+            "SETSM_WV02_20141026_1030010037D17F00_10300100380B4000_mosaic5_2m_v3.0_dem.tif",
+            "AST_L1A_00303132015224418_final.tif",
+            "ILAKS1B_20190928_271_Gilkey-DEM.tif",
+            "srtm_06_01.tif",
+            "ASTGTM2_N00E108_dem.tif",
+            "N00E015.hgt",
+            "NASADEM_HGT_n00e041.hgt",
+        ]
         # Corresponding data, filled manually
-        satellites = ['TanDEM-X', 'WorldView', 'Terra', 'IceBridge', 'SRTM',
-                      'Terra', 'SRTM', 'SRTM']
-        sensors = ['TanDEM-X', 'WV02', 'ASTER', 'UAF-LS', 'SRTM', 'ASTER',
-                   'SRTM', 'SRTM']
-        products = ['TDM1', 'ArcticDEM/REMA', 'L1A', 'ILAKS1B', 'SRTMv4.1',
-                    'ASTGTM2', 'SRTMGL1', 'NASADEM-HGT']
+        satellites = ["TanDEM-X", "WorldView", "Terra", "IceBridge", "SRTM", "Terra", "SRTM", "SRTM"]
+        sensors = ["TanDEM-X", "WV02", "ASTER", "UAF-LS", "SRTM", "ASTER", "SRTM", "SRTM"]
+        products = ["TDM1", "ArcticDEM/REMA", "L1A", "ILAKS1B", "SRTMv4.1", "ASTGTM2", "SRTMGL1", "NASADEM-HGT"]
         # we can skip the version, bit subjective...
-        tiles = ['N00E104', None, None, None, '06_01', 'N00E108', 'N00E015',
-                 'n00e041']
-        datetimes = [None, dt.datetime(year=2014, month=10, day=26), dt.datetime(year=2015, month=3, day=13, hour=22, minute=44, second=18),
-                     dt.datetime(year=2019, month=9, day=28), dt.datetime(year=2000, month=2,
-                                                                          day=15), None, dt.datetime(year=2000, month=2, day=15),
-                     dt.datetime(year=2000, month=2, day=15)]
+        tiles = ["N00E104", None, None, None, "06_01", "N00E108", "N00E015", "n00e041"]
+        datetimes = [
+            None,
+            dt.datetime(year=2014, month=10, day=26),
+            dt.datetime(year=2015, month=3, day=13, hour=22, minute=44, second=18),
+            dt.datetime(year=2019, month=9, day=28),
+            dt.datetime(year=2000, month=2, day=15),
+            None,
+            dt.datetime(year=2000, month=2, day=15),
+            dt.datetime(year=2000, month=2, day=15),
+        ]
 
         for names in copied_names:
             attrs = si.parse_metadata_from_fn(names)
@@ -174,7 +182,7 @@ class TestSatelliteImage:
     def test_sw_tile_naming_parsing(self):
 
         # normal examples
-        test_tiles = ['N14W065', 'S14E065', 'N014W065', 'W065N014', 'W065N14', 'N00E000']
+        test_tiles = ["N14W065", "S14E065", "N014W065", "W065N014", "W065N14", "N00E000"]
         test_latlon = [(14, -65), (-14, 65), (14, -65), (14, -65), (14, -65), (0, 0)]
 
         for tile in test_tiles:
@@ -185,11 +193,10 @@ class TestSatelliteImage:
             assert si.latlon_to_sw_naming(latlon) == test_tiles[test_latlon.index(latlon)]
 
         # check possible exceptions, rounded lat/lon belong to their southwest border
-        assert si.latlon_to_sw_naming((0, 0)) == 'N00E000'
+        assert si.latlon_to_sw_naming((0, 0)) == "N00E000"
         # those are the same point, should give same naming
-        assert si.latlon_to_sw_naming((-90, 0)) == 'S90E000'
-        assert si.latlon_to_sw_naming((90, 0)) == 'S90E000'
+        assert si.latlon_to_sw_naming((-90, 0)) == "S90E000"
+        assert si.latlon_to_sw_naming((90, 0)) == "S90E000"
         # same here
-        assert si.latlon_to_sw_naming((0, -180)) == 'N00W180'
-        assert si.latlon_to_sw_naming((0, 180)) == 'N00W180'
-
+        assert si.latlon_to_sw_naming((0, -180)) == "N00W180"
+        assert si.latlon_to_sw_naming((0, 180)) == "N00W180"


### PR DESCRIPTION
This was a big one!! Up until now, the code style in GeoUtils has been largely inconsistent, where each contributor has more or less had their own style. This PR brings an automatic check to validate the code using a bunch of tools, and a refactor of the entire code-base to adhere to these standards.

* The codebase now uses black and isort to format the code automatically
* An exception to black's strict rules is the 120 character limit instead of 88. This applies for all linters as well
* Incorrectly spelled words in comments and text are now shown as lints (valdate -> validate and so on)
* mypy is running in strict mode, with some exceptions. This means that all functions have to be type-annotated. I've needed to add the `# type: ignore` flag to some places where mypy doesn't understand the syntax (but it is still technically valid). In the future, we should try to avoid that flag, and could even add it as an anti-pattern (like e.g. pandas does). If mypy can't understand the syntax, it can most often be expressed in a more fool-proof way.
* Docstring type annotations are now flagged as erroneous, and the function/method definition type hints are suggested instead.
* An instruction of how to use these tools is added in `CONTRIBUTING.md`.

Tools that are used:
* `black`: Formats the code in a strict and systematic way
* `mypy`: Validates and enforces type hints
* `flake8`: Provides various lints
* `check-yaml`: Formats yaml files consistently
* `end-of-file-fixer`: Formats the end of files consistently
* `trailing-whitespace`:  Removes trailing whitespaces
* `codespell`: Fixes common spelling mistakes in documentation
* `absolufy-imports`: Convert relative imports to absolute (e.g. "from . import georaster" -> "from geoutils import georaster")
* `isort`: Sorts imports alphabetically and by origin (builtin, third party, local)
* `pyupgrade`: Automatically formats code to use the most modern syntax (set to fit 3.7+)
* Multiple rst lints
* `python-no-eval`: Avoid the use of `eval()` as it can execute arbitrary code.
* `relint`: Custom regex lints. Used currently to define docstring types as an anti-pattern.

Tools that could be added are docstring checks. I didn't bother to add missing docstrings (there are quite many) in this PR, but we should probably enforce them at some point.