### PR TITLE
Improve array interface of `Raster` for consistency with `np.ma.masked_array` operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           rev: v2.0.0
           hooks:
                 - id: codespell
-                  args: [--ignore-words-list=alos]
+                  args: [--ignore-words-list=alos, --ignore-regex=\bnin\b]
                   types_or: [python, rst, markdown]
                   files: ^(geoutils|doc|tests)/
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1065,7 +1065,9 @@ Must be a Raster, np.ndarray or single number."
                     {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
                 )
 
-    def __array_function__(self, func: Callable[[np.ndarray, Any], Any], types: tuple[type], args: Any, kwargs: Any) -> Any:
+    def __array_function__(
+        self, func: Callable[[np.ndarray, Any], Any], types: tuple[type], args: Any, kwargs: Any
+    ) -> Any:
         """
         Method to cast NumPy array function directly on a Raster object by applying it to the masked array.
         A limited number of function is supported, listed in raster._HANDLED_FUNCTIONS.

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1027,42 +1027,37 @@ Must be a Raster, np.ndarray or single number."
             # If the universal function has only one output
             if ufunc.nout == 1:
                 return self.from_array(
-                    {
-                        "data": getattr(ufunc, method)(inputs[0].data, **kwargs),  # type: ignore
-                        "transform": self.transform,
-                        "crs": self.crs,
-                        "nodata": self.nodata,
-                    }
-                )
+                        data=getattr(ufunc, method)(inputs[0].data, **kwargs),
+                        transform=self.transform,
+                        crs=self.crs,
+                        nodata=self.nodata)
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
-                output = getattr(ufunc, method)(inputs[0].data, **kwargs)  # type: ignore
+                output = getattr(ufunc, method)(inputs[0].data, **kwargs)
                 return self.from_array(
-                    {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                    data=output[0], transform=self.transform, crs=self.crs, nodata=self.nodata
                 ), self.from_array(
-                    {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                    data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata
                 )
 
         # If the universal function takes two inputs (Note: no ufunc exists that has three inputs or more)
         else:
             if ufunc.nout == 1:
                 return self.from_array(
-                    {
-                        "data": getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),  # type: ignore
-                        "transform": self.transform,
-                        "crs": self.crs,
-                        "nodata": self.nodata,
-                    }
+                    data=getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),
+                        transform=self.transform,
+                        crs=self.crs,
+                        nodata=self.nodata
                 )
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
-                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)  # type: ignore
+                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)
                 return self.from_array(
-                    {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                    data=output[0], transform=self.transform, crs=self.crs, nodata=self.nodata
                 ), self.from_array(
-                    {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                    data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata
                 )
 
     def __array_function__(

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1026,7 +1026,7 @@ Must be a Raster, np.ndarray or single number."
         if ufunc.nin == 1:
             # If the universal function has only one output
             if ufunc.nout == 1:
-                return self.__class__(
+                return self.from_array(
                     {
                         "data": getattr(ufunc, method)(inputs[0].data, **kwargs),  # type: ignore
                         "transform": self.transform,
@@ -1038,16 +1038,16 @@ Must be a Raster, np.ndarray or single number."
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
                 output = getattr(ufunc, method)(inputs[0].data, **kwargs)  # type: ignore
-                return self.__class__(
+                return self.from_array(
                     {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
-                ), self.__class__(
+                ), self.from_array(
                     {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
                 )
 
         # If the universal function takes two inputs (Note: no ufunc exists that has three inputs or more)
         else:
             if ufunc.nout == 1:
-                return self.__class__(
+                return self.from_array(
                     {
                         "data": getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),  # type: ignore
                         "transform": self.transform,
@@ -1059,9 +1059,9 @@ Must be a Raster, np.ndarray or single number."
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
                 output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)  # type: ignore
-                return self.__class__(
+                return self.from_array(
                     {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
-                ), self.__class__(
+                ), self.from_array(
                     {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
                 )
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1027,38 +1027,35 @@ Must be a Raster, np.ndarray or single number."
             # If the universal function has only one output
             if ufunc.nout == 1:
                 return self.from_array(
-                        data=getattr(ufunc, method)(inputs[0].data, **kwargs),
-                        transform=self.transform,
-                        crs=self.crs,
-                        nodata=self.nodata)
+                    data=getattr(ufunc, method)(inputs[0].data, **kwargs),  # type: ignore
+                    transform=self.transform,
+                    crs=self.crs,
+                    nodata=self.nodata,
+                )  # type: ignore
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
-                output = getattr(ufunc, method)(inputs[0].data, **kwargs)
+                output = getattr(ufunc, method)(inputs[0].data, **kwargs)  # type: ignore
                 return self.from_array(
                     data=output[0], transform=self.transform, crs=self.crs, nodata=self.nodata
-                ), self.from_array(
-                    data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata
-                )
+                ), self.from_array(data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata)
 
         # If the universal function takes two inputs (Note: no ufunc exists that has three inputs or more)
         else:
             if ufunc.nout == 1:
                 return self.from_array(
-                    data=getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),
-                        transform=self.transform,
-                        crs=self.crs,
-                        nodata=self.nodata
+                    data=getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),  # type: ignore
+                    transform=self.transform,
+                    crs=self.crs,
+                    nodata=self.nodata,
                 )
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
             else:
-                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)
+                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)  # type: ignore
                 return self.from_array(
                     data=output[0], transform=self.transform, crs=self.crs, nodata=self.nodata
-                ), self.from_array(
-                    data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata
-                )
+                ), self.from_array(data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata)
 
     def __array_function__(
         self, func: Callable[[np.ndarray, Any], Any], types: tuple[type], args: Any, kwargs: Any

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1065,7 +1065,7 @@ Must be a Raster, np.ndarray or single number."
                     {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
                 )
 
-    def __array_function__(self, func: Callable[[np.ndarray, Any], Any], types: type, args: Any, kwargs: Any) -> Any:
+    def __array_function__(self, func: Callable[[np.ndarray, Any], Any], types: tuple[type], args: Any, kwargs: Any) -> Any:
         """
         Method to cast NumPy array function directly on a Raster object by applying it to the masked array.
         A limited number of function is supported, listed in raster._HANDLED_FUNCTIONS.
@@ -1087,10 +1087,10 @@ Must be a Raster, np.ndarray or single number."
 
         # For percentiles and quantiles, there exist no masked array version, so we compute on the valid data directly
         elif func.__name__ in ["percentile", "nanpercentile"]:
-            first_arg = args[0].data.data[~args[0].data.mask]
+            first_arg = args[0].data.compressed()
 
         elif func.__name__ in ["quantile", "nanquantile"]:
-            first_arg = args[0].data.data[~args[0].data.mask]
+            first_arg = args[0].data.compressed()
 
         # Otherwise, we run the numpy function normally (most take masks into account)
         else:

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1063,7 +1063,7 @@ Must be a Raster, np.ndarray or single number."
     def __array_function__(self, func: Callable[[np.ndarray, Any], Any], types: type, args: Any, kwargs: Any) -> Any:
         """
         Method to cast NumPy array function directly on a Raster object by applying it to the masked array.
-        A limited number of function is supported, listed in XXX.
+        A limited number of function is supported, listed in raster._HANDLED_FUNCTIONS.
         """
 
         # If function is not implemented

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -895,7 +895,7 @@ Must be a Raster, np.ndarray or single number."
             f"Size:                 {self.width}, {self.height}\n",
             f"Number of bands:      {self.count:d}\n",
             f"Data types:           {self.dtypes}\n",
-            f"Coordinate System:    EPSG:{self.crs.to_epsg()}\n",
+            f"Coordinate System:    EPSG:{[self.crs.to_string() if self.crs is not None else None]}\n",
             f"NoData Value:         {self.nodata}\n",
             "Pixel Size:           {}, {}\n".format(*self.res),
             "Upper Left Corner:    {}, {}\n".format(*self.bounds[:2]),
@@ -943,7 +943,7 @@ Must be a Raster, np.ndarray or single number."
     # @property
     # def __array_interface__(self) -> dict[str, Any]:
     #     if not self.is_loaded:
-    #         self.load()
+    #         self.load()__array
     #
     #     return self._data.__array_interface__  # type: ignore
 
@@ -958,10 +958,16 @@ Must be a Raster, np.ndarray or single number."
         if not self.is_loaded:
             self.load()
 
-        return  self.__class__({"data": ufunc(self._data, *inputs, **kwargs),
-                               "transform": self.transform,
-                               "crs": self.crs,
-                               "nodata": self.nodata}) # type: ignore
+        if ufunc.nin == 1:
+            return self.__class__({"data": getattr(ufunc, method)(inputs[0].data, **kwargs),
+                                   "transform": self.transform,
+                                   "crs": self.crs,
+                                   "nodata": self.nodata})
+        else:
+            return self.__class__({"data": getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),
+                                   "transform": self.transform,
+                                   "crs": self.crs,
+                                   "nodata": self.nodata})
 
     def __array_function__(self, func, types, args, kwargs):
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -48,6 +48,43 @@ else:
 
 RasterType = TypeVar("RasterType", bound="Raster")
 
+# List of numpy functions that are handled: nan statistics function, normal statistics function and sorting/counting
+_HANDLED_FUNCTIONS = (
+    [
+        "nansum",
+        "nanmax",
+        "nanmin",
+        "nanargmax",
+        "nanargmin",
+        "nanmean",
+        "nanmedian",
+        "nanpercentile",
+        "nanvar",
+        "nanstd",
+        "nanprod",
+        "nancumsum",
+        "nancumprod",
+        "nanquantile",
+    ]
+    + [
+        "sum",
+        "amax",
+        "amin",
+        "argmax",
+        "argmin",
+        "mean",
+        "median",
+        "percentile",
+        "var",
+        "std",
+        "prod",
+        "cumsum",
+        "cumprod",
+        "quantile",
+    ]
+    + ["sort", "count_nonzero", "unique"]
+)
+
 
 # Function to set the default nodata values for any given dtype
 # Similar to GDAL for int types, but without absurdly long nodata values for floats.
@@ -68,7 +105,7 @@ def _default_ndv(dtype: str | np.dtype | type) -> int:
         "float32": -99999,
         "float64": -99999,
         "float128": -99999,
-        "longdouble": -99999, # This is float64 on Windows, float128 on other systems, for compatibility
+        "longdouble": -99999,  # This is float64 on Windows, float128 on other systems, for compatibility
     }
     # Check argument dtype is as expected
     if not isinstance(dtype, (str, np.dtype, type)):
@@ -960,13 +997,18 @@ Must be a Raster, np.ndarray or single number."
 
         return cp
 
-
-    def __array__(self):
+    def __array__(self) -> np.ndarray:
         """Method to cast np.array() or np.asarray() function directly on Raster classes."""
 
         return self._data
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> RasterType | tuple[RasterType, RasterType]:
+    def __array_ufunc__(
+        self,
+        ufunc: Callable[[np.ndarray | tuple[np.ndarray, np.ndarray]], np.ndarray | tuple[np.ndarray, np.ndarray]],
+        method: str,
+        *inputs: Raster | tuple[Raster, Raster],
+        **kwargs: Any,
+    ) -> Raster | tuple[Raster, Raster]:
         """
         Method to cast NumPy universal functions directly on Raster classes, by passing to the masked array.
         This function basically applies the ufunc (with its method and kwargs) to .data, and rebuilds the Raster from
@@ -979,53 +1021,77 @@ Must be a Raster, np.ndarray or single number."
         if ufunc.nin == 1:
             # If the universal function has only one output
             if ufunc.nout == 1:
-                return self.__class__({"data": getattr(ufunc, method)(inputs[0].data, **kwargs),
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata})
+                return self.__class__(
+                    {
+                        "data": getattr(ufunc, method)(inputs[0].data, **kwargs),  # type: ignore
+                        "transform": self.transform,
+                        "crs": self.crs,
+                        "nodata": self.nodata,
+                    }
+                )
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
-            elif ufunc.nout ==2:
-                output = getattr(ufunc, method)(inputs[0].data, **kwargs)
-                return self.__class__({"data": output[0],
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata}), \
-                       self.__class__({"data": output[1],
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata})
+            else:
+                output = getattr(ufunc, method)(inputs[0].data, **kwargs)  # type: ignore
+                return self.__class__(
+                    {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                ), self.__class__(
+                    {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                )
 
         # If the universal function takes two inputs (Note: no ufunc exists that has three inputs or more)
-        elif ufunc.nin == 2:
+        else:
             if ufunc.nout == 1:
-                return self.__class__({"data": getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata})
+                return self.__class__(
+                    {
+                        "data": getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs),  # type: ignore
+                        "transform": self.transform,
+                        "crs": self.crs,
+                        "nodata": self.nodata,
+                    }
+                )
 
             # If the universal function has two outputs (Note: no ufunc exists that has three outputs or more)
-            elif ufunc.nout == 2:
-                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)
-                return self.__class__({"data": output[0],
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata}),\
-                       self.__class__({"data": output[1],
-                                       "transform": self.transform,
-                                       "crs": self.crs,
-                                       "nodata": self.nodata})
+            else:
+                output = getattr(ufunc, method)(inputs[0].data, inputs[1].data, **kwargs)  # type: ignore
+                return self.__class__(
+                    {"data": output[0], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                ), self.__class__(
+                    {"data": output[1], "transform": self.transform, "crs": self.crs, "nodata": self.nodata}
+                )
 
-    def __array_function__(self, func, types, args, kwargs) -> Any:
+    def __array_function__(self, func: Callable[[np.ndarray, Any], Any], types: type, args: Any, kwargs: Any) -> Any:
         """
         Method to cast NumPy array function directly on a Raster object by applying it to the masked array.
         A limited number of function is supported, listed in XXX.
         """
+
+        # If function is not implemented
+        if func.__name__ not in _HANDLED_FUNCTIONS:
+            return NotImplemented
+
         # For subclassing
         if not all(issubclass(t, self.__class__) for t in types):
             return NotImplemented
 
-        return func(args[0].data, *args[1:], **kwargs)
+        # We now choose the behaviour of array functions
+        # For median, np.median ignores masks of masked array, so we force np.ma.median
+        if func.__name__ in ["median", "nanmedian"]:
+            func = np.ma.median
+            first_arg = args[0].data
+
+        # For percentiles and quantiles, there exist no masked array version, so we compute on the valid data directly
+        elif func.__name__ in ["percentile", "nanpercentile"]:
+            first_arg = args[0].data.data[~args[0].data.mask]
+
+        elif func.__name__ in ["quantile", "nanquantile"]:
+            first_arg = args[0].data.data[~args[0].data.mask]
+
+        # Otherwise, we run the numpy function normally (most take masks into account)
+        else:
+            first_arg = args[0].data
+
+        return func(first_arg, *args[1:], **kwargs)  # type: ignore
 
     # Note the star is needed because of the default argument 'mode' preceding non default arg 'inplace'
     # Then the final overload must be duplicated

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -598,12 +598,17 @@ Must be a Raster, np.ndarray or single number."
         # Case 2 - other is a numpy array
         elif isinstance(other, np.ndarray):
             # Check that both array have the same shape
-            if self.data.shape == other.shape:
+
+            if len(other.shape) == 2:
+                other_data = other[np.newaxis, :, :]
+            else:
+                other_data = other
+
+            if self.data.shape == other_data.shape:
                 pass
             else:
                 raise ValueError("Both rasters must have the same shape.")
 
-            other_data = other
             ndv2 = None
             dtype2 = other_data.dtype
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -39,6 +39,7 @@ class TestRaster:
     def test_init(self, example: str) -> None:
         """Test that all possible inputs work properly in Raster class init"""
 
+        example = aster_dem_path
         # First, filename
         r = gr.Raster(example)
         assert isinstance(r, gr.Raster)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -2058,8 +2058,10 @@ class TestArrayInterface:
 
                 # For two outputs
                 elif ufunc.nout == 2:
-                    assert np.ma.allequal(ufunc(rst.data)[0], ufunc(rst)[0].data) and np.ma.allequal(
-                        ufunc(rst.data)[1], ufunc(rst)[1].data
+                    outputs_rst = ufunc(rst)
+                    outputs_ma = ufunc(rst.data)
+                    assert np.ma.allequal(outputs_ma[0], outputs_rst[0].data) and np.ma.allequal(
+                        outputs_ma[1], outputs_rst[1].data
                     )
 
             # If the input dtype is not possible, check that NumPy raises a TypeError
@@ -2139,8 +2141,10 @@ class TestArrayInterface:
 
                 # For two outputs
                 elif ufunc.nout == 2:
-                    assert np.ma.allequal(ufunc(rst1.data, rst2.data)[0], ufunc(rst1, rst2)[0].data) and np.ma.allequal(
-                        ufunc(rst1.data, rst2.data)[1], ufunc(rst1, rst2)[1].data
+                    outputs_rst = ufunc(rst1, rst2)
+                    outputs_ma = ufunc(rst1.data, rst2.data)
+                    assert np.ma.allequal(outputs_ma[0], outputs_rst[0].data) and np.ma.allequal(
+                        outputs_ma[1], outputs_rst[1].data
                     )
 
             # If the input dtype is not possible, check that NumPy raises a TypeError
@@ -2185,11 +2189,11 @@ class TestArrayInterface:
                 arg = 80.0
                 # For percentiles and quantiles, the statistic is computed after removing the masked values
                 output_rst = arrfunc(rst, arg)
-                output_ma = arrfunc(rst.data.data[~rst.data.mask], arg)
+                output_ma = arrfunc(rst.data.compressed(), arg)
             elif "quantile" in arrfunc_str:
                 arg = 0.8
                 output_rst = arrfunc(rst, arg)
-                output_ma = arrfunc(rst.data.data[~rst.data.mask], arg)
+                output_ma = arrfunc(rst.data.compressed(), arg)
             elif "median" in arrfunc_str:
                 # For the median, the statistic is computed by masking the values through np.ma.median
                 output_rst = arrfunc(rst)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -922,7 +922,7 @@ This may have unexpected consequences. Consider setting a different nodata with 
         assert _default_ndv("uint16") == np.iinfo("uint16").max
         assert _default_ndv("int16") == np.iinfo("int16").min
         assert _default_ndv("uint32") == 99999
-        for dtype in ["int32", "float32", "float64", "float128"]:
+        for dtype in ["int32", "float32", "float64", "longdouble"]:
             assert _default_ndv(dtype) == -99999
 
         # Check it works with most frequent np.dtypes too
@@ -1732,7 +1732,7 @@ class TestArrayInterface:
 
     @pytest.mark.parametrize("ufunc_str", ufuncs_str)
     @pytest.mark.parametrize("dtype", ["uint8", "int8", "uint16", "int16", "uint32", "int32",
-                                       "float32", "float64", "float128"])
+                                       "float32", "float64", "longdouble"])
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])
     def test_array_ufunc(self, ufunc_str: str, nodata_init: None | str, dtype: str):
         """Test that ufuncs consistently return the same result as for the np.ma.masked_array"""

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1968,7 +1968,7 @@ class TestArrayInterface:
 
     # To my knowledge, there is no list that includes all numpy functions (and we probably don't want to test them all)
     # Let's include manually the important ones:
-    # - statistics: normal, for NaNs, and for masked_arrays;
+    # - statistics: normal and for NaNs;
     # - sorting and counting;
     # Most other math functions are already universal functions
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -21,8 +21,7 @@ import geoutils.geovector as gv
 import geoutils.misc
 import geoutils.projtools as pt
 from geoutils import examples
-from geoutils.georaster.raster import (_HANDLED_FUNCTIONS, _default_ndv,
-                                       _default_rio_attrs)
+from geoutils.georaster.raster import _default_ndv, _default_rio_attrs
 from geoutils.misc import resampling_method_from_str
 
 DO_PLOT = False
@@ -1973,7 +1972,7 @@ class TestArrayInterface:
     # Most other math functions are already universal functions
 
     # The full list exists in Raster
-    handled_functions = _HANDLED_FUNCTIONS
+    handled_functions = gu.georaster.raster._HANDLED_FUNCTIONS
 
     # Details below:
     # NaN functions: [f for f in np.lib.nanfunctions.__all__]

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1959,6 +1959,14 @@ class TestArrayInterface:
     arr1 = np.random.randint(min_val, max_val, (height, width), dtype="int32") + np.random.normal(size=(height, width))
     arr2 = np.random.randint(min_val, max_val, (height, width), dtype="int32") + np.random.normal(size=(height, width))
 
+    # Create two random masks
+    mask1 = np.random.randint(0, 2, size=(width, height), dtype=bool)
+    mask2 = np.random.randint(0, 2, size=(width, height), dtype=bool)
+
+    # Assert that there is at least one unmasked value
+    assert np.count_nonzero(~mask1) > 0
+    assert np.count_nonzero(~mask2) > 0
+
     @pytest.mark.parametrize("ufunc_str", ufuncs_str_1nin_1nout + ufuncs_str_1nin_2nout)
     @pytest.mark.parametrize("dtype", ["uint8", "int8", "uint16", "int16", "uint32", "int32",
                                        "float32", "float64", "longdouble"])
@@ -1973,7 +1981,8 @@ class TestArrayInterface:
             nodata = None
 
         # Create Raster
-        rst = gr.Raster.from_array(self.arr1.astype(dtype), transform=self.transform, crs=None, nodata=nodata)
+        ma1 = np.ma.masked_array(data = self.arr1.astype(dtype), mask=self.mask1)
+        rst = gr.Raster.from_array(ma1, transform=self.transform, crs=None, nodata=nodata)
 
         # Get ufunc
         ufunc = getattr(np, ufunc_str)
@@ -2027,8 +2036,10 @@ class TestArrayInterface:
         else:
             nodata2 = None
 
-        rst1 = gr.Raster.from_array(self.arr1.astype(dtype1), transform=self.transform, crs=None, nodata=nodata1)
-        rst2 = gr.Raster.from_array(self.arr2.astype(dtype2), transform=self.transform, crs=None, nodata=nodata2)
+        ma1 = np.ma.masked_array(data = self.arr1.astype(dtype1), mask=self.mask1)
+        ma2 = np.ma.masked_array(data = self.arr2.astype(dtype2), mask=self.mask2)
+        rst1 = gr.Raster.from_array(ma1, transform=self.transform, crs=None, nodata=nodata1)
+        rst2 = gr.Raster.from_array(ma2, transform=self.transform, crs=None, nodata=nodata2)
 
         ufunc = getattr(np, ufunc_str)
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1828,18 +1828,21 @@ class TestArithmetic:
         """
         warnings.filterwarnings("ignore", message="invalid value encountered")
 
-        # Test various inputs: Raster with different dtypes, np.ndarray, single number
+        # Test various inputs: Raster with different dtypes, np.ndarray with 2D or 3D shape, single number
         r1 = self.r1
         r1_f32 = self.r1_f32
         r2 = self.r2
-        array = np.random.randint(1, 255, (1, self.height, self.width)).astype("uint8")
+        array_3d = np.random.randint(1, 255, (1, self.height, self.width)).astype("uint8")
+        array_2d = np.random.randint(1, 255, (self.height, self.width)).astype("uint8")
         floatval = 3.14
 
         # Addition
         assert r1 + r2 == self.from_array(r1.data + r2.data, rst_ref=r1)
         assert r1_f32 + r2 == self.from_array(r1_f32.data + r2.data, rst_ref=r1)
-        # assert array + r2 == self.from_array(array + r2.data, rst_ref=r1)  # this case fails as using numpy's add...
-        assert r2 + array == self.from_array(r2.data + array, rst_ref=r1)
+        assert array_3d + r2 == self.from_array(array_3d + r2.data, rst_ref=r1)
+        assert r2 + array_3d == self.from_array(r2.data + array_3d, rst_ref=r1)
+        assert array_2d + r2 == self.from_array(array_2d[np.newaxis, :, :] + r2.data, rst_ref=r1)
+        assert r2 + array_2d == self.from_array(r2.data + array_2d[np.newaxis, :, :], rst_ref=r1)
         assert r1 + floatval == self.from_array(r1.data.astype("float32") + floatval, rst_ref=r1)
         assert floatval + r1 == self.from_array(floatval + r1.data.astype("float32"), rst_ref=r1)
         assert r1 + r2 == r2 + r1
@@ -1847,8 +1850,10 @@ class TestArithmetic:
         # Multiplication
         assert r1 * r2 == self.from_array(r1.data * r2.data, rst_ref=r1)
         assert r1_f32 * r2 == self.from_array(r1_f32.data * r2.data, rst_ref=r1)
-        # assert array * r2 == self.from_array(array * r2.data, rst_ref=r1)  # this case fails as using numpy's mul...
-        assert r2 * array == self.from_array(r2.data * array, rst_ref=r1)
+        assert array_3d * r2 == self.from_array(array_3d * r2.data, rst_ref=r1)
+        assert r2 * array_3d == self.from_array(r2.data * array_3d, rst_ref=r1)
+        assert array_2d * r2 == self.from_array(array_2d[np.newaxis, :, :] * r2.data, rst_ref=r1)
+        assert r2 * array_2d == self.from_array(r2.data * array_2d[np.newaxis, :, :], rst_ref=r1)
         assert r1 * floatval == self.from_array(r1.data.astype("float32") * floatval, rst_ref=r1)
         assert floatval * r1 == self.from_array(floatval * r1.data.astype("float32"), rst_ref=r1)
         assert r1 * r2 == r2 * r1
@@ -1856,32 +1861,40 @@ class TestArithmetic:
         # Subtraction
         assert r1 - r2 == self.from_array(r1.data - r2.data, rst_ref=r1)
         assert r1_f32 - r2 == self.from_array(r1_f32.data - r2.data, rst_ref=r1)
-        # assert array - r2 == self.from_array(array - r2.data, rst_ref=r1)  # this case fails
-        assert r2 - array == self.from_array(r2.data - array, rst_ref=r1)
+        assert array_3d - r2 == self.from_array(array_3d - r2.data, rst_ref=r1)
+        assert r2 - array_3d == self.from_array(r2.data - array_3d, rst_ref=r1)
+        assert array_2d - r2 == self.from_array(array_2d[np.newaxis, :, :] - r2.data, rst_ref=r1)
+        assert r2 - array_2d == self.from_array(r2.data - array_2d[np.newaxis, :, :], rst_ref=r1)
         assert r1 - floatval == self.from_array(r1.data.astype("float32") - floatval, rst_ref=r1)
         assert floatval - r1 == self.from_array(floatval - r1.data.astype("float32"), rst_ref=r1)
 
         # True division
         assert r1 / r2 == self.from_array(r1.data / r2.data, rst_ref=r1)
         assert r1_f32 / r2 == self.from_array(r1_f32.data / r2.data, rst_ref=r1)
-        # assert array / r2 == self.from_array(array / r2.data, rst_ref=r1)  # this case fails
-        assert r2 / array == self.from_array(r2.data / array, rst_ref=r2)
+        assert array_3d / r2 == self.from_array(array_3d / r2.data, rst_ref=r1)
+        assert r2 / array_3d == self.from_array(r2.data / array_3d, rst_ref=r2)
+        assert array_2d / r2 == self.from_array(array_2d[np.newaxis, :, :] / r2.data, rst_ref=r1)
+        assert r2 / array_2d == self.from_array(r2.data / array_2d[np.newaxis, :, :], rst_ref=r2)
         assert r1 / floatval == self.from_array(r1.data.astype("float32") / floatval, rst_ref=r1)
         assert floatval / r1 == self.from_array(floatval / r1.data.astype("float32"), rst_ref=r1)
 
         # Floor division
         assert r1 // r2 == self.from_array(r1.data // r2.data, rst_ref=r1)
         assert r1_f32 // r2 == self.from_array(r1_f32.data // r2.data, rst_ref=r1)
-        # assert array // r2 == self.from_array(array // r2.data, rst_ref=r1)  # this case fails
-        assert r2 // array == self.from_array(r2.data // array, rst_ref=r1)
+        assert array_3d // r2 == self.from_array(array_3d // r2.data, rst_ref=r1)
+        assert r2 // array_3d == self.from_array(r2.data // array_3d, rst_ref=r1)
+        assert array_2d // r2 == self.from_array(array_2d[np.newaxis, :, :] // r2.data, rst_ref=r1)
+        assert r2 // array_2d == self.from_array(r2.data // array_2d[np.newaxis, :, :], rst_ref=r1)
         assert r1 // floatval == self.from_array(r1.data // floatval, rst_ref=r1)
         assert floatval // r1 == self.from_array(floatval // r1.data, rst_ref=r1)
 
         # Modulo
         assert r1 % r2 == self.from_array(r1.data % r2.data, rst_ref=r1)
         assert r1_f32 % r2 == self.from_array(r1_f32.data % r2.data, rst_ref=r1)
-        # assert array % r2 == self.from_array(array % r2.data, rst_ref=r1)  # this case fails
-        assert r2 % array == self.from_array(r2.data % array, rst_ref=r1)
+        assert array_3d % r2 == self.from_array(array_3d % r2.data, rst_ref=r1)
+        assert r2 % array_3d == self.from_array(r2.data % array_3d, rst_ref=r1)
+        assert array_2d % r2 == self.from_array(array_2d[np.newaxis, :, :] % r2.data, rst_ref=r1)
+        assert r2 % array_2d == self.from_array(r2.data % array_2d[np.newaxis, :, :], rst_ref=r1)
         assert r1 % floatval == self.from_array(r1.data.astype("float32") % floatval, rst_ref=r1)
 
     @pytest.mark.parametrize("op", ops_2args)  # type: ignore


### PR DESCRIPTION
## Summary

This PR adds a **nodata-aware array interface** to work with `Raster` objects and their subclasses. **All of the ~90 universal functions of NumPy are now supported** (see ufuncs: https://numpy.org/doc/stable/reference/ufuncs.html), **and also ~25 NumPy array functions** defined on a per-need basis (such as np.min, np.max, np.mean, np.median, np.std, np.var, np.percentile, np.quantile). All these functions are wrapped in a way that accounts for possible `nodata` in `Raster.data`.

## From `__array_interface__` to `__array_ufunc__` and `__array_function__`

In #210, we added `__array_interface__` as a property to perform operations on `Raster` classes as if on array. However, this interface points to the array of the masked array `.data.data`, and therefore gives inconsistent results depending on `nodata` values.
For example:
```python
np.min(raster.data) # minimum value is around 340, nodata value is -9999
Out[1]: 341.2

np.min(raster) 
Out[2]: -9999
```

This PR tries to expand the addition of @erikmannerfelt to apply to the masked array (Note: there is a `mask` key in the dict of `__array_interface__`, but I didn't understand how this is supposed to work, see https://numpy.org/doc/stable/reference/arrays.interface.html). 
Instead, this PR uses `__array__`, `__array_ufunc__` and `__array_function__` methods of NumPy, that allow to define the comportement of the `Raster` class when functions are applied to it, respectively, `np.array()`, any universal functions `ufunc`, and any array function `function`. See https://numpy.org/doc/stable/user/basics.dispatch.html#basics-dispatch.

## Choosing the behaviour of NumPy functions on `Raster` objects

Important note to start: I did not find a way to define the comportement of `np.ma` functions (which are not covered by `__array_function__` of NumPy, and no equivalent seem to exists in the `ma` module). So this PR only concerns NumPy functions with the format `np.function`.

For defining behaviour, I thought the best option would be to enforce the exact same behaviour as when applying to the masked array `.data`. NumPy function generally account for masks even if not called from `np.ma`. However, there are a couple exceptions that ignore the mask (raising a `UserWarning`), those are:

- `np.median`
- `np.quantile`
- `np.percentile`

And so, because of those three, I thought preferable to make the behaviour of NumPy functions on `Raster` always **nodata-aware**. This means that the behaviour is:

1. All NumPy functions except the 3 listed above are cast to the masked array `Raster.data`. Then, if the function preserves shape (all ufuncs), the output masked array is encapsulated in a `Raster` object.
2. For "median", the NumPy function is redefined into `np.ma.median` to be nodata-aware and cast on the masked array `.data`,
3. For "quantile" and "percentile", no `np.ma` function exists, so the NumPy function is left the same and cast on valid values `.data.data[~.data.mask]`

Seeing how NumPy has made most classic functions outside of `np.ma` account for mask, it could be only a matter of years until they add `np.median`, `np.percentile` and `np.quantile`. Then the behaviour of our array interface would become fully consistent without the need for specific cases.

## For documentation

In the documentation (once we set it up a bit better), we would recommend three options for array calculations, that always remain fully consistent:

1. Applying any `np.function` to the `Raster` object,
2. Applying any `np.ma.function` to the masked array `.data` of the `Raster` object,
3. Applying any `np.nanfunction` to `Raster.get_nanarray()` once implemented (see #277).

## Tests

A specific test class `TestArrayInterface` is added.
It tests all combinations of: 

- `np.function` (all ufuncs and supported array funcs), 
- `dtype` supported by `Raster` (possibly two loops for two inputs),
- `nodata`, either None or the default value of a `dtype` (possibly two nodata for two inputs),

which are applied to `Raster` object with a 5x5 masked array with random values of the `dtype`, and with a mask containing at least one `True` and one `False` value.

For all combinations, the test check that the output of the NumPy function applied to `Raster.data` is fully consistent with the same function applied to `Raster`, at the exception of the special case of "median", "percentile" and "quantile" checked separately. 

Additionally, the PR checks that NumPy `TypeError` or `ValueError` are always raised through application to `Raster` when supposed to, i.e. for a wrong combination of input `dtypes`, and that this error behaviour is fully consistent with the one for the function being applied to `Raster.data`.

The many combinations increases our number of test reported by `pytest` by about 13,500. This is a lot but helps tracing quickly exactly which combination is failing (which occured quite a bit during the drafting phase of the PR). If we feel it's too much, we could move some of these test loops inside the `test_` functions instead of as `@pytest.mark.parametrize` loops.

## Little addition

I have uncommented tests on reflective arithmetic operations with 3D np.ndarrays that use to fail due to #256. I have also added 2D tests and updated the `_overloading_check` function to enable #304.

## Linked issues

Resolves #261
Resolves #256
Resolves #304