### PR TITLE
Improve `data.setter` of `Raster` for consistent array output

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - geopandas >= 0.10.0
   - matplotlib
   - pyproj
-  - rasterio
+  - rasterio >= 1.3
   - scipy
   - pip
   - tqdm

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ geopandas >= 0.10.0
 pyproj
 flake8
 pytest
+pytest-xdist
 pytest-lazy-fixture
 sphinx
 sphinx_rtd_theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ sphinx_autodoc_typehints
 matplotlib
 scipy
 pre-commit
-typing-extensions; python_version < '3.8'
+typing-extensions
 sphinx-gallery
 scikit-image
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - geopandas >= 0.10.0
   - matplotlib
   - pyproj
-  - rasterio
+  - rasterio >= 1.3
   - scipy
   - pip
   - tqdm

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -825,7 +825,7 @@ Must be a Raster, np.ndarray or single number."
         if str(new_data.dtype) != dtype:
             raise ValueError(
                 "New data must be of the same type as existing\
- data: {}".format(
+ data: {}. Use copy() to set a new array with different dtype, or astype() to change type.".format(
                     dtype
                 )
             )

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -66,7 +66,7 @@ def _default_ndv(dtype: str | np.dtype | type) -> int:
         "int32": -99999,
         "float32": -99999,
         "float64": -99999,
-        "float128": -99999,
+        "longdouble": -99999,
     }
     # Check argument dtype is as expected
     if not isinstance(dtype, (str, np.dtype, type)):

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -836,9 +836,11 @@ Must be a Raster, np.ndarray or single number."
             )
 
         # If the new data is not masked and has non-finite values, we define a fill_value
-        if (not np.ma.is_masked(new_data) and self.nodata is None and np.count_nonzero(~np.isfinite(new_data)) > 0) \
-                or (np.ma.is_masked(new_data) and self.nodata is None and
-                    np.count_nonzero(~np.isfinite(new_data.data[~new_data.mask])) > 0):
+        if (not np.ma.is_masked(new_data) and self.nodata is None and np.count_nonzero(~np.isfinite(new_data)) > 0) or (
+            np.ma.is_masked(new_data)
+            and self.nodata is None
+            and np.count_nonzero(~np.isfinite(new_data.data[~new_data.mask])) > 0
+        ):
             self._nodata = _default_ndv(dtype)
 
         # If the new data is not masked (a classic ndarray) and contains non-finite values such as NaNs, define a mask
@@ -846,12 +848,11 @@ Must be a Raster, np.ndarray or single number."
             self._data = np.ma.masked_array(data=new_data, mask=~np.isfinite(new_data), fill_value=self.nodata)
         # If the new data is masked but some non-finite values aren't masked, add them to the mask
         elif np.ma.is_masked(new_data) and np.count_nonzero(~np.isfinite(new_data.data[~new_data.mask])) > 0:
-            self._data = np.ma.masked_array(data=new_data,
-                                            mask=np.logical_or(~np.isfinite(new_data.data), new_data.mask),
-                                            fill_value=self.nodata)
+            self._data = np.ma.masked_array(
+                data=new_data, mask=np.logical_or(~np.isfinite(new_data.data), new_data.mask), fill_value=self.nodata
+            )
         else:
             self._data = np.ma.masked_array(data=new_data, fill_value=self.nodata)
-
 
     def set_mask(self, mask: np.ndarray) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -259,9 +259,9 @@ class TestRaster:
 
         # Compare the consistency of the data setter whether it is passed a masked_array or an unmasked one
         assert np.array_equal(r1.data.data, arr)
-        assert r1.data.mask is False
+        assert not r1.data.mask
         assert np.array_equal(r2.data.data, arr)
-        assert r2.data.mask is False
+        assert not r2.data.mask
         assert np.array_equal(r3.data.data, arr)
         assert np.array_equal(r3.data.mask, mask)
 
@@ -281,9 +281,9 @@ class TestRaster:
 
         # Check the shape has been adjusted back to 3D
         assert np.array_equal(r1.data.data, arr)
-        assert r1.data.mask is False
+        assert not r1.data.mask
         assert np.array_equal(r2.data.data, arr)
-        assert r2.data.mask is False
+        assert not r2.data.mask
         assert np.array_equal(r3.data.data, arr)
         assert np.array_equal(r3.data.mask, mask)
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -215,9 +215,6 @@ class TestRaster:
         6. Raises an error if the new data does not have the dtype of the Raster.
         """
 
-        nodata_init = None
-        dtype = "float32"
-
         # Initiate a random array for testing
         width = height = 5
         transform = rio.transform.from_bounds(0, 0, 1, 1, width, height)
@@ -245,7 +242,7 @@ class TestRaster:
             arr += np.random.normal(size=(1, width, height))
 
         # Use either the default nodata or None
-        if nodata_init == "default":
+        if nodata_init == "type_default":
             nodata: int | None = _default_ndv(dtype)
         else:
             nodata = None

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -4,8 +4,8 @@ Test functions for georaster
 from __future__ import annotations
 
 import os
-import tempfile
 import re
+import tempfile
 import warnings
 from tempfile import NamedTemporaryFile, TemporaryFile
 
@@ -328,22 +328,29 @@ class TestRaster:
         # Check that setting data with a different data type results in an error
         rst = gr.Raster.from_array(data=arr, transform=transform, crs=None, nodata=nodata)
         if "int" in dtype:
-            new_dtype = 'float32'
+            new_dtype = "float32"
         else:
-            new_dtype = 'uint8'
+            new_dtype = "uint8"
 
-        with pytest.raises(ValueError,
-                           match=re.escape("New data must be of the same type as existing data: {}. Use copy() to set a new array "
-                                 "with different dtype, or astype() to change type.".format(dtype))):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "New data must be of the same type as existing data: {}. Use copy() to set a new array "
+                "with different dtype, or astype() to change type.".format(dtype)
+            ),
+        ):
             rst.data = rst.data.astype(new_dtype)
 
         # Check that setting data with a different shape results in an error
         new_shape = (1, 25)
-        with pytest.raises(ValueError,
-                           match=re.escape("New data must be of the same shape as existing data: ({}, {}). Given: "
-                                           "{}.".format(str(width), str(height), str(new_shape)))):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "New data must be of the same shape as existing data: ({}, {}). Given: "
+                "{}.".format(str(width), str(height), str(new_shape))
+            ),
+        ):
             rst.data = rst.data.reshape(new_shape)
-
 
     def test_downsampling(self) -> None:
         """
@@ -460,7 +467,7 @@ class TestRaster:
         2. If r.data is modified and r copied, the updated data is copied
         3. If r is copied, r.data changed, r2.data should be unchanged
         Then, we check the new_array argument of copy():
-        4. Check that ouput Rasters are equal whether the input array is a NaN np.ndarray or a masked_array
+        4. Check that output Rasters are equal whether the input array is a NaN np.ndarray or a masked_array
         5. Check that the new_array argument works when providing a different data type
         """
 
@@ -513,14 +520,13 @@ class TestRaster:
         assert r == r2
 
         # -- Fifth test: check that the new_array argument works when providing a new dtype ##
-        if "int" in  r.dtypes[0]:
-            new_dtype = 'float32'
+        if "int" in r.dtypes[0]:
+            new_dtype = "float32"
         else:
-            new_dtype = 'uint8'
+            new_dtype = "uint8"
         r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype))
 
         assert r2.dtypes[0] == new_dtype
-
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_is_modified(self, example: str) -> None:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -347,6 +347,24 @@ class TestRaster:
         r.data += 5
         assert not geoutils.misc.array_equal(r.data, r2.data, equal_nan=True)
 
+        # Check the new array parameter works with either ndarray filled with NaNs, or masked arrays
+
+        # First, we pass the new array as the masked array, mask and data of the new Raster object should be identical
+        r2 = r.copy(new_array=r.data)
+        assert np.array_equal(r.data.data, r2.data.data)
+        assert np.array_equal(r.data.mask, r2.data.mask)
+
+        # Same when passing the new array as a NaN ndarray
+        r_arr = gu.spatial_tools.get_array_and_mask(r)[0]
+        r2 = r.copy(new_array=r_arr)
+        assert np.array_equal(r.data.data, r2.data.data)
+        assert np.array_equal(r.data.mask, r2.data.mask)
+
+
+
+
+
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_is_modified(self, example: str) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -198,7 +198,7 @@ class TestRaster:
 
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
     @pytest.mark.parametrize(
-        "dtype", ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64", "float128"]
+        "dtype", ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64", "longdouble"]
     )  # type: ignore
     def test_data_setter(self, dtype: str, nodata_init: str | None) -> None:
         """
@@ -356,7 +356,7 @@ class TestRaster:
             ValueError,
             match=re.escape(
                 "New data must be of the same type as existing data: {}. Use copy() to set a new array "
-                "with different dtype, or astype() to change type.".format(dtype)
+                "with different dtype, or astype() to change type.".format(str(np.dtype(dtype)))
             ),
         ):
             rst.data = rst.data.astype(new_dtype)
@@ -1122,7 +1122,7 @@ This may have unexpected consequences. Consider setting a different nodata with 
         assert _default_ndv("uint16") == np.iinfo("uint16").max
         assert _default_ndv("int16") == np.iinfo("int16").min
         assert _default_ndv("uint32") == 99999
-        for dtype in ["int32", "float32", "float64", "float128"]:
+        for dtype in ["int32", "float32", "float64", "longdouble"]:
             assert _default_ndv(dtype) == -99999
 
         # Check it works with most frequent np.dtypes too

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import geopandas as gpd
 import numpy as np
 import pytest
-from scipy.ndimage.morphology import binary_erosion
+from scipy.ndimage import binary_erosion
 from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.geometry.multipolygon import MultiPolygon


### PR DESCRIPTION
This PR corrects the behaviour of `Raster.data.setter`, which is directly used by `Raster.__init__()` or `Raster.from_array()` to construct/update the `data` attribute. It also adds tests to ensure this behaviour will be constant.

**The previous behaviour was:**

1. A unmasked `np.ndarray` or a `np.ma.masked_array` can both be used to set a new `data`,
2. The shape was checked: if 2D broadcast to 3D, otherwise an error was raised,
3. The dtype was checked: if it didn't match the previous `dtype`, an error was raised.
4. The array was simply cast to a `np.ma.masked_array` with `fill_value` set from the `nodata`.

**The new behaviour modifies point 4. Now:**

- If the array is unmasked and has non-finite values, a mask of these non-finite values is created and passed to `np.ma.masked_array`. If the nodata was not defined to pass to fill_value, the default for the dtype is used.
- If the array is masked, but has non-finite values that are unmasked, the mask is extended to non-finite values. If the nodata was not defined to pass to fill_value, the default for the dtype is used.
- Otherwise, the array is cast normally to a np.ma.masked_array.

This behaviour directly affects: `__init__()`, `from_array()`, `copy()` and arithmetic operations that all use the `data.setter`.
**Points 1, 2 and 3 are now also thoroughly tested, in addition to point 1.**

For these reasons, this PR:

- Removes the setting of `nodata` within arithmetic functions, as this is now always done consistently by the `data.setter` after the `from_array` operation triggered by arithmetic operations,
- Inverts the lines in `__init__()` for setting `self.nodata` and `self.data` from a `dict` (passed by `from_array()`), putting the nodata first so it can be used by `self.data`, and so that `self.data` can possibly set a new one afterwards with the new behaviour,
- Adds `nodata` as a property so it cannot be set directly, as this is the role of `set_ndv()`,
- Adds None as a possible input/output of `nodata` in `set_ndv()`, for the sake of testing,
- Adds a `test_data_setter()` function that tests the behaviour of `data.setter` for all data types, for nodata as None or default value, and for all types of input (masked array with mask, masked array without mask, classic array). The function also checks that errors are properly raised for different `dtype` or `shape`,
- Adds tests to `test_copy` for the `new_array` attribute. Among other, it checks that `copy(new_array=)` can change the `dtype` of the output,
- Modifies the error of `data.setter` when trying to set a different `dtype` into "New data must be of the same type as existing data: {}. Use copy() to set a new array with different dtype, or astype() to change type.".
- Adds a warning that is raised when the nodata is set during the `data.setter` because of unmasked non-finite values.

Addionally, this PR:

- Forces `rasterio` > 1.3 to avoid failure of tests related to cropping on older versions,
- Allows None to be passed to `crs` for testing reasons,
- Prints the CRS directly in `info` instead of with `to_epsg()` that can trigger error for CRS that do not have an EPSG code,
- Removes some warnings.

This PR:
Resolves #298
Resolves #294