### PR TITLE
Fix issue with merge_rasters creating NaNs

### DIFF
--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -187,6 +187,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
 
     # Convert to numpy array
     data = np.asarray(data)
+    data[np.isnan(data)] = reference_raster.nodata
 
     # Save as gu.Raster - needed as some child classes may not accept multiple bands
     r = gu.Raster.from_array(
@@ -266,6 +267,10 @@ If several algorithms are provided, each result is returned as a separate band.
             if "'axis' is an invalid keyword" not in str(exception):
                 raise exception
             merged_data.append(np.apply_along_axis(algo, axis=0, arr=raster_stack.data))
+
+    # Convert to masked array, and set all Nans to nodata
+    merged_data = np.ma.asarray(merged_data)
+    merged_data[np.isnan(merged_data)] = reference_raster.nodata
 
     # Save as gu.Raster
     merged_raster = reference_raster.from_array(

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -16,8 +16,8 @@ from tqdm import tqdm
 
 import geoutils as gu
 from geoutils.georaster import Raster, RasterType
-from geoutils.misc import resampling_method_from_str
 from geoutils.georaster.raster import _default_ndv
+from geoutils.misc import resampling_method_from_str
 
 
 def get_mask(array: np.ndarray | np.ma.masked_array) -> np.ndarray:

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -170,6 +170,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             dst_crs=reference_raster.crs,
             dtype=reference_raster.data.dtype,
             dst_nodata=reference_raster.nodata,
+            silent=True
         )
 
         # Optionally calculate difference

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -170,7 +170,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             dst_crs=reference_raster.crs,
             dtype=reference_raster.data.dtype,
             dst_nodata=reference_raster.nodata,
-            silent=True
+            silent=True,
         )
 
         # Optionally calculate difference

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -276,7 +276,11 @@ If several algorithms are provided, each result is returned as a separate band.
 
     # Convert to masked array, and set all Nans to nodata
     merged_data = np.ma.asarray(merged_data)
-    merged_data[np.isnan(merged_data)] = reference_raster.nodata
+    if reference_raster.nodata is not None:
+        nodata = reference_raster.nodata
+    else:
+        nodata = _default_ndv(merged_data.dtype)
+    merged_data[np.isnan(merged_data)] = nodata
 
     # Save as gu.Raster
     merged_raster = reference_raster.from_array(
@@ -285,7 +289,7 @@ If several algorithms are provided, each result is returned as a separate band.
             *raster_stack.bounds, width=merged_data[0].shape[1], height=merged_data[0].shape[0]
         ),
         crs=reference_raster.crs,
-        nodata=reference_raster.nodata,
+        nodata=nodata,
     )
 
     return merged_raster

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -187,7 +187,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
         if not raster.is_loaded:
             raster._data = None
 
-    # Convert to numpy array
+    # Convert to masked array
     data = np.ma.asarray(data)
     if reference_raster.nodata is not None:
         nodata = reference_raster.nodata

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -93,6 +93,7 @@ def test_stack_rasters(rasters) -> None:  # type: ignore
     assert stacked_img.count == 2
     assert rasters.img.shape == stacked_img.shape
     assert type(stacked_img) == gu.Raster  # Check output object is always Raster, whatever input was given
+    assert np.count_nonzero(np.isnan(stacked_img.data)) == 0  # Check no NaNs introduced
 
     merged_bounds = gu.spatial_tools.merge_bounding_boxes(
         [rasters.img1.bounds, rasters.img2.bounds], resolution=rasters.img1.res[0]
@@ -131,6 +132,7 @@ def test_merge_rasters(rasters) -> None:  # type: ignore
     merged_img = gu.spatial_tools.merge_rasters([rasters.img1, rasters.img2])
     assert rasters.img.data.shape == merged_img.data.shape
     assert rasters.img.bounds == merged_img.bounds
+    assert np.count_nonzero(np.isnan(merged_img.data)) == 0  # Check no NaNs introduced
 
     diff = rasters.img.data - merged_img.data
 


### PR DESCRIPTION
When calling `spatial_tools.stack_rasters` or `spatial_tools.merge_rasters`, masked values are converted to NaNs.
Change code so that outputs are properly masked.

**Reproducible example:**
```
import xdem
import geoutils as gu
import numpy as np

# Load some data and create masked raster
raster = gu.Raster(gu.datasets.get_path("landsat_B4"))
raster.set_ndv(255)
raster2 = raster.copy()
raster2.set_ndv(254)

# Check no NaNs are present
print(np.min([raster.data, raster2.data]))
# -> 13

# Stack and merge rasters
stacked_rasters = gu.spatial_tools.stack_rasters([raster, raster2], progress=True)
merged_raster = gu.spatial_tools.merge_rasters([raster, raster2])

# Outputs contain Nans
print(np.min(stacked_rasters.data))
print(np.min(merged_raster.data))
```

