### PR TITLE
Set default resampling to bilinear instead of nearest in reproject

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -996,7 +996,7 @@ Must be a Raster, np.ndarray or single number."
         dst_nodata: int | float | None = None,
         src_nodata: int | float | None = None,
         dtype: np.dtype | None = None,
-        resampling: Resampling | str = Resampling.nearest,
+        resampling: Resampling | str = Resampling.bilinear,
         silent: bool = False,
         n_threads: int = 0,
         memory_limit: int = 64,

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -502,7 +502,7 @@ class TestRaster:
         # Particularly crucial if nodata falls outside the original image range -> check range is preserved (with nearest interpolation)
         r_float = r.astype("float32")  # type: ignore
         assert r_float.nodata is None
-        r3 = r_float.reproject(dst_bounds=dst_bounds, resampling='nearest')
+        r3 = r_float.reproject(dst_bounds=dst_bounds, resampling="nearest")
         assert r3.nodata == -99999
         assert np.min(r3.data.data) == r3.nodata
         assert np.min(r3.data) == np.min(r_float.data)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -499,7 +499,8 @@ class TestRaster:
         assert r.nodata is None
         assert r3.nodata == 255
 
-        # Particularly crucial if nodata falls outside the original image range -> check range is preserved (with nearest interpolation)
+        # Particularly crucial if nodata falls outside the original image range
+        # -> check range is preserved (with nearest interpolation)
         r_float = r.astype("float32")  # type: ignore
         assert r_float.nodata is None
         r3 = r_float.reproject(dst_bounds=dst_bounds, resampling="nearest")

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -499,10 +499,10 @@ class TestRaster:
         assert r.nodata is None
         assert r3.nodata == 255
 
-        # Particularly crucial if nodata falls outside the original image range -> check range is preserved
+        # Particularly crucial if nodata falls outside the original image range -> check range is preserved (with nearest interpolation)
         r_float = r.astype("float32")  # type: ignore
         assert r_float.nodata is None
-        r3 = r_float.reproject(dst_bounds=dst_bounds)
+        r3 = r_float.reproject(dst_bounds=dst_bounds, resampling='nearest')
         assert r3.nodata == -99999
         assert np.min(r3.data.data) == r3.nodata
         assert np.min(r3.data) == np.min(r_float.data)


### PR DESCRIPTION
I think 'nearest' should not be the default resampling algorithm in reproject. For non integer warping, it will create artificial shifts between the two rasters. 
Bilinear is the safest option as it is relatively fast, preserves range and will have an effect even for subpixel shifts.
Any thought against that?