### PR TITLE
Add `Raster.to_points()` method

### DIFF
--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1823,7 +1823,7 @@ to be cleared due to the setting of GCPs."
         rows = (choice / self.width).astype(int)
 
         # Extract the coordinates of the pixels and filter by the chosen pixels.
-        x_coords, y_coords = [np.array(a) for a in self.ij2xy(rows, cols, offset="center")]
+        x_coords, y_coords = (np.array(a) for a in self.ij2xy(rows, cols, offset="center"))
 
         # If the Raster is loaded, pick from the data, otherwise use the disk-sample method from rasterio.
         if self.is_loaded:

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1832,6 +1832,9 @@ to be cleared due to the setting of GCPs."
         else:
             pixel_data = np.array(list(self.ds.sample(zip(x_coords, y_coords)))).T
 
+        if isinstance(pixel_data, np.ma.masked_array):
+            pixel_data = np.where(pixel_data.mask, np.nan, pixel_data.data)
+
         # Merge the coordinates and pixel data into a point cloud.
         points = np.vstack((x_coords.reshape(1, -1), y_coords.reshape(1, -1), pixel_data)).T
 

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -1776,14 +1776,14 @@ to be cleared due to the setting of GCPs."
     # Unfortunately, the Literal type doesn't work for py37, so a bool | None has to be used instead.
     # When py38 is the least supported version, this should be 'as_frame: Literal[True]`) -> pd.GeoDataFrame etc.
     @overload
-    def point_subset(self, subset: float | int, as_frame: bool) -> gpd.GeoDataFrame:
+    def to_points(self, subset: float | int, as_frame: bool) -> gpd.GeoDataFrame:
         ...
 
     @overload
-    def point_subset(self, subset: float | int, as_frame: None) -> np.ndarray:
+    def to_points(self, subset: float | int, as_frame: None) -> np.ndarray:
         ...
 
-    def point_subset(self, subset: float | int, as_frame: bool | None = None) -> np.ndarray:
+    def to_points(self, subset: float | int = 1, as_frame: bool | None = None) -> np.ndarray:
         """
         Subset a point cloud of the raster.
 
@@ -1823,8 +1823,7 @@ to be cleared due to the setting of GCPs."
         rows = (choice / self.width).astype(int)
 
         # Extract the coordinates of the pixels and filter by the chosen pixels.
-        x_coords, y_coords = self.coords(offset="center")
-        x_coords, y_coords = x_coords[rows, cols], y_coords[rows, cols]
+        x_coords, y_coords = [np.array(a) for a in self.ij2xy(rows, cols, offset="center")]
 
         # If the Raster is loaded, pick from the data, otherwise use the disk-sample method from rasterio.
         if self.is_loaded:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -887,6 +887,7 @@ class TestRaster:
         points = img1.point_subset(1)
 
         # Validate that 25 points were sampled (equating to img1.height * img1.width) with x, y, and band0 values.
+        assert isinstance(points, np.ndarray)
         assert points.shape == (25, 3)
         assert np.array_equal(np.asarray(points[:, 0]), np.tile(np.linspace(0.5, 4.5, 5), 5))
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -876,31 +876,31 @@ class TestRaster:
         img3b = img1.reproject(img2, resampling=rio.warp.Resampling.q1)
         assert img3a == img3b
 
-    def test_point_subset(self) -> None:
-        """Test the outputs of the point_subset method and that it doesn't load if not needed."""
+    def test_to_points(self) -> None:
+        """Test the outputs of the to_points method and that it doesn't load if not needed."""
         # Create a small raster to test point sampling on
         img1 = gu.Raster.from_array(
             np.arange(25, dtype="int32").reshape(5, 5), transform=rio.transform.from_origin(0, 5, 1, 1), crs=4326
         )
 
         # Sample the whole raster (fraction==1)
-        points = img1.point_subset(1)
+        points = img1.to_points(1)
 
         # Validate that 25 points were sampled (equating to img1.height * img1.width) with x, y, and band0 values.
         assert isinstance(points, np.ndarray)
         assert points.shape == (25, 3)
         assert np.array_equal(np.asarray(points[:, 0]), np.tile(np.linspace(0.5, 4.5, 5), 5))
 
-        assert img1.point_subset(0.2).shape == (5, 3)
+        assert img1.to_points(0.2).shape == (5, 3)
 
         img2 = gu.Raster(datasets.get_path("landsat_RGB"), load_data=False)
 
-        points = img2.point_subset(10)
+        points = img2.to_points(10)
 
         assert points.shape == (10, 5)
         assert not img2.is_loaded
 
-        points_frame = img2.point_subset(10, as_frame=True)
+        points_frame = img2.to_points(10, as_frame=True)
 
         assert np.array_equal(points_frame.columns, ["b1", "b2", "b3", "geometry"])
         assert points_frame.crs == img2.crs


### PR DESCRIPTION
This is one that I've been missing in many projects!

Many tools work with point clouds, and there's not been a great way to convert a `Raster` (or any other raster-type) into a point cloud. This is for example good for coregistration, as one might not want to load the entire raster.

## As a numpy array
A point cloud with x/y coordinate and all bands' values is returned.
```python
>>> img = gu.Raster(gu.datasets.get_path("landsat_rgb"))
>>> points = img.to_points(subset=10)
>>> points.shape  # It has the columns ["x", "y", "red", "green", "blue"]
(10, 5)
>>> points[0, :]
array([4.931650e+05, 3.106325e+06, 2.550000e+02, 2.550000e+02, 2.550000e+02])
``` 

## As a GeoDataFrame
A `GeoDataFrame` may be more convenient for some, allowing e.g. easier plotting, CRS conversions and much more.
```python
>>> points_frame = img.to_points(subset=3, as_frame=True)
>>> points_frame
      b1     b2     b3                        geometry
0  196.0  186.0  225.0  POINT (490855.000 3094145.000)
1  198.0  191.0  229.0  POINT (480505.000 3095075.000)
2  255.0  255.0  255.0  POINT (484525.000 3096245.000)
>>> points_frame.crs
<Projected CRS: EPSG:32645>
Name: WGS 84 / UTM zone 45N
Axis Info [cartesian]:
- [east]: Easting (metre)
- [north]: Northing (metre)
Area of Use:
- undefined
Coordinate Operation:
- name: UTM zone 45N
- method: Transverse Mercator
Datum: World Geodetic System 1984
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
```

This may be one large step toward https://github.com/GlacioHack/xdem/issues/134.