### PR TITLE
Include Voronoi polygons and method to create non-overlapping buffers

### DIFF
--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -2,7 +2,7 @@
 GeoUtils is a python package of raster and vector tools.
 """
 
-from geoutils import datasets, georaster, geovector, satimg, projtools  # noqa
+from geoutils import datasets, georaster, geovector, projtools, satimg  # noqa
 from geoutils.georaster import Raster  # noqa
 from geoutils.geovector import Vector  # noqa
 from geoutils.satimg import SatelliteImage  # noqa

--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -2,7 +2,7 @@
 GeoUtils is a python package of raster and vector tools.
 """
 
-from geoutils import datasets, georaster, geovector, satimg  # noqa
+from geoutils import datasets, georaster, geovector, satimg, projtools  # noqa
 from geoutils.georaster import Raster  # noqa
 from geoutils.geovector import Vector  # noqa
 from geoutils.satimg import SatelliteImage  # noqa

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -413,9 +413,9 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
         return gu.Vector(merged_voronoi)
 
 
-############################################
-# Additional stand-alone utility functions #
-############################################
+# -----------------------------------------
+# Additional stand-alone utility functions
+# -----------------------------------------
 
 
 def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
@@ -449,7 +449,7 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
 
 def generate_voronoi_polygons(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """
-    Function to generate the Voronoi polygons (tessellation) from the vertices of all geometries in a GeoDataFrame.
+    Generate Voronoi polygons (tessellation) from the vertices of all geometries in a GeoDataFrame.
 
     Uses scipy.spatial.voronoi.
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -375,8 +375,9 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
         # Extract Voronoi polygons only within the buffer area
         voronoi_diff = voronoi_all.intersection(buffer.geometry[0])
 
-        # Join attributes of original geometries into the Voronoi polygons
-        voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff)
+        # Split all polygons, and join attributes of original geometries into the Voronoi polygons
+        # Splitting, i.e. explode, is needed when Voronoi generate MultiPolygons that may extend over several features.
+        voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff.explode())
         joined_voronoi = gpd.tools.sjoin(gdf, voronoi_gdf, how="right")
 
         # Plot results -> some polygons are duplicated
@@ -505,7 +506,7 @@ are filled with new polygons.
         tot_area = np.sum(gaps.area.values)
 
     if not tot_area == 0:
-        voronoi_all = gpd.GeoDataFrame(geometry=list(voronoi_crop.geometry) + list(gaps.geometry[0]))
+        voronoi_all = gpd.GeoDataFrame(geometry=list(voronoi_crop.geometry) + list(gaps.geometry))
         voronoi_all.crs = gdf.crs
         return voronoi_all
     else:

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -495,7 +495,13 @@ are filled with new polygons.
     gaps = bound_gdf.difference(voronoi_merged)
 
     # Merge cropped Voronoi with gaps, if not empty, otherwise return cropped Voronoi
-    if not np.sum(gaps.area.values) == 0:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "Geometry is in a geographic CRS. Results from 'area' are likely incorrect."
+        )
+        tot_area = np.sum(gaps.area.values)
+
+    if not tot_area == 0:
         voronoi_all = gpd.GeoDataFrame(geometry=list(voronoi_crop.geometry) + list(gaps.geometry[0]))
         voronoi_all.crs = gdf.crs
         return voronoi_all

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -335,6 +335,9 @@ of each geometry.
         The buffer is slightly inaccurate where two geometries touch, due to the nature of the Voronoi polygons,\
 hence one geometry "steps" slightly on the neighbor buffer in some cases.
 
+        Note: A similar functionality is provided by momepy (http://docs.momepy.org) and is probably more robust.
+        It could be implemented in GeoPandas in the future: https://github.com/geopandas/geopandas/issues/2015
+
         :examples:
         >>> outlines = gu.Vector(gu.datasets.get_path('glacier_outlines'))
         >>> outlines = gu.Vector(outlines.ds.to_crs('EPSG:32645'))

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -320,3 +320,35 @@ the provided raster file.
         new_vector = self.__new__(type(self))
         new_vector.__init__(self.ds.query(expression))
         return new_vector  # type: ignore
+
+
+############################################
+# Additional stand-alone utility functions #
+############################################
+
+def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
+    """
+    Function to extract the exterior vertices of all shapes within a gpd.GeoDataFrame.
+
+    :param gdf: The GeoDataFrame from which the vertices need to be extracted.
+
+    :returns: A list containing a list of (x, y) positions of the vertices. The length of the primary list is equal \ to the number of geometries inside gdf, and length of each sublist is the number of vertices in the geometry.
+    """
+    vertices = []
+    # Loop on all geometries within gdf
+    for geom in gdf.geometry:
+        # Extract geometry exterior(s)
+        if geom.geom_type == 'MultiPolygon':
+            exteriors = [p.exterior for p in geom]
+        elif geom.geom_type == 'Polygon':
+            exteriors = [geom.exterior,]
+        elif geom.geom_type == 'LineString':
+            exteriors = [geom,]
+        elif geom.geom_type == 'MultiLineString':
+            exteriors = geom
+        else:
+            raise NotImplementedError(f"Geometry type {geom.geom_type} not implemented.")
+
+        vertices.extend([list(ext.coords) for ext in exteriors])
+
+    return vertices

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -16,6 +16,7 @@ from rasterio.crs import CRS
 import shapely
 from shapely.geometry.polygon import Polygon
 from scipy.spatial import Voronoi
+import matplotlib.pyplot as plt
 
 import geoutils as gu
 
@@ -323,6 +324,88 @@ the provided raster file.
         new_vector = self.__new__(type(self))
         new_vector.__init__(self.ds.query(expression))
         return new_vector  # type: ignore
+
+    def buffer_without_overlap(self, buffer_size: int | float, plot: bool = False) -> np.ndarray:
+        """
+        Returns a Vector object containing self's geometries extended by a buffer, without overlapping each other.
+
+        The algorithm is based upon this tutorial: https://statnmap.com/2020-07-31-buffer-area-for-nearest-neighbour/.
+        The buffered polygons are created using Voronoi polygons in order to delineate the "area of influence" \
+of each geometry.
+        The buffer is slightly inaccurate where two geometries touch, due to the nature of the Voronoi polygons,\
+hence one geometry "steps" slightly on the neighbor buffer in some cases.
+
+        :examples:
+        >>> outlines = gu.Vector(gu.datasets.get_path('glacier_outlines'))
+        >>> outlines = gu.Vector(outlines.ds.to_crs('EPSG:32645'))
+        >>> buffer = outlines.buffer_without_overlap(500)
+        >>> ax = buffer.ds.plot()
+        >>> outlines.ds.plot(ax=ax, ec='k', fc='none')
+        >>> plt.show()
+
+        :param buffer_size: Buffer size in self's coordinate system units.
+        :param plot: Set to True to show intermediate plots, useful for understanding or debugging.
+
+        :returns: A Vector containing the buffered geometries.
+        """
+        # Dissolve all geometries into one
+        gdf = self.ds
+        merged = gdf.dissolve()
+
+        # Add buffer around geometries
+        merged_buffer = merged.buffer(buffer_size)
+
+        # Extract only the buffered area
+        buffer = merged_buffer.difference(merged)
+
+        # Crop Voronoi polygons to bound geometry and add missing polygons
+        bound_poly = gu.projtools.bounds2poly(gdf)
+        bound_poly = bound_poly.buffer(buffer_size)
+        voronoi_all = generate_voronoi_with_bounds(gdf, bound_poly)
+        if plot:
+            plt.figure(figsize=(16, 4))
+            ax1 = plt.subplot(141)
+            voronoi_all.plot(ax=ax1)
+            gdf.plot(fc='none', ec='k', ax=ax1)
+            ax1.set_title("Voronoi polygons, cropped")
+
+        # Extract Voronoi polygons only within the buffer area
+        voronoi_diff = voronoi_all.intersection(buffer.geometry[0])
+
+        # Join attributes of original geometries into the Voronoi polygons
+        voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff)
+        joined_voronoi = gpd.tools.sjoin(gdf, voronoi_gdf, how='right')
+
+        # Plot results -> some polygons are duplicated
+        if plot:
+            ax2 = plt.subplot(142, sharex=ax1, sharey=ax1)
+            joined_voronoi.plot(ax=ax2, column="index_left", alpha=0.5, ec='k')
+            gdf.plot(ax=ax2, column=gdf.index.values)
+            ax2.set_title("Buffer with duplicated polygons")
+
+        # Find non unique Voronoi polygons, and retain only first one
+        _, indexes = np.unique(joined_voronoi.index, return_index=True)
+        unique_voronoi = joined_voronoi.iloc[indexes]
+
+        # Plot results -> unique polygons only
+        if plot:
+            ax3 = plt.subplot(143, sharex=ax1, sharey=ax1)
+            unique_voronoi.plot(ax=ax3, column="index_left", alpha=0.5, ec='k')
+            gdf.plot(ax=ax3, column=gdf.index.values)
+            ax3.set_title("Buffer with unique polygons")
+
+        # Dissolve all polygons by original index
+        merged_voronoi = unique_voronoi.dissolve(by='index_left')
+
+        # Plot
+        if plot:
+            ax4 = plt.subplot(144, sharex=ax1, sharey=ax1)
+            gdf.plot(ax=ax4, column=gdf.index.values)
+            merged_voronoi.plot(column=merged_voronoi.index.values, ax=ax4, alpha=0.5)
+            ax4.set_title("Final buffer")
+            plt.show()
+
+        return gu.Vector(merged_voronoi)
 
 
 ############################################

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -334,6 +334,7 @@ the provided raster file.
 of each geometry.
         The buffer is slightly inaccurate where two geometries touch, due to the nature of the Voronoi polygons,\
 hence one geometry "steps" slightly on the neighbor buffer in some cases.
+        The algorithm may also yield unexpected results on very simple geometries.
 
         Note: A similar functionality is provided by momepy (http://docs.momepy.org) and is probably more robust.
         It could be implemented in GeoPandas in the future: https://github.com/geopandas/geopandas/issues/2015

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -9,14 +9,14 @@ from numbers import Number
 from typing import TypeVar
 
 import geopandas as gpd
+import matplotlib.pyplot as plt
 import numpy as np
 import rasterio as rio
+import shapely
 from rasterio import features, warp
 from rasterio.crs import CRS
-import shapely
-from shapely.geometry.polygon import Polygon
 from scipy.spatial import Voronoi
-import matplotlib.pyplot as plt
+from shapely.geometry.polygon import Polygon
 
 import geoutils as gu
 
@@ -369,7 +369,7 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
             plt.figure(figsize=(16, 4))
             ax1 = plt.subplot(141)
             voronoi_all.plot(ax=ax1)
-            gdf.plot(fc='none', ec='k', ax=ax1)
+            gdf.plot(fc="none", ec="k", ax=ax1)
             ax1.set_title("Voronoi polygons, cropped")
 
         # Extract Voronoi polygons only within the buffer area
@@ -377,12 +377,12 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
 
         # Join attributes of original geometries into the Voronoi polygons
         voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff)
-        joined_voronoi = gpd.tools.sjoin(gdf, voronoi_gdf, how='right')
+        joined_voronoi = gpd.tools.sjoin(gdf, voronoi_gdf, how="right")
 
         # Plot results -> some polygons are duplicated
         if plot:
             ax2 = plt.subplot(142, sharex=ax1, sharey=ax1)
-            joined_voronoi.plot(ax=ax2, column="index_left", alpha=0.5, ec='k')
+            joined_voronoi.plot(ax=ax2, column="index_left", alpha=0.5, ec="k")
             gdf.plot(ax=ax2, column=gdf.index.values)
             ax2.set_title("Buffer with duplicated polygons")
 
@@ -393,12 +393,12 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
         # Plot results -> unique polygons only
         if plot:
             ax3 = plt.subplot(143, sharex=ax1, sharey=ax1)
-            unique_voronoi.plot(ax=ax3, column="index_left", alpha=0.5, ec='k')
+            unique_voronoi.plot(ax=ax3, column="index_left", alpha=0.5, ec="k")
             gdf.plot(ax=ax3, column=gdf.index.values)
             ax3.set_title("Buffer with unique polygons")
 
         # Dissolve all polygons by original index
-        merged_voronoi = unique_voronoi.dissolve(by='index_left')
+        merged_voronoi = unique_voronoi.dissolve(by="index_left")
 
         # Plot
         if plot:
@@ -415,8 +415,9 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
 # Additional stand-alone utility functions #
 ############################################
 
+
 def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
-    """
+    r"""
     Function to extract the exterior vertices of all shapes within a gpd.GeoDataFrame.
 
     :param gdf: The GeoDataFrame from which the vertices need to be extracted.
@@ -427,13 +428,13 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
     # Loop on all geometries within gdf
     for geom in gdf.geometry:
         # Extract geometry exterior(s)
-        if geom.geom_type == 'MultiPolygon':
+        if geom.geom_type == "MultiPolygon":
             exteriors = [p.exterior for p in geom]
-        elif geom.geom_type == 'Polygon':
-            exteriors = [geom.exterior,]
-        elif geom.geom_type == 'LineString':
-            exteriors = [geom,]
-        elif geom.geom_type == 'MultiLineString':
+        elif geom.geom_type == "Polygon":
+            exteriors = [geom.exterior]
+        elif geom.geom_type == "LineString":
+            exteriors = [geom]
+        elif geom.geom_type == "MultiLineString":
             exteriors = geom
         else:
             raise NotImplementedError(f"Geometry type {geom.geom_type} not implemented.")
@@ -499,9 +500,7 @@ are filled with new polygons.
 
     # Merge cropped Voronoi with gaps, if not empty, otherwise return cropped Voronoi
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "Geometry is in a geographic CRS. Results from 'area' are likely incorrect."
-        )
+        warnings.filterwarnings("ignore", "Geometry is in a geographic CRS. Results from 'area' are likely incorrect.")
         tot_area = np.sum(gaps.area.values)
 
     if not tot_area == 0:

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -422,7 +422,8 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
 
     :param gdf: The GeoDataFrame from which the vertices need to be extracted.
 
-    :returns: A list containing a list of (x, y) positions of the vertices. The length of the primary list is equal \ to the number of geometries inside gdf, and length of each sublist is the number of vertices in the geometry.
+    :returns: A list containing a list of (x, y) positions of the vertices. The length of the primary list is equal \
+ to the number of geometries inside gdf, and length of each sublist is the number of vertices in the geometry.
     """
     vertices = []
     # Loop on all geometries within gdf
@@ -446,7 +447,7 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
 
 def generate_voronoi_polygons(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """
-    Function to generate the Voronoi polygons (tesselation) from the vertices of all geometries in a GeoDataFrame.
+    Function to generate the Voronoi polygons (tessellation) from the vertices of all geometries in a GeoDataFrame.
 
     Uses scipy.spatial.voronoi.
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -149,7 +149,7 @@ class TestSynthetic:
             eroded_diff = binary_erosion(diff.squeeze(), np.ones((abs(buffer) + 1, abs(buffer) + 1)))
             assert np.count_nonzero(eroded_diff) == 0
 
-    def test_extract_vertices(self):
+    def test_extract_vertices(self) -> None:
         """
         Test that extract_vertices works with simple geometries.
         """
@@ -175,10 +175,10 @@ class TestSynthetic:
         assert vertices[0] == [(10.0, 10.0), (11.0, 10.0), (11.0, 11.0)]
         assert vertices[1] == [(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)]
 
-    def test_generate_voronoi(self):
+    def test_generate_voronoi(self) -> None:
         """
         Check that geovector.generate_voronoi_polygons works on a simple Polygon.
-        Does not work with simple shapes as squares or triangles as teh diagram is infinite.
+        Does not work with simple shapes as squares or triangles as the diagram is infinite.
         For now, test on a set of two squares.
         """
         # Check with a multipolygon

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -2,10 +2,10 @@ import geopandas as gpd
 import numpy as np
 import pytest
 from scipy.ndimage.morphology import binary_erosion
-from shapely.geometry.polygon import Polygon
-from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import Polygon
 
 import geoutils as gu
 
@@ -185,8 +185,10 @@ class TestSynthetic:
         voronoi = gu.geovector.generate_voronoi_polygons(self.vector_multipoly.ds)
         assert len(voronoi) == 2
         vertices = gu.geovector.extract_vertices(voronoi)
-        assert vertices == [[(5.5, 10.5), (10.5, 10.5), (10.5, 5.5), (5.5, 10.5)],
-                            [(5.5, 10.5), (10.5, 5.5), (5.5, 5.5), (5.5, 10.5)]]
+        assert vertices == [
+            [(5.5, 10.5), (10.5, 10.5), (10.5, 5.5), (5.5, 10.5)],
+            [(5.5, 10.5), (10.5, 5.5), (5.5, 5.5), (5.5, 10.5)],
+        ]
 
         # Check that it fails with proper error for too simple geometries
         expected_message = "Invalid geometry, cannot generate finite Voronoi polygons"

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -218,7 +218,7 @@ class TestSynthetic:
         mask_nobuffer = two_squares.create_mask(xres=0.1, bounds=(0, 0, 21, 21))
         assert np.all(mask_nobuffer | mask_nonoverlap == mask_buffer)
 
-        # Check with buffers that overlap -> this case is actually not the expected result !
+        # Case 2 - Check with buffers that overlap -> this case is actually not the expected result !
         # -------------------------------
         buffer_size = 5
         buffer = two_squares.buffer_without_overlap(buffer_size)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -55,8 +55,8 @@ class TestVector:
 class TestSynthetic:
 
     # Create a synthetic vector file with a square of size 1, started at position (10, 10)
-    poly = Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])
-    gdf = gpd.GeoDataFrame({"geometry": [poly]}, crs="EPSG:4326")
+    poly1 = Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])
+    gdf = gpd.GeoDataFrame({"geometry": [poly1]}, crs="EPSG:4326")
     vector = gu.Vector(gdf)
 
     # Same with a square started at position (5, 5)
@@ -65,13 +65,13 @@ class TestSynthetic:
     vector2 = gu.Vector(gdf)
 
     # Create a multipolygon with both
-    multipoly = MultiPolygon([poly, poly2])
+    multipoly = MultiPolygon([poly1, poly2])
     gdf = gpd.GeoDataFrame({"geometry": [multipoly]}, crs="EPSG:4326")
     vector_multipoly = gu.Vector(gdf)
 
     # Create a synthetic vector file with a square of size 5, started at position (8, 8)
-    poly = Polygon([(8, 8), (13, 8), (13, 13), (8, 13)])
-    gdf = gpd.GeoDataFrame({"geometry": [poly]}, crs="EPSG:4326")
+    poly3 = Polygon([(8, 8), (13, 8), (13, 13), (8, 13)])
+    gdf = gpd.GeoDataFrame({"geometry": [poly3]}, crs="EPSG:4326")
     vector_5 = gu.Vector(gdf)
 
     # Create a synthetic LineString geometry
@@ -79,6 +79,7 @@ class TestSynthetic:
     gdf = gpd.GeoDataFrame({"geometry": [lines]}, crs="EPSG:4326")
     vector_lines = gu.Vector(gdf)
 
+    # Create a synthetic MultiLineString geometry
     multilines = MultiLineString([[(10, 10), (11, 10), (11, 11)], [(5, 5), (6, 5), (6, 6)]])
     gdf = gpd.GeoDataFrame({"geometry": [multilines]}, crs="EPSG:4326")
     vector_multilines = gu.Vector(gdf)
@@ -180,3 +181,67 @@ class TestSynthetic:
         expected_message = "Invalid geometry, cannot generate finite Voronoi polygons"
         with pytest.raises(ValueError, match=expected_message):
             voronoi = gu.geovector.generate_voronoi_polygons(self.vector.ds)
+
+    def test_buffer_without_overlap(self) -> None:
+        """
+        Check that non-overlapping buffer feature works. Does not work on simple geometries, so test on MultiPolygon.
+        Yet, very simple geometries yield unexpected results, as is the case for the second test case here.
+        """
+        # Case 1, test with two squares, in separate Polygons
+        two_squares = gu.Vector(gpd.GeoDataFrame(geometry=[self.poly1, self.poly2], crs="EPSG:4326"))
+
+        # Check with buffers that should not overlap
+        # ------------------------------------------
+        buffer_size = 2
+        buffer = two_squares.buffer_without_overlap(buffer_size)
+
+        # Output should be of same size as input and same geometry type
+        assert len(buffer.ds) == len(two_squares.ds)
+        assert np.all(buffer.ds.geometry.geom_type == two_squares.ds.geometry.geom_type)
+
+        # Extract individual geometries
+        polys = []
+        for geom in buffer.ds.geometry:
+            if geom.geom_type in ["MultiPolygon"]:
+                polys.extend(list(geom))
+            else:
+                polys.append(geom)
+
+        # Check they do not overlap
+        for i in range(len(polys)):
+            for j in range(i + 1, len(polys)):
+                assert not polys[i].intersects(polys[j])
+
+        # buffer should yield the same result as create_mask with buffer, minus the original mask
+        mask_nonoverlap = buffer.create_mask(xres=0.1, bounds=(0, 0, 21, 21))
+        mask_buffer = two_squares.create_mask(xres=0.1, bounds=(0, 0, 21, 21), buffer=buffer_size)
+        mask_nobuffer = two_squares.create_mask(xres=0.1, bounds=(0, 0, 21, 21))
+        assert np.all(mask_nobuffer | mask_nonoverlap == mask_buffer)
+
+        # Check with buffers that overlap -> this case is actually not the expected result !
+        # -------------------------------
+        buffer_size = 5
+        buffer = two_squares.buffer_without_overlap(buffer_size)
+
+        # Output should be of same size as input and same geometry type
+        assert len(buffer.ds) == len(two_squares.ds)
+        assert np.all(buffer.ds.geometry.geom_type == two_squares.ds.geometry.geom_type)
+
+        # Extract individual geometries
+        polys = []
+        for geom in buffer.ds.geometry:
+            if geom.geom_type in ["MultiPolygon"]:
+                polys.extend(list(geom))
+            else:
+                polys.append(geom)
+
+        # Check they do not overlap
+        for i in range(len(polys)):
+            for j in range(i + 1, len(polys)):
+                assert polys[i].intersection(polys[j]).area == 0
+
+        # buffer should yield the same result as create_mask with buffer, minus the original mask
+        mask_nonoverlap = buffer.create_mask(xres=0.1, bounds=(0, 0, 21, 21))
+        mask_buffer = two_squares.create_mask(xres=0.1, bounds=(0, 0, 21, 21), buffer=buffer_size)
+        mask_nobuffer = two_squares.create_mask(xres=0.1, bounds=(0, 0, 21, 21))
+        assert np.all(mask_nobuffer | mask_nonoverlap == mask_buffer)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -56,14 +56,7 @@ class TestSynthetic:
 
     # Create a synthetic vector file with a square of size 1, started at position (10, 10)
     poly = Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])
-    gdf = gpd.GeoDataFrame(
-        {
-            "geometry": [
-                poly,
-            ]
-        },
-        crs="EPSG:4326",
-    )
+    gdf = gpd.GeoDataFrame({"geometry": [poly]}, crs="EPSG:4326")
     vector = gu.Vector(gdf)
 
     # Same with a square started at position (5, 5)
@@ -78,14 +71,7 @@ class TestSynthetic:
 
     # Create a synthetic vector file with a square of size 5, started at position (8, 8)
     poly = Polygon([(8, 8), (13, 8), (13, 13), (8, 13)])
-    gdf = gpd.GeoDataFrame(
-        {
-            "geometry": [
-                poly,
-            ]
-        },
-        crs="EPSG:4326",
-    )
+    gdf = gpd.GeoDataFrame({"geometry": [poly]}, crs="EPSG:4326")
     vector_5 = gu.Vector(gdf)
 
     # Create a synthetic LineString geometry

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import numpy as np
+import pytest
 from scipy.ndimage.morphology import binary_erosion
 from shapely.geometry.polygon import Polygon
 from shapely.geometry.multipolygon import MultiPolygon
@@ -173,3 +174,21 @@ class TestSynthetic:
         assert len(vertices) == 2
         assert vertices[0] == [(10.0, 10.0), (11.0, 10.0), (11.0, 11.0)]
         assert vertices[1] == [(5.0, 5.0), (6.0, 5.0), (6.0, 6.0)]
+
+    def test_generate_voronoi(self):
+        """
+        Check that geovector.generate_voronoi_polygons works on a simple Polygon.
+        Does not work with simple shapes as squares or triangles as teh diagram is infinite.
+        For now, test on a set of two squares.
+        """
+        # Check with a multipolygon
+        voronoi = gu.geovector.generate_voronoi_polygons(self.vector_multipoly.ds)
+        assert len(voronoi) == 2
+        vertices = gu.geovector.extract_vertices(voronoi)
+        assert vertices == [[(5.5, 10.5), (10.5, 10.5), (10.5, 5.5), (5.5, 10.5)],
+                            [(5.5, 10.5), (10.5, 5.5), (5.5, 5.5), (5.5, 10.5)]]
+
+        # Check that it fails with proper error for too simple geometries
+        expected_message = "Invalid geometry, cannot generate finite Voronoi polygons"
+        with pytest.raises(ValueError, match=expected_message):
+            voronoi = gu.geovector.generate_voronoi_polygons(self.vector.ds)


### PR DESCRIPTION
### Implemented

- simple function to extract vertices from a geopandas geodataframe (needed for the rest)
- function to create Voronoi polygons from a gpd.GeoDataFrame. These may spread a lot depending on the geometry.
- function to create Voronoi Polygons that are contained within a Polygon
- Vector method to create non-overlapping buffers around each geometries in self, using the previous functions

### Example

```
import geoutils as gu
import numpy as np
import matplotlib.pyplot as plt
outlines = gu.Vector(gu.datasets.get_path('glacier_outlines'))
outlines = gu.Vector(outlines.ds.to_crs('EPSG:32645'))
buffer = outlines.buffer_without_overlap(500)
ax = buffer.ds.plot()
outlines.ds.plot(ax=ax, ec='k', fc='none')
plt.show()
```
![Figure_2](https://user-images.githubusercontent.com/3285905/127353756-4b67dd84-1233-4d78-8b78-3d9c68a88bd9.png)

or with colors to see that the attributes are retained (although some colors are more or less duplicated)
```
ax = buffer.ds.plot(column="RGIId")
outlines.ds.plot(ax=ax, ec='k', column="RGIId", alpha=0.5)
plt.show()
```
![Figure_3](https://user-images.githubusercontent.com/3285905/127353772-4ecbe4d1-3cc0-45d9-991d-6afe411810a9.png)

```
buffer = outlines.buffer_without_overlap(500, plot=True)
```
nicely shows the individual steps to get to the result!

### Limitations 

This does not work so well with very simple geometries. Here two squares and a buffer of size 5 (case 2 of the tests).
![Figure_2](https://user-images.githubusercontent.com/3285905/127501439-7c3576f2-1963-4479-9b3f-3875d684989a.png)

To fix this, a better function to generate bounded Voronoi polygons is needed. See for example [here](https://stackoverflow.com/questions/28665491/getting-a-bounded-polygon-coordinates-from-voronoi-cells)?

### TODO
- possibly add overload so that the functions optionally take a Vector (and return a Vector in that case)