### PR TITLE
Fix `__eq__`, make arithmetic operations fully consistent with masked arrays, deprecate `gu.misc.array_equal` and bug fixes

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1193,10 +1193,11 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # In addition to running ufuncs, this function takes over arithmetic operations (__add__, __multiply__, etc...)
         # when the first input provided is a NumPy array and second input a Raster.
 
-        # The Raster ufuncs behave exactly as arithmetic operations (+, *, .) of NumPy that call np.ma  instead of np
-        # when available, which sometimes returns a full boolean mask even when there is no invalid value (true_divide
-        # and floor_divide). We find one exception, however, for modulo: np.ma.remainder is not called but np.remainder
-        # instead (an inconsistency in NumPy?!), so we mirror it below:
+        # The Raster ufuncs behave exactly as arithmetic operations (+, *, .) of NumPy masked array (call np.ma instead
+        # of np when available). There is an inconsistency when calling np.ma: operations return a full boolean mask
+        # even when there is no invalid value (true_divide and floor_divide).
+        # We find one exception, however, for modulo: np.ma.remainder is not called but np.remainder instead one the
+        # masked array is the second input (an inconsistency in NumPy!), so we mirror this exception below:
         if 'remainder' in ufunc.__name__:
             final_ufunc = getattr(ufunc, method)
         else:

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1538,7 +1538,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 (dst_transform == self.transform) or (dst_transform is None),
                 (dst_crs == self.crs) or (dst_crs is None),
                 (dst_size == self.shape[::-1]) or (dst_size is None),
-                (dst_res == self.res) or (dst_res == self.res[0] == self.res[1]) or (dst_res is None),
+                np.all(dst_res == self.res) or (dst_res == self.res[0] == self.res[1]) or (dst_res is None),
             ]
         ):
             if (dst_nodata == self.nodata) or (dst_nodata is None):

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -761,7 +761,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         return out_rst
 
     @overload
-    def astype(self, dtype: DTypeLike, inplace: Literal[False]) -> Raster:
+    def astype(self, dtype: DTypeLike, inplace: Literal[False] = False) -> Raster:
         ...
 
     @overload
@@ -1027,16 +1027,16 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # 1/ If the new data is not masked (either classic array or masked array with no mask, hence the use of
         # as array) and contains non-finite values such as NaNs, define a mask
         if not np.ma.is_masked(new_data) and np.count_nonzero(~np.isfinite(new_data)) > 0:
-            self._data = np.ma.masked_array(data=np.asarray(new_data),
-                                            mask=~np.isfinite(new_data.data),
-                                            fill_value=self.nodata)
+            self._data = np.ma.masked_array(
+                data=np.asarray(new_data), mask=~np.isfinite(new_data.data), fill_value=self.nodata
+            )
 
         # 2/ If the new data is masked but some non-finite values aren't masked, add them to the mask
         elif np.ma.is_masked(new_data) and np.count_nonzero(~np.isfinite(new_data.data[~new_data.mask])) > 0:
             self._data = np.ma.masked_array(
                 data=new_data.data,
                 mask=np.logical_or(~np.isfinite(new_data.data), new_data.mask),
-                fill_value=self.nodata
+                fill_value=self.nodata,
             )
 
         # 3/ If the new data is a Masked Array, we pass data.data and data.mask independently (passing directly the
@@ -1047,7 +1047,6 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # 4/ If the new data is classic ndarray
         else:
             self._data = np.ma.masked_array(data=new_data, fill_value=self.nodata)
-
 
     def set_mask(self, mask: np.ndarray) -> None:
         """
@@ -1198,7 +1197,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # even when there is no invalid value (true_divide and floor_divide).
         # We find one exception, however, for modulo: np.ma.remainder is not called but np.remainder instead one the
         # masked array is the second input (an inconsistency in NumPy!), so we mirror this exception below:
-        if 'remainder' in ufunc.__name__:
+        if "remainder" in ufunc.__name__:
             final_ufunc = getattr(ufunc, method)
         else:
             try:

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -8,6 +8,7 @@ import rasterio as rio
 
 import geoutils
 
+
 def deprecate(removal_version: str | None = None, details: str | None = None):  # type: ignore
     """
     Trigger a DeprecationWarning for the decorated function.

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -11,7 +11,7 @@ import geoutils
 from geoutils._typing import ArrayLike
 from geoutils.georaster import Raster, RasterType
 
-
+@deprecate('0.0.10', 'This function is deprecated and will be removed in 0.0.10, use np.ma.allequal for similar behaviour.')
 def array_equal(
     array1: RasterType | ArrayLike,
     array2: RasterType | ArrayLike,

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -4,98 +4,9 @@ from __future__ import annotations
 import functools
 import warnings
 
-import numpy as np
 import rasterio as rio
 
 import geoutils
-from geoutils._typing import ArrayLike
-from geoutils.georaster import Raster, RasterType
-
-
-def array_equal(
-    array1: RasterType | ArrayLike,
-    array2: RasterType | ArrayLike,
-    equal_nan: bool = True,
-    tolerance: float = 0.0,
-) -> bool:
-    """
-    Check if two arrays or Rasters are equal.
-
-    This function mirrors (and partly uses) 'np.array_equal' with these exceptions:
-        1. Different dtypes are okay as long as they are equal (e.g. '1 == 1.0' is True)
-        2. Rasters are directly comparable.
-        3. masked_array masks are respected.
-        4. A tolerance argument is added.
-        5. The function works with numpy<=1.18.
-
-    :param array1: The first array-like object to compare.
-    :param array2: The second array-like object to compare.
-    :param equal_nan: Whether to compare NaNs as equal ('NaN == NaN' is True)
-    :param tolerance: The maximum allowed summed difference between the arrays.
-
-    Examples:
-        Any object that can be parsed as an array can be compared.
-        >>> arr1 = [1, 2, 3]
-        >>> arr2 = np.array([1., 2., 3.])
-        >>> array_equal(arr1, arr2)
-        True
-
-        Nans are equal by default, but can be disabled with 'equal_nan=False'
-        >>> arr3 = np.array([1., 2., np.nan])
-        >>> array_equal(arr1, arr3)
-        False
-        >>> array_equal(arr3, arr3.copy())
-        True
-        >>> array_equal(arr3, arr3, equal_nan=False)
-        False
-
-        The equality tolerance can be set with the 'tolerance' argument (defaults to 0).
-        >>> arr4 = np.array([1., 2., 3.1])
-        >>> array_equal(arr1, arr4)
-        False
-        >>> array_equal(arr1, arr4, tolerance=0.2)
-        True
-
-        Masks in masked_arrays are respected.
-        >>> arr5 = np.ma.masked_array(arr1, [False, False, True])
-        >>> array_equal(arr1, arr5)
-        False
-        >>> array_equal(arr3, arr5)
-        True
-        >>> array_equal(arr3, arr5, equal_nan=False)
-        False
-    """
-    arrays: list[np.ndarray] = []
-    strings_compared = False  # Flag to handle string arrays instead of numeric
-
-    # Convert both inputs to numpy ndarrays
-    for arr in array1, array2:
-        if any(s in np.dtype(type(np.asanyarray(arr)[0])).name for s in ("<U", "str")):
-            strings_compared = True
-        if isinstance(arr, Raster):  # If a Raster subclass, take its data. I don't know why mypy complains here!
-            arr = arr.data  # type: ignore
-        if isinstance(arr, np.ma.masked_array):  # If a masked_array, replace the masked values with nans
-            if "float" not in np.dtype(arr.dtype).name:
-                arr = arr.astype(float)
-            arrays.append(arr.filled(np.nan))  # type: ignore
-        else:
-            arrays.append(np.asarray(arr))
-
-    if np.shape(arrays[0]) != np.shape(arrays[1]):
-        return False
-
-    if strings_compared:  # If they are strings, the tolerance/nan handling is irrelevant.
-        return bool(np.array_equal(arrays[0], arrays[1]))
-
-    diff = np.diff(arrays, axis=0)
-
-    if "float" in np.dtype(diff.dtype).name and np.any(~np.isfinite(diff)):
-        # Check that the nan-mask is equal. If it's not, or nans are not allowed at all, return False
-        if not equal_nan or not np.array_equal(np.isfinite(arrays[0]), np.isfinite(arrays[1])):
-            return False
-
-    return bool(np.nansum(np.abs(diff)) <= tolerance)
-
 
 def deprecate(removal_version: str | None = None, details: str | None = None):  # type: ignore
     """

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -11,6 +11,7 @@ import geoutils
 from geoutils._typing import ArrayLike
 from geoutils.georaster import Raster, RasterType
 
+
 def array_equal(
     array1: RasterType | ArrayLike,
     array2: RasterType | ArrayLike,

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -11,7 +11,6 @@ import geoutils
 from geoutils._typing import ArrayLike
 from geoutils.georaster import Raster, RasterType
 
-@deprecate('0.0.10', 'This function is deprecated and will be removed in 0.0.10, use np.ma.allequal for similar behaviour.')
 def array_equal(
     array1: RasterType | ArrayLike,
     array2: RasterType | ArrayLike,

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -717,7 +717,7 @@ class TestRaster:
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert r.shape[1] - (r_cropped.bounds.right - r_cropped.bounds.left) / r.res[0] == int(rand_float)
         assert np.array_equal(r.data[:, :, int(rand_float) :].data, r_cropped.data.data, equal_nan=True)
-        assert np.array_equal(r.data[:, :, int(rand_float):].mask, r_cropped.data.mask)
+        assert np.array_equal(r.data[:, :, int(rand_float) :].mask, r_cropped.data.mask)
 
         # right
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2] - rand_float * r.res[0], cropGeom[3]]
@@ -990,7 +990,6 @@ self.set_nodata()."
         for i in range(len(astype_funcs)):
             for j in range(len(astype_funcs)):
                 r.reproject(dst_res=(astype_funcs[i](20.5), astype_funcs[j](10.5)), dst_nodata=0)
-
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_intersection(self, example: list[str]) -> None:
@@ -1562,7 +1561,7 @@ self.set_nodata()."
             plt.close()
         assert True
 
-    @pytest.mark.parametrize('example', [landsat_b4_path, aster_dem_path]) # type: ignore
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_saving(self, example: str) -> None:
 
         # Read single band raster
@@ -1639,7 +1638,6 @@ self.set_nodata()."
             # Currently not covered by test image
             assert yy.min() == pytest.approx(img.bounds.top + hy)
             assert yy.max() == pytest.approx(img.bounds.bottom - hy)
-
 
     def test_value_at_coords2(self) -> None:
         """
@@ -1757,15 +1755,15 @@ self.set_nodata()."
         assert red != img
 
         # Test that the red band corresponds to the first band of the img
-        assert np.array_equal(red.data.data.squeeze().astype("float32"),
-                              img.data.data[0, :, :].astype("float32"),
-                              equal_nan=True)
+        assert np.array_equal(
+            red.data.data.squeeze().astype("float32"), img.data.data[0, :, :].astype("float32"), equal_nan=True
+        )
 
         # Modify the red band and make sure it propagates to the original img (it's not a copy)
         red.data += 1
-        assert np.array_equal(red.data.data.squeeze().astype("float32"),
-                              img.data.data[0, :, :].astype("float32"),
-                              equal_nan=True)
+        assert np.array_equal(
+            red.data.data.squeeze().astype("float32"), img.data.data[0, :, :].astype("float32"), equal_nan=True
+        )
 
         # Copy the bands instead of pointing to the same memory.
         red_c = img.split_bands(copy=True, subset=0)[0]

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -18,7 +18,6 @@ from pylint import epylint
 import geoutils as gu
 import geoutils.georaster as gr
 import geoutils.geovector as gv
-import geoutils.misc
 import geoutils.projtools as pt
 from geoutils import examples
 from geoutils.georaster.raster import _default_nodata, _default_rio_attrs
@@ -1594,20 +1593,21 @@ self.set_nodata()."
         assert np.ma.allequal(img.data, saved.data)
         assert saved.nodata == 0
 
-        # Test that mask is preserved
+        # Test that mask is preserved if nodata value is valid
         mask = img.data == np.min(img.data)
         img.set_mask(mask)
-        temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
-        img.save(temp_file.name)
-        saved = gr.Raster(temp_file.name)
-        assert np.array_equal(img.data.mask, saved.data.mask)
+        if img.nodata is not None:
+            temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
+            img.save(temp_file.name)
+            saved = gr.Raster(temp_file.name)
+            assert np.array_equal(img.data.mask, saved.data.mask)
 
-        # Test that a warning is raised if nodata is not set
+        # Test that a warning is raised if nodata is not set and a mask exists (defined above)
         if img.nodata is None:
             with pytest.warns(UserWarning):
                 img.save(TemporaryFile())
 
-        # Clean up teporary folder - fails on Windows
+        # Clean up temporary folder - fails on Windows
         try:
             temp_dir.cleanup()
         except (NotADirectoryError, PermissionError):

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -985,6 +985,15 @@ self.set_nodata()."
         r4 = r.reproject(dst_crs=out_crs, dst_nodata=0)
         assert gu.misc.array_equal(r3.data, r4.data)
 
+        # Test that reproject does not fail with resolution as np.integer or np.float types, single value or tuple
+        astype_funcs = [int, np.int32, float, np.float64]
+        for astype_func in astype_funcs:
+            r.reproject(dst_res=astype_func(20.5), dst_nodata=0)
+        for i in range(len(astype_funcs)):
+            for j in range(len(astype_funcs)):
+                r.reproject(dst_res=(astype_funcs[i](20.5), astype_funcs[j](10.5)), dst_nodata=0)
+
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_intersection(self, example: list[str]) -> None:
         """Check the behaviour of the intersection function"""

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -59,21 +59,7 @@ class TestRaster:
         r4 = gr.Raster(memfile)
         assert isinstance(r4, gr.Raster)
 
-        assert np.logical_and.reduce(
-            (
-                geoutils.misc.array_equal(r.data, r2.data, equal_nan=True),
-                geoutils.misc.array_equal(r2.data, r3.data, equal_nan=True),
-                geoutils.misc.array_equal(r3.data, r4.data, equal_nan=True),
-            )
-        )
-
-        assert np.logical_and.reduce(
-            (
-                np.all(r.data.mask == r2.data.mask),
-                np.all(r2.data.mask == r3.data.mask),
-                np.all(r3.data.mask == r4.data.mask),
-            )
-        )
+        assert r == r2 == r3 == r4
 
         # The data will not be copied, immutable objects will
         r.data[0, 0, 0] += 5
@@ -137,9 +123,9 @@ class TestRaster:
         assert r.height == 655
         assert r.shape == (r.height, r.width)
         assert r.count == 1
-        assert geoutils.misc.array_equal(r.dtypes, ["uint8"])
+        assert np.array_equal(r.dtypes, ["uint8"])
         assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
-        assert geoutils.misc.array_equal(r.res, [30.0, 30.0])
+        assert np.array_equal(r.res, [30.0, 30.0])
         assert r.bounds == rio.coords.BoundingBox(left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0)
         assert r.crs == rio.crs.CRS.from_epsg(32645)
         assert not r.is_loaded
@@ -152,9 +138,9 @@ class TestRaster:
         assert r2.height == 618
         assert r2.shape == (r2.height, r2.width)
         assert r2.count == 1
-        assert geoutils.misc.array_equal(r2.dtypes, ["float32"])
+        assert np.array_equal(r2.dtypes, ["float32"])
         assert r2.transform == rio.transform.Affine(30.0, 0.0, 627175.0, 0.0, -30.0, 4852085.0)
-        assert geoutils.misc.array_equal(r2.res, [30.0, 30.0])
+        assert np.array_equal(r2.res, [30.0, 30.0])
         assert r2.bounds == rio.coords.BoundingBox(left=627175.0, bottom=4833545.0, right=643345.0, top=4852085.0)
         assert r2.crs == rio.crs.CRS.from_epsg(32718)
         assert not r2.is_loaded
@@ -174,15 +160,15 @@ class TestRaster:
         # Test 4 - multiple bands, load all bands
         r = gr.Raster(self.landsat_rgb_path, load_data=True)
         assert r.count == 3
-        assert geoutils.misc.array_equal(r.indexes, [1, 2, 3])
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 3
-        assert geoutils.misc.array_equal(r.bands, [1, 2, 3])
+        assert np.array_equal(r.bands, [1, 2, 3])
         assert r.data.shape == (r.count, r.height, r.width)
 
         # Test 5 - multiple bands, load one band only
         r = gr.Raster(self.landsat_rgb_path, load_data=True, bands=1)
         assert r.count == 3
-        assert geoutils.misc.array_equal(r.indexes, [1, 2, 3])
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 1
         # assert r.bands == (1)
         assert r.data.shape == (r.nbands, r.height, r.width)
@@ -190,9 +176,9 @@ class TestRaster:
         # Test 6 - multiple bands, load a list of bands
         r = gr.Raster(self.landsat_rgb_path, load_data=True, bands=[2, 3])
         assert r.count == 3
-        assert geoutils.misc.array_equal(r.indexes, [1, 2, 3])
+        assert np.array_equal(r.indexes, [1, 2, 3])
         assert r.nbands == 2
-        assert geoutils.misc.array_equal(r.bands, (2, 3))
+        assert np.array_equal(r.bands, (2, 3))
         assert r.data.shape == (r.nbands, r.height, r.width)
 
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
@@ -451,17 +437,17 @@ class TestRaster:
         # Test negation
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test addition
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test subtraction
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtypes, ["uint8"])
 
         # Test with dtype Float32
         r1 = gr.Raster.from_array(
@@ -469,15 +455,15 @@ class TestRaster:
         )
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert geoutils.misc.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtypes, ["float32"])
 
         # Check that errors are properly raised
         # different shapes
@@ -557,14 +543,14 @@ class TestRaster:
             assert r.__getattribute__(attr) == r2.__getattribute__(attr)
 
         # Check data array
-        assert geoutils.misc.array_equal(r.data, r2.data, equal_nan=True)
+        assert np.array_equal(r.data, r2.data, equal_nan=True)
 
         # Check dataset_mask array
-        assert np.all(r.data.mask == r2.data.mask)
+        assert np.array_equal(r.data.mask, r2.data.mask)
 
         # -- Third test: if r.data is modified, it does not affect r2.data --
         r.data += 5
-        assert not geoutils.misc.array_equal(r.data, r2.data, equal_nan=True)
+        assert not np.array_equal(r.data.data, r2.data.data, equal_nan=True)
 
         # -- Fourth test: check the new array parameter works with either ndarray filled with NaNs, or masked arrays --
 
@@ -670,8 +656,7 @@ class TestRaster:
         # Test with same bounds -> should be the same #
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
-        assert r_cropped.bounds == r.bounds
-        assert gu.misc.array_equal(r.data, r_cropped.data)
+        assert r_cropped == r
 
         # - Test cropping each side by a random integer of pixels - #
         rand_int = np.random.randint(1, min(r.shape) - 1)
@@ -680,25 +665,29 @@ class TestRaster:
         cropGeom2 = [cropGeom[0] + rand_int * r.res[0], cropGeom[1], cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert list(r_cropped.bounds) == cropGeom2
-        assert gu.misc.array_equal(r.data[:, :, rand_int:], r_cropped.data)
+        assert np.array_equal(r.data[:, :, rand_int:].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, :, rand_int:].mask, r_cropped.data.mask)
 
         # right
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2] - rand_int * r.res[0], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert list(r_cropped.bounds) == cropGeom2
-        assert gu.misc.array_equal(r.data[:, :, :-rand_int], r_cropped.data)
+        assert np.array_equal(r.data[:, :, :-rand_int].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, :, :-rand_int].mask, r_cropped.data.mask)
 
         # bottom
         cropGeom2 = [cropGeom[0], cropGeom[1] + rand_int * abs(r.res[1]), cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert list(r_cropped.bounds) == cropGeom2
-        assert gu.misc.array_equal(r.data[:, :-rand_int, :], r_cropped.data)
+        assert np.array_equal(r.data[:, :-rand_int, :].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, :-rand_int, :].mask, r_cropped.data.mask)
 
         # top
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2], cropGeom[3] - rand_int * abs(r.res[1])]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert list(r_cropped.bounds) == cropGeom2
-        assert gu.misc.array_equal(r.data[:, rand_int:, :], r_cropped.data)
+        assert np.array_equal(r.data[:, rand_int:, :].data, r_cropped.data, equal_nan=True)
+        assert np.array_equal(r.data[:, rand_int:, :].mask, r_cropped.data.mask)
 
         # same but tuple
         cropGeom3: tuple[float, float, float, float] = (
@@ -709,18 +698,17 @@ class TestRaster:
         )
         r_cropped = r.crop(cropGeom3, inplace=False)
         assert list(r_cropped.bounds) == list(cropGeom3)
-        assert gu.misc.array_equal(r.data[:, rand_int:, :], r_cropped.data)
+        assert np.array_equal(r.data[:, rand_int:, :].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, rand_int:, :].mask, r_cropped.data.mask)
 
         # -- Test with CropGeom being a Raster -- #
         r_cropped2 = r.crop(r_cropped, inplace=False)
-        assert r_cropped2.bounds == r_cropped.bounds
-        assert gu.misc.array_equal(r_cropped2.data, r_cropped)
+        assert r_cropped2 == r_cropped
 
         # -- Test with inplace=True (Default) -- #
         r_copy = r.copy()
         r_copy.crop(r_cropped)
-        assert r_copy.bounds == r_cropped.bounds
-        assert gu.misc.array_equal(r_copy.data, r_cropped)
+        assert r_copy == r_cropped
 
         # - Test cropping each side with a non integer pixel, mode='match_pixel' - #
         rand_float = np.random.randint(1, min(r.shape) - 1) + 0.25
@@ -729,25 +717,29 @@ class TestRaster:
         cropGeom2 = [cropGeom[0] + rand_float * r.res[0], cropGeom[1], cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert r.shape[1] - (r_cropped.bounds.right - r_cropped.bounds.left) / r.res[0] == int(rand_float)
-        assert gu.misc.array_equal(r.data[:, :, int(rand_float) :], r_cropped.data)
+        assert np.array_equal(r.data[:, :, int(rand_float) :].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, :, int(rand_float):].mask, r_cropped.data.mask)
 
         # right
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2] - rand_float * r.res[0], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert r.shape[1] - (r_cropped.bounds.right - r_cropped.bounds.left) / r.res[0] == int(rand_float)
-        assert gu.misc.array_equal(r.data[:, :, : -int(rand_float)], r_cropped.data)
+        assert np.array_equal(r.data[:, :, : -int(rand_float)].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, :, : -int(rand_float)].mask, r_cropped.data.mask)
 
         # bottom
         cropGeom2 = [cropGeom[0], cropGeom[1] + rand_float * abs(r.res[1]), cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert r.shape[0] - (r_cropped.bounds.top - r_cropped.bounds.bottom) / r.res[1] == int(rand_float)
-        assert gu.misc.array_equal(r.data[:, : -int(rand_float), :], r_cropped.data)
+        assert np.array_equal(r.data[:, : -int(rand_float), :].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, : -int(rand_float), :].mask, r_cropped.data.mask)
 
         # top
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2], cropGeom[3] - rand_float * abs(r.res[1])]
         r_cropped = r.crop(cropGeom2, inplace=False)
         assert r.shape[0] - (r_cropped.bounds.top - r_cropped.bounds.bottom) / r.res[1] == int(rand_float)
-        assert gu.misc.array_equal(r.data[:, int(rand_float) :, :], r_cropped.data)
+        assert np.array_equal(r.data[:, int(rand_float) :, :].data, r_cropped.data.data, equal_nan=True)
+        assert np.array_equal(r.data[:, int(rand_float) :, :].mask, r_cropped.data.mask)
 
         # -- Test with mode='match_extent' -- #
         # Test all sides at once, with rand_float less than half the smallest extent
@@ -767,8 +759,7 @@ class TestRaster:
         )
 
         r_cropped2 = r.crop(r_cropped, inplace=False, mode="match_extent")
-        assert r_cropped2.bounds == r_cropped.bounds
-        assert gu.misc.array_equal(r_cropped2.data, r_cropped.data)
+        assert r_cropped2 == r_cropped
 
         # -- Test with CropGeom being a Vector -- #
         outlines = gu.Vector(outlines_path)
@@ -854,13 +845,15 @@ self.set_nodata()."
         assert r.shape != r2.shape
         assert r.res != r2.res
 
-        # Test reprojecting with dst_ref=r2b (i.e. crop) -> output should have same shape, bounds and data
+        # Test reprojecting with dst_ref=r2b (i.e. crop) -> output should have same shape, bounds and data, i.e. be the
+        # same object
         r3 = r.reproject(r2b)
         assert r3.bounds == r2b.bounds
         assert r3.shape == r2b.shape
         assert r3.bounds == r2b.bounds
         assert r3.transform == r2b.transform
-        assert gu.misc.array_equal(r3.data, r2b.data)
+        assert np.array_equal(r3.data.data, r2b.data.data, equal_nan=True)
+        assert np.array_equal(r3.data.mask, r2b.data.mask)
 
         if DO_PLOT:
             fig1, ax1 = plt.subplots()
@@ -881,7 +874,7 @@ self.set_nodata()."
         assert r3.shape == r2.shape
         assert r3.bounds == r2.bounds
         assert r3.transform == r2.transform
-        assert not gu.misc.array_equal(r3.data, r2.data)
+        assert not np.array_equal(r3.data.data, r2.data.data, equal_nan=True)
 
         if DO_PLOT:
             fig1, ax1 = plt.subplots()
@@ -989,7 +982,7 @@ self.set_nodata()."
         r3 = r.reproject(dst_crs=out_crs, dst_nodata=0)
         r = gr.Raster(example, load_data=False)
         r4 = r.reproject(dst_crs=out_crs, dst_nodata=0)
-        assert gu.misc.array_equal(r3.data, r4.data)
+        assert r3 == r4
 
         # Test that reproject does not fail with resolution as np.integer or np.float types, single value or tuple
         astype_funcs = [int, np.int32, float, np.float64]
@@ -1170,7 +1163,7 @@ self.set_nodata()."
         # First order interpolation
         rpts = r.interp_points(pts, order=1, area_or_point="Area")
         # The values interpolated should be equal
-        assert geoutils.misc.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
+        assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
         # Test there is no failure with random coordinates (edge effects, etc)
         xrand = np.random.uniform(low=xmin, high=xmax, size=(1000,))
@@ -1203,7 +1196,7 @@ self.set_nodata()."
 
         rpts = r.interp_points(pts, order=1)
 
-        assert geoutils.misc.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
+        assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
         # Test for an invidiual point (shape can be tricky at 1 dimension)
         x = 493120.0
@@ -1570,10 +1563,11 @@ self.set_nodata()."
             plt.close()
         assert True
 
-    def test_saving(self) -> None:
+    @pytest.mark.parametrize('example', [landsat_b4_path, aster_dem_path]) # type: ignore
+    def test_saving(self, example: str) -> None:
 
         # Read single band raster
-        img = gr.Raster(self.landsat_b4_path)
+        img = gr.Raster(example)
 
         # Temporary folder
         temp_dir = tempfile.TemporaryDirectory()
@@ -1582,7 +1576,7 @@ self.set_nodata()."
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
         img.save(temp_file.name)
         saved = gr.Raster(temp_file.name)
-        assert gu.misc.array_equal(img.data, saved.data)
+        assert img == saved
 
         # Test additional options
         co_opts = {"TILED": "YES", "COMPRESS": "LZW"}
@@ -1590,27 +1584,28 @@ self.set_nodata()."
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
         img.save(temp_file.name, co_opts=co_opts, metadata=metadata)
         saved = gr.Raster(temp_file.name)
-        assert gu.misc.array_equal(img.data, saved.data)
+        assert img == saved
         assert saved.tags["Type"] == "test"
 
         # Test that nodata value is enforced when masking - since value 0 is not used, data should be unchanged
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
         img.save(temp_file.name, nodata=0)
         saved = gr.Raster(temp_file.name)
-        assert gu.misc.array_equal(img.data, saved.data)
+        assert np.ma.allequal(img.data, saved.data)
         assert saved.nodata == 0
 
         # Test that mask is preserved
         mask = img.data == np.min(img.data)
         img.set_mask(mask)
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
-        img.save(temp_file.name, nodata=0)
+        img.save(temp_file.name)
         saved = gr.Raster(temp_file.name)
-        assert gu.misc.array_equal(img.data, saved.data)
+        assert np.array_equal(img.data.mask, saved.data.mask)
 
         # Test that a warning is raised if nodata is not set
-        with pytest.warns(UserWarning):
-            img.save(TemporaryFile())
+        if img.nodata is None:
+            with pytest.warns(UserWarning):
+                img.save(TemporaryFile())
 
         # Clean up teporary folder - fails on Windows
         try:
@@ -1645,22 +1640,6 @@ self.set_nodata()."
             assert yy.min() == pytest.approx(img.bounds.top + hy)
             assert yy.max() == pytest.approx(img.bounds.bottom - hy)
 
-    def test_eq(self) -> None:
-
-        img = gr.Raster(self.landsat_b4_path)
-        img2 = gr.Raster(self.landsat_b4_path)
-
-        assert geoutils.misc.array_equal(img.data, img2.data, equal_nan=True)
-        assert img.transform == img2.transform
-        assert img.crs == img2.crs
-        assert img.nodata == img2.nodata
-
-        assert img.__eq__(img2)
-        assert img == img2
-
-        img2.data += 1
-
-        assert img != img2
 
     def test_value_at_coords2(self) -> None:
         """
@@ -1694,7 +1673,7 @@ self.set_nodata()."
         # Test that changes to data are taken into account
         bias = 5
         out_img = gr.Raster.from_array(img.data + bias, img.transform, img.crs, nodata=img.nodata)
-        assert geoutils.misc.array_equal(out_img.data, img.data + bias)
+        assert np.ma.allequal(out_img.data, img.data + bias)
 
         # Test that nodata is properly taken into account
         out_img = gr.Raster.from_array(img.data + 5, img.transform, img.crs, nodata=0)
@@ -1764,9 +1743,12 @@ self.set_nodata()."
         blue2, green2 = img.split_bands(copy=False, subset=[2, 1])
 
         # Check that the subset functionality works as expected.
-        assert geoutils.misc.array_equal(red.data.astype("float32"), red2.data.astype("float32"))
-        assert geoutils.misc.array_equal(blue.data.astype("float32"), blue2.data.astype("float32"))
-        assert geoutils.misc.array_equal(green.data.astype("float32"), green2.data.astype("float32"))
+        assert np.array_equal(red.data.data.astype("float32"), red2.data.data.astype("float32"), equal_nan=True)
+        assert np.array_equal(red.data.mask, red2.data.mask)
+        assert np.array_equal(blue.data.data.astype("float32"), blue2.data.data.astype("float32"), equal_nan=True)
+        assert np.array_equal(blue.data.mask, blue2.data.mask)
+        assert np.array_equal(green.data.data.astype("float32"), green2.data.data.astype("float32"), equal_nan=True)
+        assert np.array_equal(green.data.mask, green2.data.mask)
 
         # Check that the red channel and the rgb data shares memory
         assert np.shares_memory(red.data, img.data)
@@ -1775,11 +1757,15 @@ self.set_nodata()."
         assert red != img
 
         # Test that the red band corresponds to the first band of the img
-        assert geoutils.misc.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+        assert np.array_equal(red.data.data.squeeze().astype("float32"),
+                              img.data.data[0, :, :].astype("float32"),
+                              equal_nan=True)
 
         # Modify the red band and make sure it propagates to the original img (it's not a copy)
         red.data += 1
-        assert geoutils.misc.array_equal(red.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32"))
+        assert np.array_equal(red.data.data.squeeze().astype("float32"),
+                              img.data.data[0, :, :].astype("float32"),
+                              equal_nan=True)
 
         # Copy the bands instead of pointing to the same memory.
         red_c = img.split_bands(copy=True, subset=0)[0]
@@ -1789,8 +1775,8 @@ self.set_nodata()."
 
         # Modify the copy, and make sure the original data is not modified.
         red_c.data += 1
-        assert not geoutils.misc.array_equal(
-            red_c.data.squeeze().astype("float32"), img.data[0, :, :].astype("float32")
+        assert not np.array_equal(
+            red_c.data.data.squeeze().astype("float32"), img.data.data[0, :, :].astype("float32"), equal_nan=True
         )
 
     def test_resampling_str(self) -> None:
@@ -1845,7 +1831,7 @@ self.set_nodata()."
         # Validate that 25 points were sampled (equating to img1.height * img1.width) with x, y, and band0 values.
         assert isinstance(points, np.ndarray)
         assert points.shape == (25, 3)
-        assert geoutils.misc.array_equal(np.asarray(points[:, 0]), np.tile(np.linspace(0.5, 4.5, 5), 5))
+        assert np.array_equal(np.asarray(points[:, 0]), np.tile(np.linspace(0.5, 4.5, 5), 5))
 
         assert img1.to_points(0.2).shape == (5, 3)
 
@@ -1858,7 +1844,7 @@ self.set_nodata()."
 
         points_frame = img2.to_points(10, as_frame=True)
 
-        assert geoutils.misc.array_equal(points_frame.columns, ["b1", "b2", "b3", "geometry"])
+        assert np.array_equal(points_frame.columns, ["b1", "b2", "b3", "geometry"])
         assert points_frame.crs == img2.crs
 
 
@@ -1879,11 +1865,8 @@ def test_numpy_functions(dtype: str) -> None:
     assert np.median(raster) == 12.0
     assert np.mean(raster) == 12.0
 
-    # Check that rasters don't  become arrays when using simple arithmetic.
+    # Check that rasters don't become arrays when using simple arithmetic.
     assert isinstance(raster + 1, gr.Raster)
-
-    # Test that array_equal works
-    assert geoutils.misc.array_equal(array, raster)
 
     # Test the data setter method by creating a new array
     raster.data = array + 2

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -42,16 +42,7 @@ class TestSatelliteImage:
         img3 = si.SatelliteImage(r)
         assert isinstance(img3, si.SatelliteImage)
 
-        assert np.logical_and.reduce(
-            (
-                geoutils.misc.array_equal(img.data, img2.data, equal_nan=True),
-                geoutils.misc.array_equal(img2.data, img3.data, equal_nan=True),
-            )
-        )
-
-        assert np.logical_and.reduce(
-            (np.all(img.data.mask == img2.data.mask), np.all(img2.data.mask == img3.data.mask))
-        )
+        assert img == img2 == img3
 
     @pytest.mark.parametrize("example", [landsat_b4, aster_dem])  # type: ignore
     def test_silent(self, example: str) -> None:
@@ -149,14 +140,14 @@ class TestSatelliteImage:
             assert r.__getattribute__(attr) == r2.__getattribute__(attr)
 
         # Check data array
-        assert geoutils.misc.array_equal(r.data, r2.data, equal_nan=True)
+        assert np.array_equal(r.data, r2.data, equal_nan=True)
 
         # Check dataset_mask array
-        assert np.all(r.data.mask == r2.data.mask)
+        assert np.array_equal(r.data.mask, r2.data.mask)
 
         # Check that if r.data is modified, it does not affect r2.data
         r.data += 5
-        assert not geoutils.misc.array_equal(r.data, r2.data, equal_nan=True)
+        assert not np.array_equal(r.data, r2.data, equal_nan=True)
 
     def test_filename_parsing(self) -> None:
 


### PR DESCRIPTION
## Summary

This PR modifies the behaviour of `__eq__` to have a rigorous equality check between Raster objects.

As a result, a certain number of test failed linked to arithmetic operations, and thus a correction was made to `_overloading_check` and `data.setter` to avoid inconsistencies that were created in the masked arrays. Then, tests relying on `__eq__` were updated to be more robust. 

Additionally, the custom function `gu.misc.array_equal` initially introduced for back-compatibility and for which the behaviour was not clearly defined to all (it only checked valid data, but did not compare unmasked `data`, the `mask` themselves, or the `dtypes` as some of us expected) is now deprecated as similar functionalities exist in NumPy: `np.array_equal(equal_nan=True)`, or `np.ma.allequal`, or in our new `__eq__`.

Finally, a small reprojection bug was fixed, a couple tests that did not work after the `__eq__` update, and the type linting of `Raster.astype` that was missing a default parameter for one of its `Literal`.

_Note: as the `array_equal` function lives in the same module as `deprecate`, I could not use the `deprecate` decorator (could only made it work from another module), so the function is removed entirely. I think this is fine as it is a "developer" function we use exclusively for tests, and not a "user" function._

## Details

In details, this PR:

- [x] Makes `__eq__` compute an exact Raster equality, now considering masked values in `data.data`, the mask `data.mask`, the fill_value `data.fill_value` and the dtype `data.dtype` (called by to get the Raster dtype, so always matches);
- [x] Fixes inconsistent arithmetic operation behaviour due to a forcing of `dtype` or an encapsulation by `np.ma.masked_array` in `_overloading_check` and `data.setter` to ensure the masked array operations with `Raster` always behave exactly like they would for arithmetic operation of masked arrays (the issue #299 was triggered by passing a masked array as `data=`, i.e. first argument, into `np.ma.masked_array`. This happened in both `data.setter` and `_overloading_check` in some cases);
- [x] Fixes behaviour of `__array_ufunc__` (which takes over reverse arithmetic functions when array is passed first) because of exceptions in a few arithmetic functions (found a NumPy inconsistency!),
- [x] Improves tests throughout `test_georaster.py` and `test_satimg.py` when checking raster or array equality: use `__eq__` when relevant instead of array comparison, use double `np.array_equal` when both raw data and mask should be the same, or  use`np.ma.allequal` when valid data should be the same,
- [x] Removes usage of `gu.misc.array_equal` that is now equivalent to `np.ma.allequal` but no needed for backwards compatibility (see #290).
- [x] Fixes reprojection issue and add tests (see #312).

Resolves #312
Resolves #299
Resolves #290