### PR TITLE
Add numpy interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
         # Format the code aggressively using black
         - repo: https://github.com/psf/black
-          rev: 20.8b1
+          rev: 21.5b2
           hooks:
                   - id: black
                     args: [--line-length=120]
@@ -40,7 +40,6 @@ repos:
                   additional_dependencies:
                           - flake8-comprehensions==3.1.0
                           - flake8-bugbear==21.3.2
-                          - pandas-dev-flaker==0.2.0
                   files: ^(geoutils|tests)
         # Lint the code using mypy
         - repo: https://github.com/pre-commit/mirrors-mypy
@@ -69,7 +68,7 @@ repos:
 
         # Automatically upgrade syntax to a minimum version
         - repo: https://github.com/asottile/pyupgrade
-          rev: v2.18.3
+          rev: v2.19.1
           hooks:
                 - id: pyupgrade
                   args: [--py37-plus]
@@ -95,6 +94,6 @@ repos:
 
         # Add custom regex lints (see .relint.yml)
         - repo: https://github.com/codingjoe/relint
-          rev: 1.2.0
+          rev: 1.2.1
           hooks:
                 - id: relint

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -617,6 +617,13 @@ class Raster:
 
         return cp
 
+    @property
+    def __array_interface__(self) -> dict[str, Any]:
+        if self._data is None:
+            self.load()
+
+        return self._data.__array_interface__  # type: ignore
+
     def load(self, bands: int | list[int] | None = None, **kwargs: Any) -> None:
         r"""
         Load specific bands of the dataset, using rasterio.read().

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -50,7 +50,7 @@ class Vector:
         return str(self.ds.__repr__())
 
     def __str__(self) -> str:
-        """ Provide string of information about Raster. """
+        """Provide string of information about Raster."""
         return self.info()
 
     def info(self) -> str:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -877,7 +877,7 @@ class TestRaster:
         assert img3a == img3b
 
 
-@pytest.mark.parametrize("dtype", ["float32", "uint8", "int32"])
+@pytest.mark.parametrize("dtype", ["float32", "uint8", "int32"])  # type: ignore
 def test_numpy_functions(dtype: str) -> None:
     """Test how rasters can be used as/with numpy arrays."""
     warnings.simplefilter("error")

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -875,3 +875,39 @@ class TestRaster:
         img3a = img1.reproject(img2, resampling="q1")
         img3b = img1.reproject(img2, resampling=rio.warp.Resampling.q1)
         assert img3a == img3b
+
+
+@pytest.mark.parametrize("dtype", ["float32", "uint8", "int32"])
+def test_numpy_functions(dtype: str) -> None:
+    """Test how rasters can be used as/with numpy arrays."""
+    warnings.simplefilter("error")
+
+    # Create an array of unique values starting at 0 and ending at 24
+    array = np.arange(25, dtype=dtype).reshape((1, 5, 5))
+    # Create an associated dummy transform
+    transform = rio.transform.from_origin(0, 5, 1, 1)
+
+    # Create a raster from the array
+    raster = gu.Raster.from_array(array, transform=transform, crs=4326)
+
+    # Test some ufuncs
+    assert np.median(raster) == 12.0
+    assert np.mean(raster) == 12.0
+
+    # Check that rasters don't  become arrays when using simple arithmetic.
+    assert isinstance(raster + 1, gr.Raster)
+
+    # Test that array_equal works
+    assert np.array_equal(array, raster)
+
+    # Test the data setter method by creating a new array
+    raster.data = array + 2
+
+    # Check that the median updated accordingly.
+    assert np.median(raster) == 14.0
+
+    # Test
+    raster += array
+
+    assert isinstance(raster, gr.Raster)
+    assert np.median(raster) == 26.0


### PR DESCRIPTION
As was discussed https://github.com/GlacioHack/xdem/issues/145, allowing numpy functions directly on a raster object would be very nice to have (it would just point to self._data):

```python
mean = np.mean(raster)

raster += np.ones_like(raster)
```
This turned out to be a quite simple fix! numpy has the `__array_interface__` which is used for all of their functionalities. So I just added a property that first loads the data if needed and then provides the `__array_interface__` of `self._data`. As you can see in the tests, it seems to work quite well!