### PR TITLE
Allow `Literal` for python 3.7 and lower

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install development dependencies and package
       run: |
-        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest matplotlib pylint
+        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest matplotlib pylint typing-extensions
         pip install -e . --no-dependencies
 
     - name: Lint with flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ sphinx_autodoc_typehints
 matplotlib
 scipy
 pre-commit
+typing-extensions; python_version < '3.8'

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,7 @@ dependencies:
   - pyproj
   - rasterio
   - scipy
+  - pip
+  - pip:
+
+    - "typing-extensions; python_version < '3.8'"

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from collections import abc
 from numbers import Number
-from typing import IO, Any, Callable, TypeVar
+from typing import IO, Any, Callable, Literal, TypeVar
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -38,6 +38,8 @@ else:
     _has_rioxarray = True
 
 RasterType = TypeVar("RasterType", bound="Raster")
+
+TRUE = Literal[True]
 
 
 def _resampling_from_str(resampling: str) -> Resampling:

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -10,11 +10,6 @@ from collections import abc
 from numbers import Number
 from typing import IO, Any, Callable, TypeVar
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
-
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -35,6 +30,12 @@ from shapely.geometry.polygon import Polygon
 
 from geoutils.geovector import Vector
 
+# If python38 or above, Literal is builtin. Otherwise, use typing_extensions
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
 try:
     import rioxarray
 except ImportError:
@@ -44,7 +45,7 @@ else:
 
 RasterType = TypeVar("RasterType", bound="Raster")
 
-TRUE = Literal[True]
+TRUE = Literal[True]  # This should be removed soon; it is for testing the import
 
 
 def _resampling_from_str(resampling: str) -> Resampling:

--- a/geoutils/georaster.py
+++ b/geoutils/georaster.py
@@ -8,7 +8,12 @@ import os
 import warnings
 from collections import abc
 from numbers import Number
-from typing import IO, Any, Callable, Literal, TypeVar
+from typing import IO, Any, Callable, TypeVar
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 import matplotlib
 import matplotlib.pyplot as plt

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     license="BSD-3",
     packages=["geoutils", "geoutils.datasets"],
     package_data={"geoutils": data_files},
-    install_requires=["rasterio", "geopandas", "pyproj", "scipy"],
+    install_requires=["rasterio", "geopandas", "pyproj", "scipy", "typing-extensions; python_version < '3.8'"],
     extras_require={"rioxarray": ["rioxarray"]},
     scripts=["geoutils/geoviewer.py"],
     zip_safe=False,


### PR DESCRIPTION
Motivated in #217.

This is integral for #208  and #216  to work properly!

The solution is to install+import `typing-extensions` for python versions lower than 3.8. This is an official backport of the new typing functions, so it should work as well!