### PR TITLE
Fix several issues in spatial_tools.stack_rasters

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 rasterio
-geopandas
+geopandas >= 0.10.0
 pyproj
 flake8
 pytest

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3
-  - geopandas
+  - geopandas >= 0.10.0
   - matplotlib
   - pyproj
   - rasterio

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -391,7 +391,7 @@ hence one geometry "steps" slightly on the neighbor buffer in some cases.
 
         # Split all polygons, and join attributes of original geometries into the Voronoi polygons
         # Splitting, i.e. explode, is needed when Voronoi generate MultiPolygons that may extend over several features.
-        voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff.explode(index_parts=True))
+        voronoi_gdf = gpd.GeoDataFrame(geometry=voronoi_diff.explode(index_parts=True))  # requires geopandas>=0.10
         joined_voronoi = gpd.tools.sjoin(gdf, voronoi_gdf, how="right")
 
         # Plot results -> some polygons are duplicated

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -189,7 +189,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
     data = np.asarray(data)
 
     # Save as gu.Raster
-    r = reference_raster.from_array(
+    r = gu.Raster.from_array(
         data=data,
         transform=rio.transform.from_bounds(*dst_bounds, width=data[0].shape[1], height=data[0].shape[0]),
         crs=reference_raster.crs,

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -110,7 +110,7 @@ def stack_rasters(
     use_ref_bounds: bool = False,
     diff: bool = False,
     progress: bool = True,
-) -> RasterType:
+) -> gu.Raster:
     """
     Stack a list of rasters into a common grid as a 3D np array with nodata set to Nan.
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     package_data={"geoutils": data_files},
     install_requires=[
         "rasterio",
-        "geopandas",
+        "geopandas >= 0.10.0",
         "pyproj",
         "scipy",
         "typing-extensions; python_version < '3.8'",

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -4,6 +4,7 @@ Functions to test the spatial tools.
 from __future__ import annotations
 
 import warnings
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -31,7 +32,7 @@ class stack_merge_images:
     Param `cls` is used to set the type of the output, e.g. gu.Raster (default).
     """
 
-    def __init__(self, image: str, cls: RasterType = gu.Raster) -> None:
+    def __init__(self, image: str, cls: Callable[[str], RasterType] = gu.Raster) -> None:
         img = cls(datasets.get_path(image))
         self.img = img
 

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -11,6 +11,7 @@ import rasterio as rio
 
 import geoutils as gu
 from geoutils import datasets
+from geoutils.georaster import RasterType
 
 # def test_dem_subtraction():
 #     """Test that the DEM subtraction script gives reasonable numbers."""
@@ -27,10 +28,11 @@ class stack_merge_images:
     """
     Test cases for stacking and merging images
     Split an image with some overlap, then stack/merge it, and validate bounds and shape.
+    Param `cls` is used to set the type of the output, e.g. gu.Raster (default).
     """
 
-    def __init__(self, image: str) -> None:
-        img = gu.Raster(datasets.get_path(image))
+    def __init__(self, image: str, cls: RasterType = gu.Raster) -> None:
+        img = cls(datasets.get_path(image))
         self.img = img
 
         # Find the easting midpoint of the img
@@ -69,11 +71,18 @@ def images_1d():  # type: ignore
 
 
 @pytest.fixture
+def sat_images():  # type: ignore
+    return stack_merge_images("landsat_B4", cls=gu.SatelliteImage)
+
+
+@pytest.fixture
 def images_3d():  # type: ignore
     return stack_merge_images("landsat_RGB")
 
 
-@pytest.mark.parametrize("rasters", [pytest.lazy_fixture("images_1d")])  # type: ignore
+@pytest.mark.parametrize(
+    "rasters", [pytest.lazy_fixture("images_1d"), pytest.lazy_fixture("sat_images")]
+)  # type: ignore
 #    pytest.lazy_fixture('images_3d')]) ## Requires Raster.reproject() fix.
 def test_stack_rasters(rasters) -> None:  # type: ignore
     """Test stack_rasters"""
@@ -82,6 +91,7 @@ def test_stack_rasters(rasters) -> None:  # type: ignore
 
     assert stacked_img.count == 2
     assert rasters.img.shape == stacked_img.shape
+    assert type(stacked_img) == gu.Raster  # Check output object is always Raster, whatever input was given
 
     merged_bounds = gu.spatial_tools.merge_bounding_boxes(
         [rasters.img1.bounds, rasters.img2.bounds], resolution=rasters.img1.res[0]


### PR DESCRIPTION
**Issue 1:** stack_rasters was failing when providing an xdem.DEM instance as input, because the class does not allow multiband rasters
**Issue 2:** Progress bar was not displaying when intended, and also not propagated to merge_raster.

Reproducible example:
```
import xdem
import geoutils as gu
dem = xdem.DEM(gu.datasets.get_path("landsat_B4"))
raster = gu.Raster(gu.datasets.get_path("landsat_B4"))

# Progress bar not displaying (issue 2)
stacked_rasters = gu.spatial_tools.stack_rasters([raster, raster], progress=True)

# No progress bar option (issue 2)
merged_raster = gu.spatial_tools.merge_rasters([raster, raster])

# Error with DEM instance (issue 1)
# Fails with error "ValueError: DEM rasters should be composed of one band only"
stacked_rasters = gu.spatial_tools.stack_rasters([dem, dem])
```