### PR TITLE
Add `get_nanarray` method

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1002,19 +1002,37 @@ Must be a Raster, np.ndarray or single number."
 
         return cp
 
+    @overload
+    def get_nanarray(self, return_mask: Literal[False]) -> np.ndarray:
+        ...
+
+    @overload
+    def get_nanarray(self, return_mask: Literal[True]) -> tuple[np.ndarray, np.ndarray]:
+        ...
+
+    @overload
+    def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        ...
+
     def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         """
-        Method to return a squeezed array filled with NaN and the associated mask from the masked array in .data
+        Method to return the squeezed masked array filled with NaNs and associated squeezed mask, both as a copy.
 
         :param return_mask: Whether to return the mask of valid data
 
         :returns Array with masked data as NaNs, (Optional) Mask of valid data
         """
 
+        # Get the array with masked value fill with NaNs
         nanarray = self.data.filled(fill_value=np.nan).squeeze()
 
+        # The function np.ma.filled() only returns a copy if the array is masked, copy the array if it's not the case
+        if not np.ma.is_masked(self.data):
+            nanarray = np.copy(nanarray)
+
+        # Return the NaN array, and possibly the mask as well
         if return_mask:
-            return nanarray, np.ma.getmaskarray(self.data).squeeze()
+            return nanarray, np.copy(np.ma.getmaskarray(self.data).squeeze())
         else:
             return nanarray
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1003,15 +1003,11 @@ Must be a Raster, np.ndarray or single number."
         return cp
 
     @overload
-    def get_nanarray(self, return_mask: Literal[False]) -> np.ndarray:
+    def get_nanarray(self, return_mask: Literal[False] = False) -> np.ndarray:
         ...
 
     @overload
     def get_nanarray(self, return_mask: Literal[True]) -> tuple[np.ndarray, np.ndarray]:
-        ...
-
-    @overload
-    def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
         ...
 
     def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1002,6 +1002,22 @@ Must be a Raster, np.ndarray or single number."
 
         return cp
 
+    def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+        """
+        Method to return a squeezed array filled with NaN and the associated mask from the masked array in .data
+
+        :param return_mask: Whether to return the mask of valid data
+
+        :returns Array with masked data as NaNs, (Optional) Mask of valid data
+        """
+
+        nanarray = self.data.filled(fill_value=np.nan).squeeze()
+
+        if return_mask:
+            return nanarray, np.ma.getmaskarray(self.data).squeeze()
+        else:
+            return nanarray
+
     def __array__(self) -> np.ndarray:
         """Method to cast np.array() or np.asarray() function directly on Raster classes."""
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -372,8 +372,8 @@ class TestRaster:
         ):
             rst.data = rst.data.reshape(new_shape)
 
-    @pytest.mark.parametrize('example', [aster_dem_path, landsat_b4_path, landsat_rgb_path])
-    def test_get_nanarray(self, example) -> None:
+    @pytest.mark.parametrize("example", [aster_dem_path, landsat_b4_path, landsat_rgb_path])  # type: ignore
+    def test_get_nanarray(self, example: str) -> None:
         """
         Check that self.get_nanarray behaves as expected for examples with invalid data or not, and with several bands
         or a single one.
@@ -399,7 +399,6 @@ class TestRaster:
         rst_arr, mask = rst.get_nanarray(return_mask=True)
 
         assert np.array_equal(mask, np.ma.getmaskarray(rst.data).squeeze())
-
 
     def test_downsampling(self) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -383,6 +383,7 @@ class TestRaster:
 
         # Get nanarray
         rst = gr.Raster(example)
+        rst_copy = rst.copy()
         rst_arr = rst.get_nanarray()
 
         # If there is no mask in the masked array, the array should not have NaNs and be equal to that of data.data
@@ -395,10 +396,20 @@ class TestRaster:
             assert np.count_nonzero(np.isnan(rst_arr)) > 0
             assert np.ma.allequal(rst.data.squeeze(), rst_arr, fill_value=np.nan)
 
+        # Check that modifying the NaN array does not back-propagate to the original array (np.ma.filled returns a view
+        # when there is no invalid data, but in this case get_nanarray should copy the data).
+        rst_arr += 5
+        assert rst == rst_copy
+
         # -- Then, we test with a mask returned --
         rst_arr, mask = rst.get_nanarray(return_mask=True)
 
         assert np.array_equal(mask, np.ma.getmaskarray(rst.data).squeeze())
+
+        # Also check for back-propagation here with the mask and array
+        rst_arr += 5
+        mask = ~mask
+        assert rst == rst_copy
 
     def test_downsampling(self) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -372,6 +372,35 @@ class TestRaster:
         ):
             rst.data = rst.data.reshape(new_shape)
 
+    @pytest.mark.parametrize('example', [aster_dem_path, landsat_b4_path, landsat_rgb_path])
+    def test_get_nanarray(self, example) -> None:
+        """
+        Check that self.get_nanarray behaves as expected for examples with invalid data or not, and with several bands
+        or a single one.
+        """
+
+        # -- First, we test without returning a mask --
+
+        # Get nanarray
+        rst = gr.Raster(example)
+        rst_arr = rst.get_nanarray()
+
+        # If there is no mask in the masked array, the array should not have NaNs and be equal to that of data.data
+        if not np.ma.is_masked(rst.data):
+            assert np.count_nonzero(np.isnan(rst_arr)) == 0
+            assert np.array_equal(rst.data.data.squeeze(), rst_arr)
+
+        # Otherwise, the arrays should be equal with a fill_value of NaN
+        else:
+            assert np.count_nonzero(np.isnan(rst_arr)) > 0
+            assert np.ma.allequal(rst.data.squeeze(), rst_arr, fill_value=np.nan)
+
+        # -- Then, we test with a mask returned --
+        rst_arr, mask = rst.get_nanarray(return_mask=True)
+
+        assert np.array_equal(mask, np.ma.getmaskarray(rst.data).squeeze())
+
+
     def test_downsampling(self) -> None:
         """
         Check that self.data is correct when using downsampling


### PR DESCRIPTION
As discussed many times, it is much more familiar for many people to work with classical arrays rather than masked arrays. Right now, we have to use the `gu.spatial_tools.get_array_and_mask` method to convert between the two, which is a bit unintuitive. Additionally, the `get_array_and_mask` method is made to work with any type of input to homogenize the behaviour of some functions. This is not needed when working with a `Raster` object that always has the same `.data`.

In this PR, we add the `Raster` class method `get_nanarray` to return a NaN array, with argument `return_mask` (defaults as `False`) to possibly the original mask of valid data as well. 

The behaviour is the following:

- The NaN array corresponds exactly to `Raster.data.filled(fill_value=np.nan).squeeze()`, i.e. the data with masked values replaced by NaNs, and squeezed (2D array if there was only a single band);
- The mask corresponds exactly to `np.ma.getmaskarray(Raster.data).squeeze()`, i.e. the squeezed mask if one existed for the masked array `.data`, or an array filled with `False` the same shape as `.data` otherwise.

Resolves #277