### PR TITLE
Clearly define default rio attributes

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -86,6 +86,24 @@ def _default_ndv(dtype: str | np.dtype | type) -> int:
         raise NotImplementedError(f"No default nodata value set for dtype {dtype}")
 
 
+# Set default attributes to be kept from rasterio's DatasetReader
+_default_rio_attrs = [
+    "bounds",
+    "count",
+    "crs",
+    "driver",
+    "dtypes",
+    "height",
+    "indexes",
+    "name",
+    "nodata",
+    "res",
+    "shape",
+    "transform",
+    "width",
+]
+
+
 def _load_rio(
     dataset: rio.io.DatasetReader,
     bands: int | list[int] | None = None,
@@ -164,8 +182,6 @@ class Raster:
 
         crs
 
-        dataset_mask
-
         driver
 
         dtypes
@@ -213,7 +229,8 @@ class Raster:
         :param nodata: nodata to be used (overwrites the metadata). Default is None, i.e. reads from metadata.
 
         :param attrs: Additional attributes from rasterio's DataReader class to add to the Raster object.
-            Default list is ['bounds', 'count', 'crs', 'dataset_mask', 'driver', 'dtypes', 'height', 'indexes',
+            Default list is set by geoutils.georaster.raster._default_rio_attrs, i.e.
+            ['bounds', 'count', 'crs', 'driver', 'dtypes', 'height', 'indexes',
             'name', 'nodata', 'res', 'shape', 'transform', 'width'] - if no attrs are specified, these will be added.
 
         :param as_memfile: open the dataset via a rio.MemoryFile.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from setuptools import setup
 
-FULLVERSION = "0.0.6"
+FULLVERSION = "0.0.7"
 VERSION = FULLVERSION
 
 write_version = True

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -20,7 +20,7 @@ import geoutils.geovector as gv
 import geoutils.misc
 import geoutils.projtools as pt
 from geoutils import datasets
-from geoutils.georaster.raster import _default_ndv
+from geoutils.georaster.raster import _default_ndv, _default_rio_attrs
 from geoutils.misc import resampling_method_from_str
 
 DO_PLOT = False
@@ -89,23 +89,8 @@ class TestRaster:
         r = gr.Raster(self.landsat_b4_path)
 
         # Check all is good with passing attributes
-        default_attrs = [
-            "bounds",
-            "count",
-            "crs",
-            "driver",
-            "dtypes",
-            "height",
-            "indexes",
-            "name",
-            "nodata",
-            "res",
-            "shape",
-            "transform",
-            "width",
-        ]
         with rio.open(self.landsat_b4_path) as dataset:
-            for attr in default_attrs:
+            for attr in _default_rio_attrs:
                 assert r.__getattribute__(attr) == dataset.__getattribute__(attr)
 
         # Check summary matches that of RIO
@@ -313,19 +298,10 @@ class TestRaster:
         assert r2.name != r.name
 
         # Check all attributes except name, driver and dataset_mask array
-        default_attrs = [
-            "bounds",
-            "count",
-            "crs",
-            "dtypes",
-            "height",
-            "indexes",
-            "nodata",
-            "res",
-            "shape",
-            "transform",
-            "width",
-        ]
+        default_attrs = _default_rio_attrs
+        for attr in ["name", "driver"]:
+            default_attrs.remove(attr)
+
         # using list directly available in Class
         attrs = default_attrs
         for attr in attrs:


### PR DESCRIPTION
The attributes inherited from rasterio's DatasetReader were not clearly defined, which makes it more difficult for tests, especially in child classes like in xdem.
Ideally, the docstring of the Raster class should be checked so that the list there matches the actual default list.