### PR TITLE
Fix `pip` dependency listing in CI

### DIFF
--- a/.github/get_yml_env_nopy.py
+++ b/.github/get_yml_env_nopy.py
@@ -14,12 +14,13 @@ def environment_yml_nopy(fn_env: str, print_dep: str = "both") -> None:
     # Load the yml as dictionary
     yaml_env = yaml.safe_load(open(fn_env))
     conda_dep_env = list(yaml_env["dependencies"])
-    conda_dep_env_without_python = [dep for dep in conda_dep_env if "python" not in dep]
 
     if isinstance(conda_dep_env[-1], dict):
-        pip_dep_env = list(conda_dep_env.pop())
+        pip_dep_env = list(conda_dep_env.pop()["pip"])
     else:
         pip_dep_env = ["None"]
+
+    conda_dep_env_without_python = [dep for dep in conda_dep_env if "python" not in dep]
 
     # Join the lists
     joined_list_conda_dep = " ".join(conda_dep_env_without_python)

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -110,16 +110,14 @@ def diff_environment_yml(fn_env: str, fn_devenv: str, print_dep: str = "both") -
     # Extract the dependencies values
     conda_dep_env = yaml_env["dependencies"]
     conda_dep_devenv = yaml_devenv["dependencies"]
-    if isinstance(conda_dep_env[-1], dict):
-        pip_dep_env = conda_dep_env.pop()
 
     # Check if there is any pip dependency, if yes pop it from the end of the list
     if isinstance(conda_dep_devenv[-1], dict):
-        pip_dep_devenv = conda_dep_devenv.pop()
+        pip_dep_devenv = conda_dep_devenv.pop()["pip"]
 
         # Check if there is a pip dependency in the normal env as well, if yes pop it also
         if isinstance(conda_dep_env[-1], dict):
-            pip_dep_env = conda_dep_env.pop()
+            pip_dep_env = conda_dep_env.pop()["pip"]
 
             # The diff below computes the dependencies that are in env but not in dev-env
             # It should be empty, otherwise we raise an error
@@ -138,6 +136,10 @@ def diff_environment_yml(fn_env: str, fn_devenv: str, print_dep: str = "both") -
 
     # If there is no pip dependency, we ignore this step
     else:
+        diff_pip_dep = []
+
+    # If the diff is empty for pip, return a string "None" to read easily in bash
+    if len(diff_pip_dep) == 0:
         diff_pip_dep = ["None"]
 
     # We do the same for the conda dependency, first a sanity check that everything that is in env is also in dev-ev


### PR DESCRIPTION
To match the issues found in https://github.com/GlacioHack/xdem/pull/320, in case GeoUtils relies more on `pip` in `environment.yml` and `dev-environment.yml` in the future.

The "pop" was not happening at the right line, and some functions were listing the dictionary key instead of values.