### PR TITLE
Subscript-crop `Raster` or `Vector` by bracket call `[]`, consistency and bug fixes

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1830,11 +1830,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Calculate intersection of bounding boxes
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
-        print(intersection)
-        print(type(intersection[0]))
-        print(intersection == (np.nan, np.nan, np.nan, np.nan))
         # check that intersection is not void, otherwise return 0 everywhere
-        if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
+        if intersection == () or intersection == (float('nan'), float('nan'), float('nan'), float('nan')):
             warnings.warn("Intersection is void")
             return (0.0, 0.0, 0.0, 0.0)
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -3,6 +3,7 @@ geoutils.georaster provides a toolset for working with raster data.
 """
 from __future__ import annotations
 
+import math
 import os
 import warnings
 from collections import abc
@@ -14,7 +15,6 @@ from typing import IO, Any, Callable, TypeVar, overload
 import geopandas as gpd
 import matplotlib
 import matplotlib.pyplot as plt
-import math
 import numpy as np
 import pyproj
 import rasterio as rio

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1830,6 +1830,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Calculate intersection of bounding boxes
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
+        print(intersection)
         # check that intersection is not void, otherwise return 0 everywhere
         if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void")

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1409,8 +1409,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         :param dst_ref: a reference raster. If set will use the attributes of this
             raster for the output grid. Can be provided as Raster/rasterio data set or as path to the file.
-        :param dst_crs: Specify the Coordinate Reference System to reproject to. If dst_ref not set, defaults to
-        self.crs.
+        :param dst_crs: Specify the Coordinate Reference System or EPSG to reproject to. If dst_ref not set,
+            defaults to self.crs.
         :param dst_size: Raster size to write to (x, y). Do not use with dst_res.
         :param dst_bounds: a BoundingBox object or a dictionary containing left, bottom, right, top bounds in the
         source CRS.

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1831,6 +1831,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
         print(intersection)
+        print(intersection == (np.nan, np.nan, np.nan, np.nan))
         # check that intersection is not void, otherwise return 0 everywhere
         if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void")

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1831,6 +1831,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
         print(intersection)
+        print(type(intersection[0]))
         print(intersection == (np.nan, np.nan, np.nan, np.nan))
         # check that intersection is not void, otherwise return 0 everywhere
         if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1315,7 +1315,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         inplace: bool = True,
     ) -> RasterType | None:
         """
-        Crop the Raster to a given extent.
+        Crop the Raster to a given extent, or bounds of a raster or vector.
+
+        Reprojection is done on the fly if georeferenced objects have different projections.
 
         :param cropGeom: Geometry to crop raster to, as either a Raster object, a Vector object, or a list of
             coordinates. If cropGeom is a Raster, crop() will crop to the boundary of the raster as returned by

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -526,6 +526,10 @@ class Raster:
         """Provide string of information about Raster."""
         return self.info()
 
+    def __getitem__(self, value: Raster | Vector | list[float] | tuple[float, ...]) -> Raster:
+        """Subset the Raster object: calls the crop method with default parameters"""
+        return self.crop(cropGeom=value, inplace=False)
+
     def __eq__(self, other: object) -> bool:
         """Check if a Raster masked array's data (including masked values), mask, fill_value and dtype are equal,
         as well as the Raster's nodata, and georeferencing."""

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -14,6 +14,7 @@ from typing import IO, Any, Callable, TypeVar, overload
 import geopandas as gpd
 import matplotlib
 import matplotlib.pyplot as plt
+import math
 import numpy as np
 import pyproj
 import rasterio as rio
@@ -1830,8 +1831,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Calculate intersection of bounding boxes
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
-        # check that intersection is not void, otherwise return 0 everywhere
-        if intersection == () or intersection == (float('nan'), float('nan'), float('nan'), float('nan')):
+        # Check that intersection is not void (changed to NaN instead of empty tuple end 2022)
+        if intersection == () or all(math.isnan(i) for i in intersection):
             warnings.warn("Intersection is void")
             return (0.0, 0.0, 0.0, 0.0)
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1831,7 +1831,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
 
         # check that intersection is not void, otherwise return 0 everywhere
-        if intersection == ():
+        if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void")
             return (0.0, 0.0, 0.0, 0.0)
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1404,9 +1404,11 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         :param dst_ref: a reference raster. If set will use the attributes of this
             raster for the output grid. Can be provided as Raster/rasterio data set or as path to the file.
-        :param dst_crs: Specify the Coordinate Reference System to reproject to. If dst_ref not set, defaults to self.crs.
+        :param dst_crs: Specify the Coordinate Reference System to reproject to. If dst_ref not set, defaults to
+        self.crs.
         :param dst_size: Raster size to write to (x, y). Do not use with dst_res.
-        :param dst_bounds: a BoundingBox object or a dictionary containing left, bottom, right, top bounds in the source CRS.
+        :param dst_bounds: a BoundingBox object or a dictionary containing left, bottom, right, top bounds in the
+        source CRS.
         :param dst_res: Pixel size in units of target CRS. Either 1 value or (xres, yres). Do not use with dst_size.
         :param dst_nodata: nodata value of the destination. If set to None, will use the same as source,
         and if source is None, will use GDAL's default.

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -18,9 +18,8 @@ from rasterio.crs import CRS
 from scipy.spatial import Voronoi
 from shapely.geometry.polygon import Polygon
 
-from geoutils.georaster import Raster, RasterType
+import geoutils as gu
 from geoutils.projtools import _get_bounds_projected, bounds2poly
-
 
 # This is a generic Vector-type (if subclasses are made, this will change appropriately)
 VectorType = TypeVar("VectorType", bound="Vector")
@@ -93,22 +92,22 @@ class Vector:
         return new_vector  # type: ignore
 
     @overload
-    def crop(self: RasterType,
-             cropGeom: RasterType | Vector | list[float] | tuple[float, ...],
+    def crop(self: VectorType,
+             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
              inplace: Literal[True],
              ) -> None:
         ...
 
     @overload
-    def crop(self: RasterType,
-             cropGeom: RasterType | Vector | list[float] | tuple[float, ...],
+    def crop(self: VectorType,
+             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
              inplace: Literal[False],
              ) -> VectorType:
         ...
 
 
     def crop(self: VectorType,
-             cropGeom: RasterType | VectorType | list[float] | tuple[float, ...],
+             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
              inplace: bool = True,
              ) -> VectorType | None:
         """
@@ -122,7 +121,7 @@ class Vector:
             list of coordinates, the order is assumed to be [xmin, ymin, xmax, ymax].
         :param inplace: Update the vector inplace or return copy.
         """
-        if isinstance(cropGeom, (Raster, Vector)):
+        if isinstance(cropGeom, (gu.Raster, Vector)):
             # For another Vector or Raster, we reproject the bounding box in the same CRS as self
             xmin, ymin, xmax, ymax = cropGeom.get_bounds_projected(out_crs=self.crs)
         elif isinstance(cropGeom, (list, tuple)):
@@ -141,7 +140,7 @@ class Vector:
 
     def create_mask(
         self,
-        rst: str | RasterType | None = None,
+        rst: str | gu.Raster | None = None,
         crs: CRS | None = None,
         xres: float | None = None,
         yres: float | None = None,
@@ -207,7 +206,7 @@ class Vector:
             transform = rio.transform.from_bounds(left, bottom, right, top, width, height)
 
         # otherwise use directly rst's dimensions
-        elif isinstance(rst, Raster):
+        elif isinstance(rst, gu.Raster):
             out_shape = rst.shape
             transform = rst.transform
             crs = rst.crs
@@ -247,7 +246,7 @@ class Vector:
 
     def rasterize(
         self,
-        rst: str | RasterType | None = None,
+        rst: str | gu.Raster | None = None,
         crs: CRS | None = None,
         xres: float | None = None,
         yres: float | None = None,

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 from collections import abc
 from numbers import Number
-from typing import TypeVar, overload, Literal
+from typing import Literal, TypeVar, overload
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -92,30 +92,32 @@ class Vector:
         return new_vector  # type: ignore
 
     @overload
-    def crop(self: VectorType,
-             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
-             inplace: Literal[True],
-             ) -> None:
+    def crop(
+        self: VectorType,
+        cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
+        inplace: Literal[True] = True,
+    ) -> None:
         ...
 
     @overload
-    def crop(self: VectorType,
-             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
-             inplace: Literal[False],
-             ) -> VectorType:
+    def crop(
+        self: VectorType,
+        cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
+        inplace: Literal[False],
+    ) -> VectorType:
         ...
 
-
-    def crop(self: VectorType,
-             cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
-             inplace: bool = True,
-             ) -> VectorType | None:
+    def crop(
+        self: VectorType,
+        cropGeom: gu.Raster | Vector | list[float] | tuple[float, ...],
+        inplace: bool = True,
+    ) -> VectorType | None:
         """
         Crop the Vector to given extent, or bounds of a raster or vector.
 
         Reprojection is done on the fly if georeferenced objects have different projections.
 
-        :param cropGeom: Geometry to crop raster to, as either a Raster object, a Vector object, or a list of
+        :param cropGeom: Geometry to crop vector to, as either a Raster object, a Vector object, or a list of
             coordinates. If cropGeom is a Raster, crop() will crop to the boundary of the raster as returned by
             Raster.ds.bounds. If cropGeom is a Vector, crop() will crop to the bounding geometry. If cropGeom is a
             list of coordinates, the order is assumed to be [xmin, ymin, xmax, ymax].
@@ -132,6 +134,7 @@ class Vector:
         # Need to separate the two options, inplace update
         if inplace:
             self.ds = self.ds.cx[xmin:xmax, ymin:ymax]
+            return None
         # Or create a copy otherwise
         else:
             new_vector = self.copy()
@@ -386,8 +389,7 @@ class Vector:
 
         return new_bounds
 
-
-    def buffer_without_overlap(self, buffer_size: int | float, plot: bool = False) -> VectorType:
+    def buffer_without_overlap(self, buffer_size: int | float, plot: bool = False) -> Vector:
         """
         Returns a Vector object containing self's geometries extended by a buffer, without overlapping each other.
 
@@ -500,7 +502,7 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
         elif geom.geom_type == "LineString":
             exteriors = [geom]
         elif geom.geom_type == "MultiLineString":
-            exteriors = [p for p in geom.geoms]
+            exteriors = list(geom.geoms)
         else:
             raise NotImplementedError(f"Geometry type {geom.geom_type} not implemented.")
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -120,7 +120,7 @@ class Vector:
     ) -> np.ndarray:
         """
         Rasterize the vector features into a boolean raster which has the extent/dimensions of \
-the provided raster file.
+        the provided raster file.
 
         Alternatively, user can specify a grid to rasterize on using xres, yres, bounds and crs.
         Only xres is mandatory, by default yres=xres and bounds/crs are set to self's.
@@ -154,7 +154,10 @@ the provided raster file.
             if crs is None:
                 crs = self.ds.crs
             if bounds is None:
+                bounds_shp = True
                 bounds = self.ds.total_bounds
+            else:
+                bounds_shp = False
 
             # Calculate raster shape
             left, bottom, right, top = bounds
@@ -162,7 +165,9 @@ the provided raster file.
             width = abs((top - bottom) / yres)
 
             if width % 1 != 0 or height % 1 != 0:
-                warnings.warn("Bounds not a multiple of xres/yres, use rounded bounds")
+                # Only warn if the bounds were provided, and not derived from the vector
+                if not bounds_shp:
+                    warnings.warn("Bounds not a multiple of xres/yres, use rounded bounds")
 
             width = int(np.round(width))
             height = int(np.round(height))

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -450,13 +450,13 @@ def extract_vertices(gdf: gpd.GeoDataFrame) -> list[list[tuple[float, float]]]:
     for geom in gdf.geometry:
         # Extract geometry exterior(s)
         if geom.geom_type == "MultiPolygon":
-            exteriors = [p.exterior for p in geom]
+            exteriors = [p.exterior for p in geom.geoms]
         elif geom.geom_type == "Polygon":
             exteriors = [geom.exterior]
         elif geom.geom_type == "LineString":
             exteriors = [geom]
         elif geom.geom_type == "MultiLineString":
-            exteriors = geom
+            exteriors = [p for p in geom.geoms]
         else:
             raise NotImplementedError(f"Geometry type {geom.geom_type} not implemented.")
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -61,6 +61,10 @@ class Vector:
         """Provide string of information about Raster."""
         return self.info()
 
+    def __getitem__(self, value: gu.Raster | Vector | list[float] | tuple[float, ...]) -> Vector:
+        """Subset the Raster object: calls the crop method with default parameters"""
+        return self.crop(cropGeom=value, inplace=False)
+
     def info(self) -> str:
         """
         Returns string of information about the vector (filename, coordinate system, number of layers, features, etc.).

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -15,12 +15,9 @@ from rasterio.crs import CRS
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry.polygon import Polygon
 
-from geoutils.georaster import Raster
-from geoutils.geovector import Vector
-
 
 def bounds2poly(
-    boundsGeom: list[float] | rio.io.DatasetReader | Raster | Vector,
+    boundsGeom: list[float] | rio.io.DatasetReader,
     in_crs: CRS | None = None,
     out_crs: CRS | None = None,
 ) -> Polygon:
@@ -61,7 +58,7 @@ def bounds2poly(
 
 
 def merge_bounds(
-    bounds_list: abc.Iterable[list[float] | Raster | rio.io.DatasetReader | Vector | gpd.GeoDataFrame],
+    bounds_list: abc.Iterable[list[float] | rio.io.DatasetReader | gpd.GeoDataFrame],
     merging_algorithm: str = "union",
 ) -> tuple[float, ...]:
     """
@@ -215,3 +212,12 @@ def compare_proj(proj1: CRS, proj2: CRS) -> bool:
 
     same: bool = proj1.is_exact_same(proj2)
     return same
+
+def _get_bounds_projected(bounds: rio.coords.BoundingBox, in_crs: CRS, out_crs: CRS, densify_pts: int = 5000) -> rio.coords.BoundingBox:
+
+    # Calculate new bounds
+    left, bottom, right, top = bounds
+    new_bounds = rio.warp.transform_bounds(in_crs, out_crs, left, bottom, right, top, densify_pts)
+    new_bounds = rio.coords.BoundingBox(*new_bounds)
+
+    return new_bounds

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -213,7 +213,10 @@ def compare_proj(proj1: CRS, proj2: CRS) -> bool:
     same: bool = proj1.is_exact_same(proj2)
     return same
 
-def _get_bounds_projected(bounds: rio.coords.BoundingBox, in_crs: CRS, out_crs: CRS, densify_pts: int = 5000) -> rio.coords.BoundingBox:
+
+def _get_bounds_projected(
+    bounds: rio.coords.BoundingBox, in_crs: CRS, out_crs: CRS, densify_pts: int = 5000
+) -> rio.coords.BoundingBox:
 
     # Calculate new bounds
     left, bottom, right, top = bounds

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -116,11 +116,6 @@ def align_bounds(
     ref_left = ref_transform.xoff
     ref_top = ref_transform.yoff
 
-    print(ref_left)
-    print(left)
-    print(ref_left)
-    print(xres)
-
     left = ref_left + floor((left - ref_left) / xres) * xres
     right = left + ceil((right - left) / xres) * xres
     top = ref_top + floor((top - ref_top) / yres) * yres

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -116,6 +116,11 @@ def align_bounds(
     ref_left = ref_transform.xoff
     ref_top = ref_transform.yoff
 
+    print(ref_left)
+    print(left)
+    print(ref_left)
+    print(xres)
+
     left = ref_left + floor((left - ref_left) / xres) * xres
     right = left + ceil((right - left) / xres) * xres
     top = ref_top + floor((top - ref_top) / yres) * yres

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -10,6 +10,7 @@ import warnings
 from typing import Any, Callable
 
 import numpy as np
+import math
 import rasterio as rio
 import rasterio.warp
 from tqdm import tqdm
@@ -136,8 +137,8 @@ def load_multiple_rasters(
 
     # Optionally, crop the rasters
     if crop:
-        # Check that intersection is not void
-        if intersection == () or intersection == (float('nan'), float('nan'), float('nan'), float('nan')):
+        # Check that intersection is not void (changed to NaN instead of empty tuple end 2022)
+        if intersection == () or all(math.isnan(i) for i in intersection):
             warnings.warn("Intersection is void, returning unloaded rasters.")
             return output_rst
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -133,12 +133,11 @@ def load_multiple_rasters(
 
     # Second get the intersection of all raster bounds
     intersection = gu.projtools.merge_bounds(bounds, "intersection")
-    print(intersection)
 
     # Optionally, crop the rasters
     if crop:
         # Check that intersection is not void
-        if intersection == ():
+        if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void, returning unloaded rasters.")
             return output_rst
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -133,6 +133,7 @@ def load_multiple_rasters(
 
     # Second get the intersection of all raster bounds
     intersection = gu.projtools.merge_bounds(bounds, "intersection")
+    print(intersection)
 
     # Optionally, crop the rasters
     if crop:

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -138,7 +138,7 @@ def load_multiple_rasters(
     # Optionally, crop the rasters
     if crop:
         # Check that intersection is not void (changed to NaN instead of empty tuple end 2022)
-        if intersection == () or all(math.isnan(i) for i in intersection):
+        if intersection == () or all(np.isnan(i) for i in intersection):
             warnings.warn("Intersection is void, returning unloaded rasters.")
             return output_rst
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -137,6 +137,7 @@ def load_multiple_rasters(
     # Optionally, crop the rasters
     if crop:
         print(intersection)
+        print(intersection == (np.nan, np.nan, np.nan, np.nan))
         # Check that intersection is not void
         if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void, returning unloaded rasters.")

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -264,7 +264,7 @@ height2 and width2 are set based on reference's resolution and the maximum exten
             dst_bounds=dst_bounds,
             dst_res=reference_raster.res,
             dst_crs=reference_raster.crs,
-            dtype=reference_raster.data.dtype,
+            dst_dtype=reference_raster.data.dtype,
             dst_nodata=reference_raster.nodata,
             silent=True,
         )

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -136,6 +136,7 @@ def load_multiple_rasters(
 
     # Optionally, crop the rasters
     if crop:
+        print(intersection)
         # Check that intersection is not void
         if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
             warnings.warn("Intersection is void, returning unloaded rasters.")

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -6,7 +6,6 @@ Optional dependencies:
 """
 from __future__ import annotations
 
-import math
 import warnings
 from typing import Any, Callable
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -136,10 +136,8 @@ def load_multiple_rasters(
 
     # Optionally, crop the rasters
     if crop:
-        print(intersection)
-        print(intersection == (np.nan, np.nan, np.nan, np.nan))
         # Check that intersection is not void
-        if intersection == () or intersection == (np.nan, np.nan, np.nan, np.nan):
+        if intersection == () or intersection == (float('nan'), float('nan'), float('nan'), float('nan')):
             warnings.warn("Intersection is void, returning unloaded rasters.")
             return output_rst
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -6,11 +6,11 @@ Optional dependencies:
 """
 from __future__ import annotations
 
+import math
 import warnings
 from typing import Any, Callable
 
 import numpy as np
-import math
 import rasterio as rio
 import rasterio.warp
 from tqdm import tqdm

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1849,7 +1849,7 @@ self.set_nodata()."
         # -- Test 2: data types --
 
         # Check that polygonize works as expected for any input dtype (e.g. float64 being not supported by GeoPandas)
-        for dtype in ['uint8', 'int8', 'uint16', 'int16', 'uint32', 'int32', 'float32', 'float64']:
+        for dtype in ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"]:
             img_dtype = img.copy()
             img_dtype = img_dtype.astype(dtype)
             value = np.unique(img_dtype)[0]

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -713,7 +713,9 @@ class TestRaster:
 
         # Check that bound reprojection is done automatically if the CRS differ
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*")
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
+            )
             r_cropped_reproj = r_cropped.reproject(dst_crs=3857)
         r_cropped3 = r.crop(r_cropped_reproj, inplace=False)
 
@@ -774,7 +776,9 @@ class TestRaster:
 
         # Filter warning about dst_nodata not set in reprojection (because match_extent triggers reproject)
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*")
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
+            )
             r_cropped = r.crop(cropGeom2, inplace=False, mode="match_extent")
 
         assert list(r_cropped.bounds) == cropGeom2
@@ -785,7 +789,9 @@ class TestRaster:
 
         # Filter warning about dst_nodata not set in reprojection (because match_extent triggers reproject)
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*")
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
+            )
             r_cropped2 = r.crop(r_cropped, inplace=False, mode="match_extent")
         assert r_cropped2 == r_cropped
 
@@ -1479,7 +1485,9 @@ self.set_nodata()."
 
         with warnings.catch_warnings():
             # Ignore warning that nodata value is already used in the raster data
-            warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*")
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
+            )
             r.set_nodata(_default_nodata(r.dtypes[0]))
             r_copy.nodata = _default_nodata(r.dtypes[0])
 
@@ -1867,8 +1875,9 @@ self.set_nodata()."
         for dtype in ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"]:
             img_dtype = img.copy()
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=UserWarning, message='dtype conversion will result in a '
-                                                                                'loss of information.*')
+                warnings.filterwarnings(
+                    "ignore", category=UserWarning, message="dtype conversion will result in a " "loss of information.*"
+                )
                 img_dtype = img_dtype.astype(dtype)
             value = np.unique(img_dtype)[0]
             img_dtype.polygonize(in_value=value)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1850,7 +1850,7 @@ self.set_nodata()."
 
         # Get unique value for image and the corresponding area
         value = np.unique(img)[0]
-        pixel_area = np.sum(img == value) * img.res[0] * img.res[1]
+        pixel_area = np.count_nonzero(img.data == value) * img.res[0] * img.res[1]
 
         # Polygonize the raster for this value, and compute the total area
         polygonized = img.polygonize(in_value=value)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -92,6 +92,9 @@ class TestVector:
         outlines_new = outlines.copy()
         outlines_new.crop(rst)
 
+        # Check with bracket call
+        outlines_new2 = outlines_new[rst]
+
         # Verify that geometries intersect with raster bound
         rst_poly = gu.projtools.bounds2poly(rst.bounds)
         intersects_new = []

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -77,20 +77,20 @@ class TestVector:
     test_data = [[landsat_b4_crop_path, everest_outlines_path], [aster_dem_path, aster_outlines_path]]
 
     @pytest.mark.parametrize("data", test_data)  # type: ignore
-    def test_crop2raster(self, data: list[str]) -> None:
+    def test_crop(self, data: list[str]) -> None:
 
         # Load data
         raster_path, outlines_path = data
         rst = gu.Raster(raster_path)
         outlines = gu.Vector(outlines_path)
 
-        # Need to reproject to r.crs. Otherwise, crop2raster will work but will be approximate
+        # Need to reproject to r.crs. Otherwise, crop will work but will be approximate
         # Because outlines might be warped in a different crs
         outlines.ds = outlines.ds.to_crs(rst.crs)
 
         # Crop
         outlines_new = outlines.copy()
-        outlines_new.crop2raster(rst)
+        outlines_new.crop(rst)
 
         # Verify that geometries intersect with raster bound
         rst_poly = gu.projtools.bounds2poly(rst.bounds)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import geopandas as gpd
-from geopandas.testing import assert_geodataframe_equal
 import numpy as np
 import pytest
+from geopandas.testing import assert_geodataframe_equal
 from scipy.ndimage import binary_erosion
 from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -61,7 +61,9 @@ class TestVector:
 
     def test_rasterize_proj(self) -> None:
 
-        burned = self.glacier_outlines.rasterize(xres=3000)
+        # Capture the warning on resolution not matching exactly bounds
+        with pytest.warns(UserWarning):
+            burned = self.glacier_outlines.rasterize(xres=3000)
 
         assert burned.shape[0] == 146
         assert burned.shape[1] == 115
@@ -70,7 +72,10 @@ class TestVector:
         """Test rasterizing an EPSG:3426 dataset into a projection."""
         v = gu.Vector(gu.examples.get_path("everest_rgi_outlines"))
         # Use Web Mercator at 30 m.
-        burned = v.rasterize(xres=30, crs=3857)
+
+        # Capture the warning on resolution not matching exactly bounds
+        with pytest.warns(UserWarning):
+            burned = v.rasterize(xres=30, crs=3857)
 
         assert burned.shape[0] == 1251
         assert burned.shape[1] == 1522

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -195,6 +195,13 @@ class TestSynthetic:
             eroded_diff = binary_erosion(diff.squeeze(), np.ones((abs(buffer) + 1, abs(buffer) + 1)))
             assert np.count_nonzero(eroded_diff) == 0
 
+        # Check that no warning is raised when creating a mask with a xres not multiple of vector bounds
+        vector.create_mask(xres=1.01)
+
+        # Check that a warning is raised if the bounds were passed specifically by the user
+        with pytest.warns(UserWarning):
+            vector.create_mask(xres=1.01, bounds=(0, 0, 21, 21))
+
     def test_extract_vertices(self) -> None:
         """
         Test that extract_vertices works with simple geometries.

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import geopandas as gpd
+from geopandas.testing import assert_geodataframe_equal
 import numpy as np
 import pytest
 from scipy.ndimage import binary_erosion
@@ -94,6 +95,7 @@ class TestVector:
 
         # Check with bracket call
         outlines_new2 = outlines_new[rst]
+        assert_geodataframe_equal(outlines_new.ds, outlines_new2.ds)
 
         # Verify that geometries intersect with raster bound
         rst_poly = gu.projtools.bounds2poly(rst.bounds)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -187,6 +187,9 @@ def images_3d():  # type: ignore
 #    pytest.lazy_fixture('images_3d')]) ## Requires Raster.reproject() fix.
 def test_stack_rasters(rasters) -> None:  # type: ignore
     """Test stack_rasters"""
+
+    warnings.filterwarnings("ignore", category=UserWarning)
+
     # Merge the two overlapping DEMs and check that output bounds and shape is correct
     stacked_img = gu.spatial_tools.stack_rasters([rasters.img1, rasters.img2])
 
@@ -229,6 +232,9 @@ def test_stack_rasters(rasters) -> None:  # type: ignore
 def test_merge_rasters(rasters) -> None:  # type: ignore
     """Test merge_rasters"""
     # Merge the two overlapping DEMs and check that it closely resembles the initial DEM
+
+    # Silence the reprojection warning for default nodata value already taken
+    warnings.filterwarnings("ignore", category=UserWarning)
 
     merged_img = gu.spatial_tools.merge_rasters([rasters.img1, rasters.img2], merge_algorithm=np.nanmean)
 


### PR DESCRIPTION
## Summary

This PR updates the `get_geoprojected_bounds` function, moving its core to `projtools` to make it consistent and accessible for both `Raster` and `Vector` classes. 
Then, it adds the same options in `Vector.crop()` than for `Raster.crop()` (= passing another `Raster`, `Vector` or a list of bounds). 
Finally, it implements the `__getitem__` (= `[]`) method for `Raster` and `Vector`, which calls their underlying `crop` functionality (= subsetting), as suggested previously by @erikmannerfelt.

```python
rst = Raster(fn_rst)
vec = Vector(fn_vec)

# Get only Raster on extent of Vector
rst = rst[vec]
```

Other than that, several bug fixes and test additions.

## Discussion on the `__getitem__` implementation

Several things:

- We could add the option of provides `slice` objects, which would then be used on `self.data` for `Raster` (subsetting `np.MaskedArray` in 2D) and `self.ds` on `Vector` (subsetting `gpd.GeoDataFrame` in 1D).
- We could, by default, `reproject` instead of `crop` when it is `Raster[Raster]` (only one where it makes sense)? The resampling algorithm could be passed as second argument `Raster[Raster, "bilinear"]`.

## Related issues and more details

This PR:
- Resolves #276,
- Resolves #268,
- Resolves #262,
- Resolves #213,
- Resolves #333.

Also it:
- Removes the dependency of `projtools.py` on `raster.py` and `geovector.py`,
- Moves the core of the `get_geoprojected_bounds` function in `Raster` to `projtools.py`,
- Adds `get_geoprojected_bounds` as a method for the `Vector` class,
- Mirrors the crop functionality of the `Raster` class for `Vector` objects (can provide any type of geometry: bounds, `Raster`, `Vector`),
- Adds more test for `Raster.polygonize()`,
- Solves a new bug with checking void in `intersection` triggered by package updates.