### PR TITLE
Modify `set_nodata` behaviour, improve related warnings and tests

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -567,8 +567,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # See https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
         if not isinstance(other, (Raster, np.ndarray, Number)):
             raise NotImplementedError(
-                f"Operation between an object of type {type(other)} and a Raster impossible. \
-Must be a Raster, np.ndarray or single number."
+                f"Operation between an object of type {type(other)} and a Raster impossible. Must be a Raster, "
+                f"np.ndarray or single number."
             )
 
         # Get self's dtype and nodata
@@ -910,21 +910,21 @@ Must be a Raster, np.ndarray or single number."
                     if np.count_nonzero(index_new_nodatas) > 0:
                         if update_array and update_mask:
                             warnings.warn(
-                                message="New nodata value found in the data array. Those will be masked, and the old nodata "
-                                        "cells will now take the same value. Use set_nodata() with update_array=False and/or "
-                                        "update_mask=False to change this behaviour",
+                                message="New nodata value found in the data array. Those will be masked, and the old "
+                                "nodata cells will now take the same value. Use set_nodata() with update_array=False "
+                                "and/or update_mask=False to change this behaviour",
                                 category=UserWarning,
                             )
                         elif update_array:
                             warnings.warn(
-                                "New nodata value found in the data array. The old nodata cells will now take the same value. "
-                                "Use set_nodata() with update_array=False to change this behaviour",
+                                "New nodata value found in the data array. The old nodata cells will now take the same "
+                                "value. Use set_nodata() with update_array=False to change this behaviour",
                                 category=UserWarning,
                             )
                         elif update_mask:
                             warnings.warn(
-                                "New nodata value found in the data array. Those will be masked. Use set_nodata() with "
-                                "update_mask=False to change this behaviour",
+                                "New nodata value found in the data array. Those will be masked. Use set_nodata() "
+                                "with update_mask=False to change this behaviour",
                                 category=UserWarning,
                             )
 
@@ -943,7 +943,7 @@ Must be a Raster, np.ndarray or single number."
 
                     # Only update mask with new nodata if it is defined
                     if nodata is not None:
-                        # Masking like this works from the masked array directly, whether a mask previously existed or not
+                        # Masking like this works from the masked array directly, whether a mask exists or not
                         imgdata[i, index_new_nodatas] = np.ma.masked
 
             # Update the data
@@ -1003,10 +1003,8 @@ Must be a Raster, np.ndarray or single number."
         # Check that new_data has the right type
         if str(new_data.dtype) != dtype:
             raise ValueError(
-                "New data must be of the same type as existing\
- data: {}. Use copy() to set a new array with different dtype, or astype() to change type.".format(
-                    dtype
-                )
+                "New data must be of the same type as existing data: {}. Use copy() to set a new array with "
+                "different dtype, or astype() to change type.".format(dtype)
             )
 
         if new_data.shape[1:] != orig_shape:
@@ -1443,15 +1441,15 @@ Must be a Raster, np.ndarray or single number."
                 # TODO: for uint8, if all values are used, apply rio.warp to mask to identify invalid values
                 if not self.is_loaded:
                     warnings.warn(
-                        f"For reprojection, dst_nodata must be set. Setting default nodata to {dst_nodata}. \
-You may set a different nodata with `dst_nodata`."
+                        f"For reprojection, dst_nodata must be set. Setting default nodata to {dst_nodata}. You may "
+                        f"set a different nodata with `dst_nodata`."
                     )
 
                 elif dst_nodata in self.data:
                     warnings.warn(
-                        f"For reprojection, dst_nodata must be set. Default chosen value {dst_nodata} exists in \
-self.data. This may have unexpected consequences. Consider setting a different nodata with \
-self.set_nodata()."
+                        f"For reprojection, dst_nodata must be set. Default chosen value {dst_nodata} exists in "
+                        f"self.data. This may have unexpected consequences. Consider setting a different nodata with "
+                        f"self.set_nodata()."
                     )
 
         from geoutils.misc import resampling_method_from_str
@@ -1722,10 +1720,7 @@ self.set_nodata()."
 
                 # Warning: this will overwrite the transform
                 if dst.transform != rio.transform.Affine(1, 0, 0, 0, 1, 0):
-                    warnings.warn(
-                        "A geotransform previously set is going \
-to be cleared due to the setting of GCPs."
-                    )
+                    warnings.warn("A geotransform previously set is going to be cleared due to the setting of GCPs.")
 
                 dst.gcps = (rio_gcps, gcps_crs)
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -813,13 +813,133 @@ Must be a Raster, np.ndarray or single number."
         return self._is_modified
 
     @property
-    def nodata(self) -> int | np.integer | float | np.floating | None:
+    def nodata(self) -> int | float | list[int] | list[float] | None:
         """
-        Get nodata value
+        Get nodata value.
 
-        :returns: nodata value
+        :returns: Nodata value
         """
         return self._nodata
+
+    @nodata.setter
+    def nodata(self, new_nodata: int | float | list[int] | list[float] | None) -> None:
+        """
+        Set .nodata and update .data by calling set_nodata() with default parameters.
+
+        :param new_nodata: New nodata to assign to this instance of Raster
+        """
+
+        self.set_nodata(nodata=new_nodata)
+
+    def set_nodata(
+        self, nodata: int | float | list[int] | list[float] | None, update_array: bool = True, update_mask: bool = True
+    ) -> None:
+        """
+        Set a new nodata value for each band. This updates the old nodata into a new nodata value in the metadata,
+        replaces the nodata values in the data of the masked array, and updates the mask of the masked array.
+
+        Careful! If the new nodata value already exists in the array, the related grid cells will be masked by default.
+
+        If the nodata value was not defined in the raster, run this function with a new nodata value corresponding to
+        the value of nodata that exists in the data array and is not yet accounted for. All those values will be masked.
+
+        If a nodata value was correctly defined in the raster, and you wish to change it to a new value, run
+        this function with that new value. All values having either the old or new nodata value will be masked.
+
+        If the nodata value was wrongly defined in the raster, and you wish to change it to a new value without
+        affecting data that might have the value of the old nodata, run this function with the update_array
+        argument as False. Only the values of the new nodata will be masked.
+
+        If you wish to set nodata value without updating the mask, run this function with the update_mask argument as
+        False.
+
+        :param nodata: Nodata values
+        :param update_array: Update the old nodata values into new nodata values in the data array
+        :param update_mask: Update the old mask into a new mask in the data mask
+        """
+        if nodata is not None and not isinstance(nodata, (list, int, float, np.integer, np.floating)):
+            raise ValueError("Type of ndv not understood, must be list or float or int")
+
+        elif (isinstance(nodata, (int, float, np.integer, np.floating))) and self.count > 1:
+            print("Several raster band: using nodata value for all bands")
+            nodata = [nodata] * self.count
+
+        elif isinstance(nodata, list) and self.count == 1:
+            print("Only one raster band: using first nodata value provided")
+            nodata = list(nodata)[0]
+
+        elif nodata is None:
+            self._nodata = None
+            return
+
+        # Check that ndv has same length as number of bands in self
+        if isinstance(nodata, list):
+            if len(nodata) != self.count:
+                raise ValueError(f"Length of ndv ({len(nodata)}) incompatible with number of bands ({self.count})")
+            # Check that ndv value is compatible with dtype
+            for k in range(len(nodata)):
+                if not rio.dtypes.can_cast_dtype(nodata[k], self.dtypes[k]):
+                    raise ValueError(f"ndv value {nodata[k]} incompatible with self.dtype {self.dtypes[k]}")
+        elif isinstance(nodata, (int, float, np.integer, np.floating)):
+            if not rio.dtypes.can_cast_dtype(nodata, self.dtypes[0]):
+                raise ValueError(f"ndv value {nodata} incompatible with self.dtype {self.dtypes[0]}")
+
+        # If we update mask or array, get the masked array
+        if update_array or update_mask:
+
+            # Extract the data variable, so the self.data property doesn't have to be called a bunch of times
+            imgdata = self.data
+
+            # Loop through the bands
+            for i, new_nodata in enumerate(nodata if isinstance(nodata, Iterable) else [nodata]):
+
+                # Get the index of old nodatas
+                index_old_nodatas = imgdata.data[i, :, :] == self.nodata
+
+                # Get the index of new nodatas
+                index_new_nodatas = imgdata.data[i, :, :] == new_nodata
+
+                if np.count_nonzero(index_new_nodatas) > 0:
+                    if update_array and update_mask:
+                        warnings.warn(
+                            message="New nodata value already found in the data array, the corresponding grid cells "
+                            "will be indistinguishable from that updated from the old nodata value, and will "
+                            "be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.",
+                            category=UserWarning,
+                        )
+                    elif update_array:
+                        warnings.warn(
+                            "New nodata value already found in the data array, the corresponding grid cells "
+                            "will be indistinguishable from that updated from the old nodata value. Use "
+                            "set_nodata(..., update_array=False) to avoid this behaviour.",
+                            category=UserWarning,
+                        )
+                    elif update_mask:
+                        warnings.warn(
+                            "New nodata value already found in the data array, the corresponding grid cells "
+                            "will be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.",
+                            category=UserWarning,
+                        )
+
+                if update_array:
+                    # Replace the nodata value in the Raster
+                    imgdata.data[i, index_old_nodatas] = new_nodata
+
+                if update_mask:
+                    # If a mask already exists and nodata is not updated in array, unmask the old nodata values
+                    # before masking the new ones
+                    if np.ma.is_masked(imgdata) and not update_array:
+                        # No way to unmask a value from the masked array, so we modify the mask directly
+                        imgdata.mask[i, index_old_nodatas] = False
+
+                    # Masking like this works from the masked array directly, whether a mask previously existed or not
+                    imgdata[i, index_new_nodatas] = np.ma.masked
+
+            # Update the data
+            self._data = imgdata
+
+        # Update the nodata value
+        self._nodata = nodata
 
     @property
     def data(self) -> np.ma.masked_array:
@@ -836,7 +956,7 @@ Must be a Raster, np.ndarray or single number."
     @data.setter
     def data(self, new_data: np.ndarray | np.ma.masked_array) -> None:
         """
-        Set the contents of .data.
+        Set the contents of .data and possibly update .nodata.
 
         The data setter behaviour is the following:
 
@@ -1479,116 +1599,6 @@ self.set_nodata()."
         dx, b, xmin, d, dy, ymax = list(self.transform)[:6]
 
         self.transform = rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)
-
-    @nodata.setter
-    def nodata(self, new_nodata):
-        """Setter for nodata which calls set_nodata() with default parameters."""
-
-        self.set_nodata(nodata=new_nodata)
-
-    def set_nodata(self, nodata: int | float | list[int] | list[float] | None,
-                   update_array: bool = True,
-                   update_mask: bool = True) -> None:
-        """
-        Set a new nodata value for each band. This updates the old nodata into a new nodata value in the metadata,
-        replaces the nodata values in the data of the masked array, and updates the mask of the masked array.
-
-        Careful! If the new nodata value already exists in the array, the related grid cells will be masked by default.
-
-        If the nodata value was not defined in the raster, run this function with a new nodata value corresponding to
-        the value of nodata that exists in the data array and is not yet accounted for. All those values will be masked.
-
-        If a nodata value was correctly defined in the raster, and you wish to change it to a new value, run
-        this function with that new value. All values having either the old or new nodata value will be masked.
-
-        If the nodata value was wrongly defined in the raster, and you wish to change it to a new value without
-        affecting data that might have the value of the old nodata, run this function with the update_array
-        argument as False. Only the values of the new nodata will be masked.
-
-        If you wish to set nodata value without updating the mask, run this function with the update_mask argment as
-        False.
-
-        :param nodata: Nodata values
-        :param update_array: Update the old nodata values into new nodata values in the data array
-        :param update_mask: Update the old mask into a new mask in the data mask
-        """
-        if nodata is not None and not isinstance(nodata, (list, int, float, np.integer, np.floating)):
-            raise ValueError("Type of ndv not understood, must be list or float or int")
-
-        elif (isinstance(nodata, (int, float, np.integer, np.floating))) and self.count > 1:
-            print("Several raster band: using nodata value for all bands")
-            nodata = [nodata] * self.count
-
-        elif isinstance(nodata, list) and self.count == 1:
-            print("Only one raster band: using first nodata value provided")
-            nodata = list(nodata)[0]
-
-        elif nodata is None:
-            self._nodata = None
-            return
-
-        # Check that ndv has same length as number of bands in self
-        if isinstance(nodata, list):
-            if len(nodata) != self.count:
-                raise ValueError(f"Length of ndv ({len(nodata)}) incompatible with number of bands ({self.count})")
-            # Check that ndv value is compatible with dtype
-            for k in range(len(nodata)):
-                if not rio.dtypes.can_cast_dtype(nodata[k], self.dtypes[k]):
-                    raise ValueError(f"ndv value {nodata[k]} incompatible with self.dtype {self.dtypes[k]}")
-        elif isinstance(nodata, (int, float, np.integer, np.floating)):
-            if not rio.dtypes.can_cast_dtype(nodata, self.dtypes[0]):
-                raise ValueError(f"ndv value {nodata} incompatible with self.dtype {self.dtypes[0]}")
-
-        # If we update mask or array, get the masked array
-        if update_array or update_mask:
-
-            # Extract the data variable, so the self.data property doesn't have to be called a bunch of times
-            imgdata = self.data
-
-            # Loop through the bands
-            for i, new_nodata in enumerate(nodata if isinstance(nodata, Iterable) else [nodata]):
-
-                # Get the index of old nodatas
-                index_old_nodatas = imgdata.data[i, :, :] == self.nodata
-
-                # Get the index of new nodatas
-                index_new_nodatas = imgdata.data[i, :, :] == new_nodata
-
-                if np.count_nonzero(index_new_nodatas) > 0:
-                    if update_array and update_mask:
-                        warnings.warn(message='New nodata value already found in the data array, the corresponding grid cells '
-                                      'will be indistinguishable from that updated from the old nodata value, and will '
-                                      'be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.',
-                                       category=UserWarning)
-                    elif update_array:
-                        warnings.warn('New nodata value already found in the data array, the corresponding grid cells '
-                                      'will be indistinguishable from that updated from the old nodata value. Use '
-                                      'set_nodata(..., update_array=False) to avoid this behaviour.',
-                                      category=UserWarning)
-                    elif update_mask:
-                        warnings.warn('New nodata value already found in the data array, the corresponding grid cells '
-                                      'will be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.',
-                                      category=UserWarning)
-
-                if update_array:
-                    # Replace the nodata value in the Raster
-                    imgdata.data[i, index_old_nodatas] = new_nodata
-
-                if update_mask:
-                    # If a mask already exists and nodata is not updated in array, unmask the old nodata values
-                    # before masking the new ones
-                    if np.ma.is_masked(imgdata) and not update_array:
-                        # No way to unmask a value from the masked array, so we modify the mask directly
-                        imgdata.mask[i, index_old_nodatas] = False
-
-                    # Masking like this works from the masked array directly, whether a mask previously existed or not
-                    imgdata[i, index_new_nodatas] = np.ma.masked
-
-            # Update the data
-            self._data = imgdata
-
-        # Update the nodata value
-        self._nodata = nodata
 
     def save(
         self,

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -935,7 +935,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
                 if update_mask:
                     # If a mask already exists, unmask the old nodata values before masking the new ones
-                    # Can be skipped if array is updated (nodata is transfered from old to new, this part of the mask
+                    # Can be skipped if array is updated (nodata is transferred from old to new, this part of the mask
                     # stays the same)
                     if np.ma.is_masked(imgdata) and (not update_array or nodata is None):
                         # No way to unmask a value from the masked array, so we modify the mask directly

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1464,7 +1464,7 @@ self.set_nodata()."
                    update_array: bool = True,
                    update_mask: bool = True) -> None:
         """
-        Set a new nodata values for each band. This updates the old nodata into a new nodata value in the metadata,
+        Set a new nodata value for each band. This updates the old nodata into a new nodata value in the metadata,
         replaces the nodata values in the data of the masked array, and updates the mask of the masked array.
 
         Careful! If the new nodata value already exists in the array, the related grid cells will be masked by default.
@@ -1478,6 +1478,9 @@ self.set_nodata()."
         If the nodata value was wrongly defined in the raster, and you wish to change it to a new value without
         affecting data that might have the value of the old nodata, run this function with the update_array
         argument as False. Only the values of the new nodata will be masked.
+
+        If you wish to set nodata value without updating the mask, run this function with the update_mask argment as
+        False.
 
         :param nodata: Nodata values
         :param update_array: Update the old nodata values into new nodata values in the data array

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -202,7 +202,7 @@ class Raster:
     to the attributes defined by rasterio.
 
     Attributes:
-        filename : str
+        filename_or_dataset : str
             The path/filename of the loaded, file, only set if a disk-based file is read in.
         data : np.array
             Loaded image. Dimensions correspond to (bands, height, width).
@@ -212,8 +212,6 @@ class Raster:
             The indexes of the opened dataset which correspond to the bands loaded into data.
         is_loaded : bool
             True if the image data have been loaded into this Raster.
-        ds : rio.io.DatasetReader
-            Link to underlying DatasetReader object.
 
         bounds
 
@@ -271,8 +269,6 @@ class Raster:
             Default list is set by geoutils.georaster.raster._default_rio_attrs, i.e.
             ['bounds', 'count', 'crs', 'driver', 'dtypes', 'height', 'indexes',
             'name', 'nodata', 'res', 'shape', 'transform', 'width'] - if no attrs are specified, these will be added.
-
-        :param as_memfile: open the dataset via a rio.MemoryFile.
 
         :return: A Raster object
         """
@@ -455,7 +451,7 @@ class Raster:
         """
         Load the data from disk.
 
-        :param **kwargs: Optional keyword arguments sent to '_load_rio()'
+        :param kwargs: Optional keyword arguments sent to '_load_rio()'
 
         :raises ValueError: If the data are already loaded.
         :raises AttributeError: If no 'filename' attribute exists.
@@ -1516,14 +1512,14 @@ self.set_nodata()."
         :param update_array: Update the old nodata values into new nodata values in the data array
         :param update_mask: Update the old mask into a new mask in the data mask
         """
-        if nodata is not None and not isinstance(nodata, (abc.Sequence, int, float, np.integer, np.floating)):
+        if nodata is not None and not isinstance(nodata, (list, int, float, np.integer, np.floating)):
             raise ValueError("Type of ndv not understood, must be list or float or int")
 
         elif (isinstance(nodata, (int, float, np.integer, np.floating))) and self.count > 1:
             print("Several raster band: using nodata value for all bands")
             nodata = [nodata] * self.count
 
-        elif isinstance(nodata, abc.Sequence) and self.count == 1:
+        elif isinstance(nodata, list) and self.count == 1:
             print("Only one raster band: using first nodata value provided")
             nodata = list(nodata)[0]
 
@@ -1532,7 +1528,7 @@ self.set_nodata()."
             return
 
         # Check that ndv has same length as number of bands in self
-        if isinstance(nodata, abc.Sequence):
+        if isinstance(nodata, list):
             if len(nodata) != self.count:
                 raise ValueError(f"Length of ndv ({len(nodata)}) incompatible with number of bands ({self.count})")
             # Check that ndv value is compatible with dtype

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1959,7 +1959,7 @@ to be cleared due to the setting of GCPs."
 
         :examples:
 
-            >>> self.value_at_coords(-48.125,67.8901,window=3)  # doctest: +SKIP
+            >>> self.value_at_coords(-48.125, 67.8901, window=3)  # doctest: +SKIP
             Returns mean of a 3*3 window:
                 v v v \
                 v c v  | = float(mean)

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -826,6 +826,13 @@ Must be a Raster, np.ndarray or single number."
         """
         Set .nodata and update .data by calling set_nodata() with default parameters.
 
+        By default, the old nodata values are updated into the new nodata in the data array .data.data, and the
+        mask .data.mask is updated to mask all new nodata values (i.e., the mask from old nodata stays and is extended
+        to potential new values of new nodata found in the array).
+
+        To set nodata for more complex cases (e.g., redefining a wrong nodata that has a valid value in the array),
+        call the function set_nodata() directly to set the arguments update_array and update_mask adequately.
+
         :param new_nodata: New nodata to assign to this instance of Raster
         """
 
@@ -855,7 +862,8 @@ Must be a Raster, np.ndarray or single number."
 
         :param nodata: Nodata values
         :param update_array: Update the old nodata values into new nodata values in the data array
-        :param update_mask: Update the old mask into a new mask in the data mask
+        :param update_mask: Update the old mask by unmasking old nodata and masking new nodata (if array is updated,
+            old nodata are changed to new nodata and thus stay masked)
         """
         if nodata is not None and not isinstance(nodata, (list, int, float, np.integer, np.floating)):
             raise ValueError("Type of nodata not understood, must be list or float or int")

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -912,19 +912,19 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                             warnings.warn(
                                 message="New nodata value found in the data array. Those will be masked, and the old "
                                 "nodata cells will now take the same value. Use set_nodata() with update_array=False "
-                                "and/or update_mask=False to change this behaviour",
+                                "and/or update_mask=False to change this behaviour.",
                                 category=UserWarning,
                             )
                         elif update_array:
                             warnings.warn(
                                 "New nodata value found in the data array. The old nodata cells will now take the same "
-                                "value. Use set_nodata() with update_array=False to change this behaviour",
+                                "value. Use set_nodata() with update_array=False to change this behaviour.",
                                 category=UserWarning,
                             )
                         elif update_mask:
                             warnings.warn(
                                 "New nodata value found in the data array. Those will be masked. Use set_nodata() "
-                                "with update_mask=False to change this behaviour",
+                                "with update_mask=False to change this behaviour.",
                                 category=UserWarning,
                             )
 

--- a/geoutils/geoviewer.py
+++ b/geoutils/geoviewer.py
@@ -151,7 +151,7 @@ def main() -> None:
         except ValueError:
             raise ValueError("ERROR: nodata must be a float, currently set to %s" % args.nodata)
 
-        img.set_ndv(nodata)
+        img.set_nodata(nodata)
 
     # Set default parameters #
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 import geoutils as gu
 from geoutils.georaster import Raster, RasterType
-from geoutils.georaster.raster import _default_ndv
+from geoutils.georaster.raster import _default_nodata
 from geoutils.misc import resampling_method_from_str
 
 
@@ -257,7 +257,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             raster.load()
             raster.is_loaded = False
 
-        ndv = reference_raster.nodata or gu.georaster.raster._default_ndv(reference_raster.data.dtype)
+        nodata = reference_raster.nodata or gu.georaster.raster._default_nodata(reference_raster.data.dtype)
         # Reproject to reference grid
         reprojected_raster = raster.reproject(
             dst_bounds=dst_bounds,
@@ -267,7 +267,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             dst_nodata=reference_raster.nodata,
             silent=True,
         )
-        reprojected_raster.set_nodata(ndv)
+        reprojected_raster.set_nodata(nodata)
 
         # Optionally calculate difference
         if diff:
@@ -287,7 +287,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
     if reference_raster.nodata is not None:
         nodata = reference_raster.nodata
     else:
-        nodata = _default_ndv(data.dtype)
+        nodata = _default_nodata(data.dtype)
     data[np.isnan(data)] = nodata
 
     # Save as gu.Raster - needed as some child classes may not accept multiple bands
@@ -374,7 +374,7 @@ If several algorithms are provided, each result is returned as a separate band.
     if reference_raster.nodata is not None:
         nodata = reference_raster.nodata
     else:
-        nodata = _default_ndv(merged_data.dtype)
+        nodata = _default_nodata(merged_data.dtype)
     merged_data[np.isnan(merged_data)] = nodata
 
     # Save as gu.Raster

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -174,7 +174,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             dst_nodata=reference_raster.nodata,
             silent=True,
         )
-        reprojected_raster.set_ndv(ndv)
+        reprojected_raster.set_nodata(ndv)
 
         # Optionally calculate difference
         if diff:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1273,6 +1273,18 @@ This may have unexpected consequences. Consider setting a different nodata with 
                 # Feed a floating numeric to an integer type
                 r.set_nodata(0.5)
 
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
+    def test_nodata_setter(self, example) -> None:
+        """Check that the nodata setter gives the same result as set_nodata with default parameters"""
+
+        r = gu.Raster(example)
+        r_copy = r.copy()
+
+        r.set_nodata(_default_ndv(r.dtypes[0]))
+        r_copy.nodata = _default_ndv(r.dtypes[0])
+
+        assert r == r_copy
+
 
     def test_default_ndv(self) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -911,12 +911,7 @@ self.set_nodata()."
         # If a nodata is set, make sure it is preserved
         r_nodata = r.copy()
 
-        # Exception with the Landsat example
-        if np.count_nonzero(r_nodata.data.data == 255) > 0:
-            with pytest.warns(UserWarning):
-                r_nodata.set_nodata(255)
-        else:
-            r_nodata.set_nodata(255)
+        r_nodata.set_nodata(0)
 
         r3 = r_nodata.reproject(r2)
         assert r_nodata.nodata == r3.nodata

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1279,9 +1279,9 @@ self.set_nodata()."
         with pytest.warns(
             UserWarning,
             match=re.escape(
-                "New nodata value already found in the data array, the corresponding grid cells "
-                "will be indistinguishable from that updated from the old nodata value, and will "
-                "be masked. Use set_nodata(..., update_array=False) to avoid this behaviour."
+                "New nodata value found in the data array. Those will be masked, and the old "
+                "nodata cells will now take the same value. Use set_nodata() with update_array=False "
+                "and/or update_mask=False to change this behaviour."
             ),
         ):
             r.set_nodata(nodata=new_nodata)
@@ -1322,8 +1322,8 @@ self.set_nodata()."
         with pytest.warns(
             UserWarning,
             match=re.escape(
-                "New nodata value already found in the data array, the corresponding grid cells "
-                "will be masked. Use set_nodata(..., update_array=False) to avoid this behaviour."
+                "New nodata value found in the data array. Those will be masked. Use set_nodata() "
+                "with update_mask=False to change this behaviour."
             ),
         ):
             r.set_nodata(nodata=new_nodata, update_array=False)
@@ -1350,9 +1350,8 @@ self.set_nodata()."
         with pytest.warns(
             UserWarning,
             match=re.escape(
-                "New nodata value already found in the data array, the corresponding grid cells "
-                "will be indistinguishable from that updated from the old nodata value. Use "
-                "set_nodata(..., update_array=False) to avoid this behaviour."
+                "New nodata value found in the data array. The old nodata cells will now take the same "
+                "value. Use set_nodata() with update_array=False to change this behaviour."
             ),
         ):
             r.set_nodata(nodata=new_nodata, update_mask=False)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -805,9 +805,11 @@ class TestRaster:
         # 2 - if no dst_nodata is set and default value conflicts with existing value, a warning is raised
         with pytest.warns(
             UserWarning,
-            match=re.escape(f"For reprojection, dst_nodata must be set. Default chosen value {_default_ndv(r_ndv.dtypes[0])} exists in \
+            match=re.escape(
+                f"For reprojection, dst_nodata must be set. Default chosen value {_default_ndv(r_ndv.dtypes[0])} exists in \
 self.data. This may have unexpected consequences. Consider setting a different nodata with \
-self.set_nodata()."),
+self.set_nodata()."
+            ),
         ):
             _ = r_ndv.reproject(dst_res=r_ndv.res[0] / 2, src_nodata=default_ndv)
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1415,14 +1415,15 @@ self.set_nodata()."
         if old_nodata is not None:
             index_old_nodata = r_copy.data.data == old_nodata
             # The arrays on this index should be booleans opposites
-            assert np.array_equal(np.ma.getmaskarray(r.data)[index_old_nodata],
-                           ~np.ma.getmaskarray(r_copy.data)[index_old_nodata])
+            assert np.array_equal(
+                np.ma.getmaskarray(r.data)[index_old_nodata], ~np.ma.getmaskarray(r_copy.data)[index_old_nodata]
+            )
         else:
             index_old_nodata = np.zeros(np.shape(r.data.data), dtype=bool)
         # The rest should be equal
-        assert np.array_equal(np.ma.getmaskarray(r.data)[~index_old_nodata],
-                              np.ma.getmaskarray(r_copy.data)[~index_old_nodata])
-
+        assert np.array_equal(
+            np.ma.getmaskarray(r.data)[~index_old_nodata], np.ma.getmaskarray(r_copy.data)[~index_old_nodata]
+        )
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_nodata_setter(self, example: str) -> None:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1407,6 +1407,28 @@ self.set_nodata()."
             with pytest.raises(ValueError, match=expected_message):
                 r.set_nodata(np.finfo("longdouble").min)
 
+        # -- Sixth, check the special behaviour with None
+        r = r_copy.copy()
+        r.set_nodata(None)
+
+        # The metadata should be updated to None
+        assert r.nodata is None
+
+        # The array cannot be updated, so it is left as is
+        assert np.array_equal(r.data.data, r_copy.data.data)
+        # However, the old nodata values are unset by default, let's check this
+        if old_nodata is not None:
+            index_old_nodata = r_copy.data.data == old_nodata
+            # The arrays on this index should be booleans opposites
+            assert np.array_equal(np.ma.getmaskarray(r.data)[index_old_nodata],
+                           ~np.ma.getmaskarray(r_copy.data)[index_old_nodata])
+        else:
+            index_old_nodata = np.zeros(np.shape(r.data.data), dtype=bool)
+        # The rest should be equal
+        assert np.array_equal(np.ma.getmaskarray(r.data)[~index_old_nodata],
+                              np.ma.getmaskarray(r_copy.data)[~index_old_nodata])
+
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_nodata_setter(self, example: str) -> None:
         """Check that the nodata setter gives the same result as set_nodata with default parameters"""

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -807,7 +807,6 @@ class TestRaster:
             UserWarning,
             match="For reprojection, dst_nodata must be set. Default chosen value .* exist in self.data. \
             This may have unexpected consequences. Consider setting a different nodata with self.set_nodata.",
-
         ):
             _ = r_ndv.reproject(dst_res=r_ndv.res[0] / 2, src_nodata=default_ndv)
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1264,7 +1264,7 @@ self.set_nodata()."
         # We call np.ma.getmaskarray to always compare a full boolean array
         assert np.array_equal(np.ma.getmaskarray(r.data), np.ma.getmaskarray(r_copy.data))
 
-        # Then, we repeat for a nodata that already existed, we artificially introduce the value on an unmasked pixel
+        # Then, we repeat for a nodata that already existed, we artificially modify the value on an unmasked pixel
         r = r_copy.copy()
         mask_pixel_artificially_set = np.zeros(np.shape(r.data), dtype=bool)
         mask_pixel_artificially_set[0, 0, 0] = True
@@ -1299,7 +1299,7 @@ self.set_nodata()."
         # The rest of the array is similarly unchanged
         index_unchanged = np.logical_and(~index_old_nodata, ~mask_pixel_artificially_set)
         assert np.array_equal(r.data.data[index_unchanged], r_copy.data.data[index_unchanged])
-        # But, this time, the mask is only unchanged outside of the pixel artificially has changed
+        # But, this time, the mask is only unchanged for the array excluding the pixel artificially modified
         assert np.array_equal(
             np.ma.getmaskarray(r.data)[~mask_pixel_artificially_set],
             np.ma.getmaskarray(r_copy.data)[~mask_pixel_artificially_set],
@@ -1403,6 +1403,10 @@ self.set_nodata()."
             with pytest.raises(ValueError, match=expected_message):
                 # Feed a floating numeric to an integer type
                 r.set_nodata(0.5)
+        elif "float" in r.dtypes[0]:
+                # Feed a floating value not supported by our example data
+            with pytest.raises(ValueError, match=expected_message):
+                r.set_nodata(np.finfo('longdouble').min)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_nodata_setter(self, example: str) -> None:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1130,20 +1130,20 @@ This may have unexpected consequences. Consider setting a different nodata with 
         old_nodata = r.nodata
         # We chose nodata that doesn't exist in the raster yet for both our examples (for uint8, the default value of
         # 255 exist, so we replace by 0)
-        new_nodata = (_default_ndv(r.dtypes[0]) if not r.dtypes[0]=='uint8' else 0)
+        new_nodata = _default_ndv(r.dtypes[0]) if not r.dtypes[0] == "uint8" else 0
 
         # -- First, test set_nodata() with default parameters --
 
         # Check that the new_nodata does not exist in the raster yet, and set it
         assert np.count_nonzero(r_copy.data.data == new_nodata) == 0
-        r.set_nodata(nodata = new_nodata)
+        r.set_nodata(nodata=new_nodata)
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
 
         # By default, the array should have been updated
         if old_nodata is not None:
-            index_old_nodata = (r_copy.data.data == old_nodata)
+            index_old_nodata = r_copy.data.data == old_nodata
             assert all(r.data.data[index_old_nodata] == new_nodata)
         else:
             index_old_nodata = np.zeros(np.shape(r.data), dtype=bool)
@@ -1165,31 +1165,40 @@ This may have unexpected consequences. Consider setting a different nodata with 
         # Check the value is valid in the masked array
         assert np.count_nonzero(r_copy.data == new_nodata) >= 0
         # A warning should be raised when setting the nodata
-        with pytest.warns(UserWarning, match=re.escape('New nodata value already found in the data array, the corresponding grid cells '
-                                      'will be indistinguishable from that updated from the old nodata value, and will '
-                                      'be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.')):
-            r.set_nodata(nodata = new_nodata)
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "New nodata value already found in the data array, the corresponding grid cells "
+                "will be indistinguishable from that updated from the old nodata value, and will "
+                "be masked. Use set_nodata(..., update_array=False) to avoid this behaviour."
+            ),
+        ):
+            r.set_nodata(nodata=new_nodata)
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
 
         # By default, the array should have been updated similarly for the old nodata
         if old_nodata is not None:
-            index_old_nodata = (r_copy.data.data == old_nodata)
+            index_old_nodata = r_copy.data.data == old_nodata
             assert all(r.data.data[index_old_nodata] == new_nodata)
         else:
             index_old_nodata = np.zeros(np.shape(r.data.data), dtype=bool)
 
         # The rest of the array is similarly unchanged
         index_unchanged = np.logical_and(~index_old_nodata, ~mask_pixel_artificially_set)
-        assert np.array_equal(r.data.data[index_unchanged] , r_copy.data.data[index_unchanged])
+        assert np.array_equal(r.data.data[index_unchanged], r_copy.data.data[index_unchanged])
         # But, this time, the mask is only unchanged outside of the pixel artificially has changed
-        assert np.array_equal(np.ma.getmaskarray(r.data)[~mask_pixel_artificially_set],
-                              np.ma.getmaskarray(r_copy.data)[~mask_pixel_artificially_set])
+        assert np.array_equal(
+            np.ma.getmaskarray(r.data)[~mask_pixel_artificially_set],
+            np.ma.getmaskarray(r_copy.data)[~mask_pixel_artificially_set],
+        )
 
         # More specifically, it has changed for that pixel
-        assert np.ma.getmaskarray(r.data)[mask_pixel_artificially_set] == \
-               ~np.ma.getmaskarray(r_copy.data)[mask_pixel_artificially_set]
+        assert (
+            np.ma.getmaskarray(r.data)[mask_pixel_artificially_set]
+            == ~np.ma.getmaskarray(r_copy.data)[mask_pixel_artificially_set]
+        )
 
         # -- Second, test set_nodata() with update_array=False --
         r = r_copy.copy()
@@ -1199,9 +1208,13 @@ This may have unexpected consequences. Consider setting a different nodata with 
         r.data[mask_pixel_artificially_set] = np.ma.masked
         r.data.mask[mask_pixel_artificially_set] = False
 
-        with pytest.warns(UserWarning, match=re.escape(
-                'New nodata value already found in the data array, the corresponding grid cells '
-                'will be masked. Use set_nodata(..., update_array=False) to avoid this behaviour.')):
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "New nodata value already found in the data array, the corresponding grid cells "
+                "will be masked. Use set_nodata(..., update_array=False) to avoid this behaviour."
+            ),
+        ):
             r.set_nodata(nodata=new_nodata, update_array=False)
 
         # The nodata value should have been set in the metadata
@@ -1210,8 +1223,10 @@ This may have unexpected consequences. Consider setting a different nodata with 
         # Now, the array should not have been updated, so the entire array should be unchanged except for the pixel
         assert np.array_equal(r.data.data[~mask_pixel_artificially_set], r_copy.data.data[~mask_pixel_artificially_set])
         # But the mask should have been updated on the pixel
-        assert np.ma.getmaskarray(r.data)[mask_pixel_artificially_set] == \
-               ~np.ma.getmaskarray(r_copy.data)[mask_pixel_artificially_set]
+        assert (
+            np.ma.getmaskarray(r.data)[mask_pixel_artificially_set]
+            == ~np.ma.getmaskarray(r_copy.data)[mask_pixel_artificially_set]
+        )
 
         # -- Third, test set_nodata() with update_mask=False --
         r = r_copy.copy()
@@ -1221,9 +1236,14 @@ This may have unexpected consequences. Consider setting a different nodata with 
         r.data[mask_pixel_artificially_set] = np.ma.masked
         r.data.mask[mask_pixel_artificially_set] = False
 
-        with pytest.warns(UserWarning, match=re.escape('New nodata value already found in the data array, the corresponding grid cells '
-                                      'will be indistinguishable from that updated from the old nodata value. Use '
-                                      'set_nodata(..., update_array=False) to avoid this behaviour.')):
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "New nodata value already found in the data array, the corresponding grid cells "
+                "will be indistinguishable from that updated from the old nodata value. Use "
+                "set_nodata(..., update_array=False) to avoid this behaviour."
+            ),
+        ):
             r.set_nodata(nodata=new_nodata, update_mask=False)
 
         # The nodata value should have been set in the metadata
@@ -1231,7 +1251,7 @@ This may have unexpected consequences. Consider setting a different nodata with 
 
         # The array should have been updated
         if old_nodata is not None:
-            index_old_nodata = (r_copy.data.data == old_nodata)
+            index_old_nodata = r_copy.data.data == old_nodata
             assert all(r.data.data[index_old_nodata] == new_nodata)
         else:
             index_old_nodata = np.zeros(np.shape(r.data.data), dtype=bool)
@@ -1264,17 +1284,17 @@ This may have unexpected consequences. Consider setting a different nodata with 
 
         # A ValueError if input nodata is neither a list, tuple, integer, floating
         with pytest.raises(ValueError, match="Type of ndv not understood, must be list or float or int"):
-            r.set_nodata(nodata='this_should_not_work')
+            r.set_nodata(nodata="this_should_not_work")  # type: ignore
 
         # A ValueError if nodata value is incompatible with dtype
         expected_message = r"ndv value .* incompatible with self.dtype .*"
-        if 'int' in r.dtypes[0]:
+        if "int" in r.dtypes[0]:
             with pytest.raises(ValueError, match=expected_message):
                 # Feed a floating numeric to an integer type
                 r.set_nodata(0.5)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
-    def test_nodata_setter(self, example) -> None:
+    def test_nodata_setter(self, example: str) -> None:
         """Check that the nodata setter gives the same result as set_nodata with default parameters"""
 
         r = gu.Raster(example)
@@ -1284,7 +1304,6 @@ This may have unexpected consequences. Consider setting a different nodata with 
         r_copy.nodata = _default_ndv(r.dtypes[0])
 
         assert r == r_copy
-
 
     def test_default_ndv(self) -> None:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1404,9 +1404,9 @@ self.set_nodata()."
                 # Feed a floating numeric to an integer type
                 r.set_nodata(0.5)
         elif "float" in r.dtypes[0]:
-                # Feed a floating value not supported by our example data
+            # Feed a floating value not supported by our example data
             with pytest.raises(ValueError, match=expected_message):
-                r.set_nodata(np.finfo('longdouble').min)
+                r.set_nodata(np.finfo("longdouble").min)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_nodata_setter(self, example: str) -> None:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -805,8 +805,9 @@ class TestRaster:
         # 2 - if no dst_nodata is set and default value conflicts with existing value, a warning is raised
         with pytest.warns(
             UserWarning,
-            match="For reprojection, dst_nodata must be set. Default chosen value .* exist in self.data. \
-            This may have unexpected consequences. Consider setting a different nodata with self.set_nodata.",
+            match=re.escape(f"For reprojection, dst_nodata must be set. Default chosen value {_default_ndv(r_ndv.dtypes[0])} exists in \
+self.data. This may have unexpected consequences. Consider setting a different nodata with \
+self.set_nodata()."),
         ):
             _ = r_ndv.reproject(dst_res=r_ndv.res[0] / 2, src_nodata=default_ndv)
 


### PR DESCRIPTION
This PR homogenizes the getter and setter functionality related to `nodata` and adds more exhaustive tests.

In details, this PR:

- Renames `set_ndv()` into `set_nodata()`, and all other occurences of "ndv" to "nodata", in order to match the `nodata` naming of `rasterio` and avoid the confusion of having "ndv" and "nodata" standing for the same thing,
- Corrects the behaviour of `update_array` in `set_nodata()`,
- Adds the `update_mask` argument to `set_nodata()`,
- Adds a `nodata.setter` method that calls `set_nodata()` with default parameters,
- Improves or adds tests for `set_nodata` and `nodata.setter`,
- Moves the nodata-related functions/class methods together in the file (among others, mypy request the getter/setter method to follow each other).

The old behaviour was:

- The argument `update_array` was `False` by default,
- The argument `update_array` would modify `.data.mask` by unmasking old nodata and masking new nodatas (i.e. a rare case where the nodata value was wrongly defined and needed to be changed while ignoring old nodatas).

The new behaviour is:
- Both arguments `update_array` and `update_mask` are `True` by default,
- The argument `update_array` updates the array `.data.data` by replacing old nodata values into new nodata values.
- The argument `update_mask` updates the mask `.data.mask` by unmasking old nodata and masking new nodatas (including the ones possibly updated by `update_array`, i.e. essentially keeping the mask on old nodata that have been updated, which makes the big difference with the previous behaviour).
- A `UserWarning` is raised if the new nodata value already exist as a valid value of the array (as it will be automatically masked).

This behaviour is also explained in the function description, with typical use-cases.

Resolves #286
