### PR TITLE
Add test coverage from Coveralls in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,12 +34,11 @@ jobs:
         mamba-version: "*"
         channels: conda-forge
         channel-priority: strict
-        environment-file: environment.yml
+        environment-file: dev-environment.yml
         activate-environment: geoutils
 
-    - name: Install development dependencies and package
+    - name: Install project
       run: |
-        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest pytest-xdist pytest-lazy-fixture matplotlib pylint typing-extensions sphinx-gallery scikit-image
         pip install -e . --no-dependencies
 
     - name: Lint with flake8

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install development dependencies and package
       run: |
-        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest pytest-lazy-fixture matplotlib pylint typing-extensions sphinx-gallery scikit-image
+        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest pytest-xdist pytest-lazy-fixture matplotlib pylint typing-extensions sphinx-gallery scikit-image
         pip install -e . --no-dependencies
 
     - name: Lint with flake8

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest-cov coveralls
-        pytest -ra -n=auto --cov=geoutils/
+        pytest -ra --cov=geoutils/
 
     - name: Converting coverage to LCOV format
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -75,4 +75,3 @@ jobs:
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true
-

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
     name: ${{ matrix.os }}, python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
 
@@ -50,4 +50,29 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -ra
+        pip install pytest-cov coveralls
+        pytest -ra -n=auto --cov=geoutils/
+
+    - name: Converting coverage to LCOV format
+      run: |
+        pip install coveragepy-lcov
+        coveragepy-lcov --data_file_path .coverage --output_file_path coverage.info
+
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.test_number }}
+        path-to-lcov: coverage.info
+        parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload to Coveralls finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Set of tools to handle raster and vector data sets in Python.
 [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/geoutils.svg)](https://anaconda.org/conda-forge/geoutils)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/geoutils.svg)](https://anaconda.org/conda-forge/geoutils)
 [![PyPI version](https://badge.fury.io/py/geoutils.svg)](https://badge.fury.io/py/geoutils)
+[![Coverage Status](https://coveralls.io/repos/github/GlacioHack/geoutils/badge.svg?branch=main)](https://coveralls.io/github/GlacioHack/geoutils?branch=main)
 
 This package offers Python classes and functions as well as command line tools to work with both geospatial raster and vector datasets. It is built upon rasterio and GeoPandas. In a single command it can import any geo-referenced dataset that is understood by these libraries, complete with all geo-referencing information, various helper functions and interface between vector/raster data.
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,0 +1,27 @@
+name: geoutils-dev
+channels:
+  - conda-forge
+dependencies:
+  - python >= 3.8
+  - geopandas >= 0.10.0
+  - matplotlib
+  - pyproj
+  - rasterio
+  - scipy
+  - pip
+  - tqdm
+
+  # Development-specific
+  - sphinx
+  - sphinx_rtd_theme
+  - sphinx-autodoc-typehints
+  - sphinxcontrib-programoutput
+  - numpydoc
+  - flake8
+  - pytest
+  - pytest-xdist
+  - pytest-lazy-fixture
+  - pylint
+  - typing-extensions
+  - sphinx-gallery
+  - scikit-image

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ geopandas >= 0.10.0
 pyproj
 flake8
 pytest
+pytest-xdist
 pytest-lazy-fixture
 sphinx
 sphinx_rtd_theme

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,3 @@ dependencies:
   - scipy
   - pip
   - tqdm
-  - pip:
-
-    - "typing-extensions; python_version < '3.8'"

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -62,9 +62,7 @@ def download_examples(overwrite: bool = False) -> None:
         for dir_name in ["Everest_Landsat", "Exploradores_ASTER"]:
             tmp_dir_name = os.path.join(
                 tmp_dir,
-                [dirname for dirname in os.listdir(tmp_dir) if os.path.isdir(os.path.join(tmp_dir, dirname))][
-                    0
-                ],
+                [dirname for dirname in os.listdir(tmp_dir) if os.path.isdir(os.path.join(tmp_dir, dirname))][0],
                 "data",
                 dir_name,
             )

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -43,34 +43,34 @@ def download_examples(overwrite: bool = False) -> None:
     url = f"https://github.com/GlacioHack/geoutils-data/tarball/main#commit={commit}"
 
     # Create a temporary directory to extract the tarball in.
-    temp_dir = tempfile.TemporaryDirectory()
-    tar_path = os.path.join(temp_dir.name, "data.tar.gz")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tar_path = os.path.join(tmp_dir.name, "data.tar.gz")
 
-    response = urllib.request.urlopen(url)
-    # If the response was right, download the tarball to the temporary directory
-    if response.getcode() == 200:
-        with open(tar_path, "wb") as outfile:
-            outfile.write(response.read())
-    else:
-        raise ValueError(f"Example data fetch gave non-200 response: {response.status_code}")
+        response = urllib.request.urlopen(url)
+        # If the response was right, download the tarball to the temporary directory
+        if response.getcode() == 200:
+            with open(tar_path, "wb") as outfile:
+                outfile.write(response.read())
+        else:
+            raise ValueError(f"Example data fetch gave non-200 response: {response.status_code}")
 
-    # Extract the tarball
-    with tarfile.open(tar_path) as tar:
-        tar.extractall(temp_dir.name)
+        # Extract the tarball
+        with tarfile.open(tar_path) as tar:
+            tar.extractall(tmp_dir.name)
 
-    # Find the first directory in the temp_dir (should only be one) and construct the example data dir paths.
-    for dir_name in ["Everest_Landsat", "Exploradores_ASTER"]:
-        tmp_dir_name = os.path.join(
-            temp_dir.name,
-            [dirname for dirname in os.listdir(temp_dir.name) if os.path.isdir(os.path.join(temp_dir.name, dirname))][
-                0
-            ],
-            "data",
-            dir_name,
-        )
+        # Find the first directory in the temp_dir (should only be one) and construct the example data dir paths.
+        for dir_name in ["Everest_Landsat", "Exploradores_ASTER"]:
+            tmp_dir_name = os.path.join(
+                tmp_dir.name,
+                [dirname for dirname in os.listdir(tmp_dir.name) if os.path.isdir(os.path.join(temp_dir.name, dirname))][
+                    0
+                ],
+                "data",
+                dir_name,
+            )
 
-        # Copy the temporary extracted data to the example directory.
-        copy_tree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
+            # Copy the temporary extracted data to the example directory.
+            copy_tree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
 
 
 def get_path(name: str) -> str:

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -44,7 +44,7 @@ def download_examples(overwrite: bool = False) -> None:
 
     # Create a temporary directory to extract the tarball in.
     with tempfile.TemporaryDirectory() as tmp_dir:
-        tar_path = os.path.join(tmp_dir.name, "data.tar.gz")
+        tar_path = os.path.join(tmp_dir, "data.tar.gz")
 
         response = urllib.request.urlopen(url)
         # If the response was right, download the tarball to the temporary directory
@@ -56,13 +56,13 @@ def download_examples(overwrite: bool = False) -> None:
 
         # Extract the tarball
         with tarfile.open(tar_path) as tar:
-            tar.extractall(tmp_dir.name)
+            tar.extractall(tmp_dir)
 
         # Find the first directory in the temp_dir (should only be one) and construct the example data dir paths.
         for dir_name in ["Everest_Landsat", "Exploradores_ASTER"]:
             tmp_dir_name = os.path.join(
-                tmp_dir.name,
-                [dirname for dirname in os.listdir(tmp_dir.name) if os.path.isdir(os.path.join(tmp_dir.name, dirname))][
+                tmp_dir,
+                [dirname for dirname in os.listdir(tmp_dir) if os.path.isdir(os.path.join(tmp_dir, dirname))][
                     0
                 ],
                 "data",

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -62,7 +62,7 @@ def download_examples(overwrite: bool = False) -> None:
         for dir_name in ["Everest_Landsat", "Exploradores_ASTER"]:
             tmp_dir_name = os.path.join(
                 tmp_dir.name,
-                [dirname for dirname in os.listdir(tmp_dir.name) if os.path.isdir(os.path.join(temp_dir.name, dirname))][
+                [dirname for dirname in os.listdir(tmp_dir.name) if os.path.isdir(os.path.join(tmp_dir.name, dirname))][
                     0
                 ],
                 "data",


### PR DESCRIPTION
This PR:

- Adds the workflow for Coveralls;
- Adds a `dev-environment.yml` file to facilitate the installation for developers and feed to CI, to have the exact same environment locally;
- Adds `pytest-xdist` in development dependencies to distribute `pytest` on several CPUs when possible;
- Changes the use of `TemporaryDirectory()` as a context manager in `examples.py` to avoid failures during CI tests.