### PR TITLE
Resolve test warnings and make CI output cleaner

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,4 +50,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -rA
+        pytest -ra

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -297,7 +297,7 @@ class SatelliteImage(Raster):
         self.version = version
 
         # trying to get metadata from separate metadata file
-        if read_from_meta and self.filename is not None:
+        if read_from_meta and self.filename is not None and fn_meta is not None:
             self.__parse_metadata_from_file(fn_meta)
 
         # trying to get metadata from filename for the None attributes

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -378,6 +378,7 @@ class TestRaster:
         assert b_minmax == b_crop
 
     def test_reproj(self) -> None:
+        warnings.simplefilter("error")
 
         # Reference raster to be used
         r = gr.Raster(datasets.get_path("landsat_B4"))
@@ -385,6 +386,7 @@ class TestRaster:
 
         # A second raster with different bounds, shape and resolution
         r2 = gr.Raster(datasets.get_path("landsat_B4_crop"))
+        r2.set_ndv(0)
         r2 = r2.reproject(dst_res=20)
         assert r2.res == (20, 20)
 
@@ -858,6 +860,7 @@ class TestRaster:
 
     def test_resampling_str(self) -> None:
         """Test that resampling methods can be given as strings instead of rio enums."""
+        warnings.simplefilter("error")
         assert gr._resampling_from_str("nearest") == rio.warp.Resampling.nearest  # noqa
         assert gr._resampling_from_str("cubic_spline") == rio.warp.Resampling.cubic_spline  # noqa
 
@@ -870,6 +873,8 @@ class TestRaster:
 
         img1 = gr.Raster(datasets.get_path("landsat_B4"))
         img2 = gr.Raster(datasets.get_path("landsat_B4_crop"))
+        img1.set_ndv(0)
+        img2.set_ndv(0)
 
         # Resample the rasters using a new resampling method and see that the string and enum gives the same result.
         img3a = img1.reproject(img2, resampling="q1")


### PR DESCRIPTION
This PR includes three minor fixes:

- 8c124a6: When running CI, the output is currently littered with 49 PASSED lines (showing which ones that passed). This is quite unnecessary, as the only interesting information is if they failed or gave warnings! This commit removes the PASSED messages.
- bd73829: @rhugonnet your opinion might be valuable here. Currently, if a `SatelliteImage` is read from disk, `fn_meta` will be `None`, meaning it will try to run `SatelliteImage.__parse_metadata_from_file()`, triggering the "not implemented" warning. In this commit, I've added a check so that the function will not be run if `fn_meta` is None. This consequently removes a ton of test warnings.
- 78dfcd8: This heavily relates to #220. The nodata value has to be set, or else `Raster.reproject()` complains. I've now set nodatas so that this warning disappears.