### PR TITLE
Correct the width/height calculation in geovector.rasterize

### DIFF
--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -258,8 +258,8 @@ the provided raster file.
 
             # Calculate raster shape
             left, bottom, right, top = bounds
-            height = abs((right - left) / xres)
-            width = abs((top - bottom) / yres)
+            width = abs((right - left) / xres)
+            height = abs((top - bottom) / yres)
 
             if width % 1 != 0 or height % 1 != 0:
                 warnings.warn("Bounds not a multiple of xres/yres, use rounded bounds")

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -51,6 +51,13 @@ class TestVector:
         assert bounds.right == self.glacier_outlines.ds.total_bounds[2]
         assert bounds.top == self.glacier_outlines.ds.total_bounds[3]
 
+    def test_rasterize(self) -> None:
+
+        burned = self.glacier_outlines.rasterize(xres=30)
+
+        assert burned.shape[0] > 0
+        assert burned.shape[1] > 0
+
 
 class TestSynthetic:
 


### PR DESCRIPTION
Resolves #199 . I don't currently have any good ideas for implementing a test for this, but I have nevertheless added a rasterize() test which does, at least, allow us to check that the basic function works correctly.