### PR TITLE
Upgrade `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
         - repo: https://github.com/pre-commit/pre-commit-hooks
-          rev: v4.0.1
+          rev: v4.3.0
           hooks:
                 - id: check-yaml
                 - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
                 - id: check-merge-conflict
         # Fix common spelling mistakes
         - repo: https://github.com/codespell-project/codespell
-          rev: v2.0.0
+          rev: v2.2.1
           hooks:
                 - id: codespell
                   args: [--ignore-words-list=alos, --ignore-regex=\bnin\b]
@@ -18,16 +18,17 @@ repos:
 
         # Replace relative imports (e.g. 'from . import georaster' -> 'from geoutils import georaster')
         - repo: https://github.com/MarcoGorelli/absolufy-imports
-          rev: v0.3.0
+          rev: v0.3.1
           hooks:
                 - id: absolufy-imports
 
         # Format the code aggressively using black
         - repo: https://github.com/psf/black
-          rev: 22.3.0
+          rev: 22.10.0
           hooks:
                   - id: black
                     args: [--line-length=120]
+
         # Lint the code using flake8
         - repo: https://gitlab.com/pycqa/flake8
           rev: 3.9.2
@@ -43,7 +44,7 @@ repos:
                   files: ^(geoutils|tests)
         # Lint the code using mypy
         - repo: https://github.com/pre-commit/mirrors-mypy
-          rev: v0.910
+          rev: v0.982
           hooks:
                 - id: mypy
                   args: [
@@ -62,20 +63,21 @@ repos:
 
         # Sort imports using isort
         - repo: https://github.com/PyCQA/isort
-          rev: 5.8.0
+          rev: 5.10.1
           hooks:
                   - id: isort
+                    args: [ "--profile", "black" ]
 
-        # Automatically upgrade syntax to a minimum version
+  # Automatically upgrade syntax to a minimum version
         - repo: https://github.com/asottile/pyupgrade
-          rev: v2.19.1
+          rev: v3.1.0
           hooks:
                 - id: pyupgrade
                   args: [--py37-plus]
 
         # Various formattings
         - repo: https://github.com/pre-commit/pygrep-hooks
-          rev: v1.8.0
+          rev: v1.9.0
           hooks:
                 # Single backticks should apparently not be used
                 - id: rst-backticks
@@ -94,6 +96,6 @@ repos:
 
         # Add custom regex lints (see .relint.yml)
         - repo: https://github.com/codingjoe/relint
-          rev: 1.2.1
+          rev: 2.0.0
           hooks:
                 - id: relint

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -87,7 +87,7 @@ class Vector:
         """Return a copy of the Vector."""
         # Utilise the copy method of GeoPandas
         new_vector = self.__new__(type(self))
-        new_vector.__init__(self.ds.copy())
+        new_vector.__init__(self.ds.copy())  # type: ignore
         return new_vector  # type: ignore
 
     def crop2raster(self, rst: gu.Raster) -> None:
@@ -335,7 +335,7 @@ the provided raster file.
 
         # Otherwise, create a new Vector from the queried dataset.
         new_vector = self.__new__(type(self))
-        new_vector.__init__(self.ds.query(expression))
+        new_vector.__init__(self.ds.query(expression))  # type: ignore
         return new_vector  # type: ignore
 
     def buffer_without_overlap(self, buffer_size: int | float, plot: bool = False) -> np.ndarray:


### PR DESCRIPTION
Our current build is not passing because of `pre-commit` issues that arose since CI last run for #321 (sometime in the last two weeks). 
This PR solves those by upgrading packages, and also adding the black profile to `isort`.

After the upgrade, there is only two new mypy errors related to `__init__`  calls used in `geovector`. Those are not crucial (related to potential subclassing), so they are ignored for now.