### PR TITLE
Update SETSM product filename metadata parsing in `SatelliteImage` class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
                     args: [--line-length=120]
 
         # Lint the code using flake8
-        - repo: https://gitlab.com/pycqa/flake8
+        - repo: https://github.com/pycqa/flake8
           rev: 3.9.2
           hooks:
                 - id: flake8

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -58,7 +58,16 @@ def parse_metadata_from_fn(fname: str) -> list[Any]:
         elif re.match("T[0-9]{2}[A-Z]{3}", spl[0]):
             attrs = ("Sentinel-2", "MSI", None, None, spl[0][1:], dt.datetime.strptime(spl[1], "%Y%m%dT%H%M%S"))
         elif spl[0] == "SETSM":
-            attrs = ("WorldView", spl[1], "ArcticDEM/REMA", spl[7], None, dt.datetime.strptime(spl[2], "%Y%m%d"))
+            # For PGC DEMs: if the second part of the name starts with a "s", it is the new nomenclature (starting at "s2s041") with the version first,
+            # then the rest
+            if spl[1][0] == "s":
+                version = spl[1]
+                index = 1
+            # For backwards-compatibility, this is the old nomenclature
+            else:
+                version = spl[7]
+                index = 0
+            attrs = ("WorldView", spl[index+1], "ArcticDEM/REMA/EarthDEM", version, None, dt.datetime.strptime(spl[index+2], "%Y%m%d"))
         elif spl[0] == "SPOT":
             attrs = ("HFS", "SPOT5", None, None, None, dt.datetime.strptime(spl[2], "%Y%m%d"))
         elif spl[0] == "IODEM3":

--- a/geoutils/satimg.py
+++ b/geoutils/satimg.py
@@ -58,7 +58,8 @@ def parse_metadata_from_fn(fname: str) -> list[Any]:
         elif re.match("T[0-9]{2}[A-Z]{3}", spl[0]):
             attrs = ("Sentinel-2", "MSI", None, None, spl[0][1:], dt.datetime.strptime(spl[1], "%Y%m%dT%H%M%S"))
         elif spl[0] == "SETSM":
-            # For PGC DEMs: if the second part of the name starts with a "s", it is the new nomenclature (starting at "s2s041") with the version first,
+            # For PGC DEMs: if the second part of the name starts with a "s", it is the new nomenclature
+            # (starting at "s2s041") with the version first,
             # then the rest
             if spl[1][0] == "s":
                 version = spl[1]
@@ -67,7 +68,14 @@ def parse_metadata_from_fn(fname: str) -> list[Any]:
             else:
                 version = spl[7]
                 index = 0
-            attrs = ("WorldView", spl[index+1], "ArcticDEM/REMA/EarthDEM", version, None, dt.datetime.strptime(spl[index+2], "%Y%m%d"))
+            attrs = (
+                "WorldView",
+                spl[index + 1],
+                "ArcticDEM/REMA/EarthDEM",
+                version,
+                None,
+                dt.datetime.strptime(spl[index + 2], "%Y%m%d"),
+            )
         elif spl[0] == "SPOT":
             attrs = ("HFS", "SPOT5", None, None, None, dt.datetime.strptime(spl[2], "%Y%m%d"))
         elif spl[0] == "IODEM3":

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -150,10 +150,12 @@ class TestSatelliteImage:
         assert not np.array_equal(r.data, r2.data, equal_nan=True)
 
     def test_filename_parsing(self) -> None:
-
+        """Test metadata parsing from filenames"""
+        
         copied_names = [
             "TDM1_DEM__30_N00E104_DEM.tif",
             "SETSM_WV02_20141026_1030010037D17F00_10300100380B4000_mosaic5_2m_v3.0_dem.tif",
+            "SETSM_s2s041_WV02_20150615_10300100443C2D00_1030010043373000_seg1_2m_dem.tif",
             "AST_L1A_00303132015224418_final.tif",
             "ILAKS1B_20190928_271_Gilkey-DEM.tif",
             "srtm_06_01.tif",
@@ -162,14 +164,15 @@ class TestSatelliteImage:
             "NASADEM_HGT_n00e041.hgt",
         ]
         # Corresponding data, filled manually
-        satellites = ["TanDEM-X", "WorldView", "Terra", "IceBridge", "SRTM", "Terra", "SRTM", "SRTM"]
-        sensors = ["TanDEM-X", "WV02", "ASTER", "UAF-LS", "SRTM", "ASTER", "SRTM", "SRTM"]
-        products = ["TDM1", "ArcticDEM/REMA", "L1A", "ILAKS1B", "SRTMv4.1", "ASTGTM2", "SRTMGL1", "NASADEM-HGT"]
+        satellites = ["TanDEM-X", "WorldView", "WorldView", "Terra", "IceBridge", "SRTM", "Terra", "SRTM", "SRTM"]
+        sensors = ["TanDEM-X", "WV02", "WV02", "ASTER", "UAF-LS", "SRTM", "ASTER", "SRTM", "SRTM"]
+        products = ["TDM1", "ArcticDEM/REMA/EarthDEM", "ArcticDEM/REMA/EarthDEM", "L1A", "ILAKS1B", "SRTMv4.1", "ASTGTM2", "SRTMGL1", "NASADEM-HGT"]
         # we can skip the version, bit subjective...
-        tiles = ["N00E104", None, None, None, "06_01", "N00E108", "N00E015", "n00e041"]
+        tiles = ["N00E104", None, None, None, None, "06_01", "N00E108", "N00E015", "n00e041"]
         datetimes = [
             None,
             dt.datetime(year=2014, month=10, day=26),
+            dt.datetime(year=2015, month=6, day=15),
             dt.datetime(year=2015, month=3, day=13, hour=22, minute=44, second=18),
             dt.datetime(year=2019, month=9, day=28),
             dt.datetime(year=2000, month=2, day=15),

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -151,7 +151,7 @@ class TestSatelliteImage:
 
     def test_filename_parsing(self) -> None:
         """Test metadata parsing from filenames"""
-        
+
         copied_names = [
             "TDM1_DEM__30_N00E104_DEM.tif",
             "SETSM_WV02_20141026_1030010037D17F00_10300100380B4000_mosaic5_2m_v3.0_dem.tif",
@@ -166,7 +166,17 @@ class TestSatelliteImage:
         # Corresponding data, filled manually
         satellites = ["TanDEM-X", "WorldView", "WorldView", "Terra", "IceBridge", "SRTM", "Terra", "SRTM", "SRTM"]
         sensors = ["TanDEM-X", "WV02", "WV02", "ASTER", "UAF-LS", "SRTM", "ASTER", "SRTM", "SRTM"]
-        products = ["TDM1", "ArcticDEM/REMA/EarthDEM", "ArcticDEM/REMA/EarthDEM", "L1A", "ILAKS1B", "SRTMv4.1", "ASTGTM2", "SRTMGL1", "NASADEM-HGT"]
+        products = [
+            "TDM1",
+            "ArcticDEM/REMA/EarthDEM",
+            "ArcticDEM/REMA/EarthDEM",
+            "L1A",
+            "ILAKS1B",
+            "SRTMv4.1",
+            "ASTGTM2",
+            "SRTMGL1",
+            "NASADEM-HGT",
+        ]
         # we can skip the version, bit subjective...
         tiles = ["N00E104", None, None, None, None, "06_01", "N00E108", "N00E015", "n00e041"]
         datetimes = [


### PR DESCRIPTION
Adds a condition for the new nomenclature of PGC DEMs in `parse_metadata_from_fn` of `satimg.py`, as well as associated tests.

Resolves #332 