### PR TITLE
Add `proximity` and `buffer_metric` functionalities with `metric` option based on finding local UTM 

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2488,13 +2488,21 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return gv.Vector(gdf)
 
-    def proximity(self, vector: Vector = None, target_values: list[float] = None, geometry_type: str = "boundary", in_or_out: str = "both",
-                  distance_unit: str = 'georeferenced') -> Raster:
+    def proximity(
+        self,
+        vector: Vector | None = None,
+        target_values: list[float] | None = None,
+        geometry_type: str = "boundary",
+        in_or_out: str = "both",
+        distance_unit: str = "georeferenced",
+    ) -> Raster:
         """
         Proximity to a vector's geometry or to self's target pixels computed for each cell of a raster grid.
 
-        :param vector: Vector for which to compute the proximity to geometry, if not provided computed on self's target pixels.
-        :param target_values: (Only with self) List of target values to use for the proximity, defaults to all non-zero values.
+        :param vector: Vector for which to compute the proximity to geometry,
+            if not provided computed on self's target pixels.
+        :param target_values: (Only with self) List of target values to use for the proximity,
+            defaults to all non-zero values.
         :param geometry_type: (Only with vector) Type of geometry to use for the proximity, defaults to 'boundary'.
         :param in_or_out: (Only with vector) Compute proximity only 'in' or 'out'-side the geometry, or 'both'.
         :param distance_unit: Distance unit, either 'georeferenced' or 'pixel'.
@@ -2513,14 +2521,16 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             # We mask target pixels
             if target_values is not None:
-                mask_boundary = np.logical_or.reduce([self.get_nanarray() == target_val for target_val in target_values])
+                mask_boundary = np.logical_or.reduce(
+                    [self.get_nanarray() == target_val for target_val in target_values]
+                )
             # Otherwise, all non-zero values are considered targets
             else:
                 mask_boundary = self.get_nanarray().astype(bool)
 
         # 2/ Now, we compute the distance matrix relative to the masked geometry type
         if distance_unit.lower() == "georeferenced":
-            sampling = self.res
+            sampling: int | tuple[float | int, float | int] = self.res
         elif distance_unit.lower() == "pixel":
             sampling = 1
         else:

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2508,7 +2508,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
     ) -> Raster:
         """
-        Proximity to this Raster's target pixels, or to a Vector's geometry, computed for each cell of this Raster's grid.
+        Proximity to this Raster's target pixels, or to a Vector's geometry, computed for each cell of this Raster's
+        grid.
 
         When passing a Vector, by default, the boundary of the geometry will be used. The full geometry can be used by
         passing "geometry", or any lower dimensional geometry attribute such as "centroid", "envelope" or "convex_hull".
@@ -2525,8 +2526,14 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :return: Proximity raster.
         """
 
-        proximity = proximity_from_vector_or_raster(raster=self, vector=vector, target_values=target_values, geometry_type=geometry_type,
-                                                    in_or_out=in_or_out, distance_unit=distance_unit)
+        proximity = proximity_from_vector_or_raster(
+            raster=self,
+            vector=vector,
+            target_values=target_values,
+            geometry_type=geometry_type,
+            in_or_out=in_or_out,
+            distance_unit=distance_unit,
+        )
 
         return self.copy(new_array=proximity)
 
@@ -2537,15 +2544,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
 
 def proximity_from_vector_or_raster(
-        raster: Raster | None = None,
-        vector: Vector | None = None,
-        target_values: list[float] | None = None,
-        geometry_type: str = "boundary",
-        in_or_out: Literal["in"] | Literal["out"] | Literal["both"] = "both",
-        distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced") -> np.ndarray:
+    raster: Raster,
+    vector: Vector | None = None,
+    target_values: list[float] | None = None,
+    geometry_type: str = "boundary",
+    in_or_out: Literal["in"] | Literal["out"] | Literal["both"] = "both",
+    distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
+) -> np.ndarray:
     """
     (This function is defined here as mostly raster-based, but used in a class method for both Raster and Vector)
-    Proximity to a Raster's target values if no Vector is provided, otherwise to a Vector's geometry type rasterized on the Raster.
+    Proximity to a Raster's target values if no Vector is provided, otherwise to a Vector's geometry type
+    rasterized on the Raster.
 
     :param raster: Raster to burn the proximity grid on.
     :param vector: Vector for which to compute the proximity to geometry,
@@ -2568,9 +2577,7 @@ def proximity_from_vector_or_raster(
     else:
         # We mask target pixels
         if target_values is not None:
-            mask_boundary = np.logical_or.reduce(
-                [raster.get_nanarray() == target_val for target_val in target_values]
-            )
+            mask_boundary = np.logical_or.reduce([raster.get_nanarray() == target_val for target_val in target_values])
         # Otherwise, all non-zero values are considered targets
         else:
             mask_boundary = raster.get_nanarray().astype(bool)

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -27,7 +27,7 @@ from rasterio.crs import CRS
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
 from rasterio.warp import Resampling
-from scipy.ndimage import map_coordinates, distance_transform_edt
+from scipy.ndimage import distance_transform_edt, map_coordinates
 
 import geoutils.geovector as gv
 from geoutils._typing import AnyNumber, ArrayLike, DTypeLike
@@ -2488,7 +2488,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return gv.Vector(gdf)
 
-    def proximity(self, vector: Vector, in_or_out: str = 'both') -> Raster:
+    def proximity(self, vector: Vector, in_or_out: str = "both") -> Raster:
         """
         Proximity to the geometry boundary computed for each cell of a raster grid.
 
@@ -2498,7 +2498,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :return: Proximity to geometry boundary.
         """
 
-        # 1/ First, we rasterize the boundary of vector shape, which is a LineString (also .exterior exists, but is a LinearRing)
+        # 1/ First, we rasterize the boundary of vector shape, which is a LineString (also .exterior exists,
+        # but is a LinearRing)
 
         # We create a geodataframe with the boundary geometry
         boundary_shp = gpd.GeoDataFrame(geometry=vector.ds.boundary, crs=self.crs)
@@ -2508,15 +2509,15 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # 2/ Now, we compute the distance matrix relative to the masked boundary
         proximity = distance_transform_edt(~mask_boundary, sampling=self.res)
 
-        if in_or_out == 'both':
-            return proximity
-        elif in_or_out in ['in', 'out']:
+        if in_or_out == "both":
+            pass
+        elif in_or_out in ["in", "out"]:
             mask_polygon = Vector(vector.ds).create_mask(self).squeeze()
-            if in_or_out == 'in':
+            if in_or_out == "in":
                 proximity[~mask_polygon] = 0
             else:
                 proximity[mask_polygon] = 0
         else:
             raise ValueError('The type of proximity must be one of "in", "out" or "both".')
 
-        return proximity
+        return self.copy(new_array=proximity)

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2526,7 +2526,13 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             raise ValueError('Distance unit must be either "georeferenced" or "pixel".')
 
-        proximity = distance_transform_edt(~mask_boundary, sampling=sampling)
+        # If not all pixels are targets, then we compute the distance
+        non_targets = np.count_nonzero(mask_boundary)
+        if non_targets > 0:
+            proximity = distance_transform_edt(~mask_boundary, sampling=sampling)
+        # Otherwise, pass an array full of nodata
+        else:
+            proximity = np.ones(np.shape(mask_boundary)) * np.nan
 
         # 3/ If there was a vector input, apply the in_and_out argument to optionally mask inside/outside
         if vector is not None:

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1140,6 +1140,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return cp
 
+    def equal_georeferenced_grid(self: RasterType, raster: RasterType) -> bool:
+        """
+        Check that grid shape, geotransform and CRS are equal.
+
+        :param raster: Another Raster object
+
+        :return: Whether the two objects have the same georeferenced grid
+        """
+
+        return all([self.shape == raster.shape, self.transform == raster.transform, self.crs == raster.crs])
+
     @overload
     def get_nanarray(self, return_mask: Literal[False] = False) -> np.ndarray:
         ...

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -21,8 +21,6 @@ from scipy.ndimage import distance_transform_edt
 
 import geoutils as gu
 
-from projtools import latlon_to_utm, utm_to_epsg
-
 # This is a generic Vector-type (if subclasses are made, this will change appropriately)
 VectorType = TypeVar("VectorType", bound="Vector")
 
@@ -388,6 +386,8 @@ the provided raster file.
         :return: Buffered shapefile
         """
 
+        from geoutils.projtools import latlon_to_utm, utm_to_epsg
+
         # Get a rough centroid in geographic coordinates (ignore the warning that it is not the most precise):
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=UserWarning)
@@ -440,6 +440,8 @@ the provided raster file.
 
         :returns: A Vector containing the buffered geometries.
         """
+
+        from geoutils.projtools import latlon_to_utm, utm_to_epsg
 
         # Project in local UTM if metric is True
         if metric:

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -410,7 +410,7 @@ the provided raster file.
 
     def buffer_metric(self, buffer_size: float) -> Vector:
         """
-        Buffer the vector in a metric.
+        Buffer the vector in a metric system (UTM only).
 
         The outlines are projected to a local UTM, then reverted to the original projection after buffering.
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -15,9 +15,9 @@ import rasterio as rio
 import shapely
 from rasterio import features, warp
 from rasterio.crs import CRS
+from scipy.ndimage import distance_transform_edt
 from scipy.spatial import Voronoi
 from shapely.geometry.polygon import Polygon
-from scipy.ndimage import distance_transform_edt
 
 import geoutils as gu
 
@@ -339,7 +339,7 @@ the provided raster file.
         new_vector.__init__(self.ds.query(expression))  # type: ignore
         return new_vector  # type: ignore
 
-    def proximity(self, raster: gu.Raster, in_or_out: str = 'both') -> gu.Raster:
+    def proximity(self, raster: gu.Raster, in_or_out: str = "both") -> gu.Raster:
         """
         Proximity to the geometry boundary computed for each cell of a raster grid.
 
@@ -351,7 +351,8 @@ the provided raster file.
 
         # TODO: We could have an option to pass Raster=None with default rasterization of the vector?
 
-        # 1/ First, we rasterize the boundary of vector shape, which is a LineString (also .exterior exists, but is a LinearRing)
+        # 1/ First, we rasterize the boundary of vector shape, which is a LineString (also .exterior exists,
+        # but is a LinearRing)
 
         # We create a geodataframe with the boundary geometry
         boundary_shp = gpd.GeoDataFrame(geometry=self.ds.boundary, crs=self.crs)
@@ -361,11 +362,11 @@ the provided raster file.
         # 2/ Now, we compute the distance matrix relative to the masked boundary
         proximity = distance_transform_edt(~mask_boundary, sampling=raster.res)
 
-        if in_or_out == 'both':
+        if in_or_out == "both":
             return proximity
-        elif in_or_out in ['in', 'out']:
+        elif in_or_out in ["in", "out"]:
             mask_polygon = Vector(self.ds).create_mask(raster).squeeze()
-            if in_or_out == 'in':
+            if in_or_out == "in":
                 proximity[~mask_polygon] = 0
             else:
                 proximity[mask_polygon] = 0
@@ -374,8 +375,7 @@ the provided raster file.
 
         return proximity
 
-
-    def buffer_metric(self, buffer_size: float) -> VectorType:
+    def buffer_metric(self, buffer_size: float) -> Vector:
         """
         Buffer the vector in a metric.
 
@@ -390,7 +390,7 @@ the provided raster file.
 
         # Get a rough centroid in geographic coordinates (ignore the warning that it is not the most precise):
         with warnings.catch_warnings():
-            warnings.simplefilter(action='ignore', category=UserWarning)
+            warnings.simplefilter(action="ignore", category=UserWarning)
             shp_wgs84 = self.ds.to_crs(epsg=4326)
             lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
 
@@ -410,7 +410,6 @@ the provided raster file.
         # TODO: Clarify what is conserved in the GeoSeries and what to pass the GeoDataFrame to not lose any attributes
         # Return a Vector object of the buffered GeoDataFrame
         return Vector(gpd.GeoDataFrame(geometry=ds_buffered_origproj.geometry, crs=self.ds.crs))
-
 
     def buffer_without_overlap(self, buffer_size: int | float, metric: bool = True, plot: bool = False) -> np.ndarray:
         """
@@ -447,7 +446,7 @@ the provided raster file.
         if metric:
             # Get a rough centroid in geographic coordinates (ignore the warning that it is not the most precise):
             with warnings.catch_warnings():
-                warnings.simplefilter(action='ignore', category=UserWarning)
+                warnings.simplefilter(action="ignore", category=UserWarning)
                 shp_wgs84 = self.ds.to_crs(epsg=4326)
                 lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 from collections import abc
 from numbers import Number
-from typing import TypeVar
+from typing import TypeVar, Literal
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -341,15 +341,19 @@ the provided raster file.
 
     def proximity(
         self,
-        raster: gu.Raster = None,
+        raster: gu.Raster | None = None,
         geometry_type: str = "boundary",
-        in_or_out: str = "both",
-        distance_unit: str = "georeferenced",
+        in_or_out: Literal["in"] | Literal["out"] | Literal["both"] = "both",
+        distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
     ) -> gu.Raster:
         """
-        Proximity to the vector's geometry computed for each cell of a raster grid.
+        Proximity to this Vector's geometry computed for each cell of a Raster grid.
 
-        :param raster: Raster to burn the proximity grid on, defaults to a 1000 x 1000 pixel raster with vector extent.
+        By default, the boundary of the Vector's geometry will be used. The full geometry can be used by passing "geometry",
+        or any lower dimensional geometry attribute such as "centroid", "envelope" or "convex_hull".
+        See all geometry attributes in the Shapely documentation at https://shapely.readthedocs.io/.
+
+        :param raster: Raster to burn the proximity grid on, defaults to a 1000 x 1000 pixel grid with this Vector's extent.
         :param geometry_type: Type of geometry to use for the proximity, defaults to 'boundary'.
         :param in_or_out: Compute proximity only 'in' or 'out'-side the polygon, or 'both'.
         :param distance_unit: Distance unit, either 'georeferenced' or 'pixel'.
@@ -376,35 +380,10 @@ the provided raster file.
 
             raster = gu.Raster.from_array(data=np.zeros((1000, 1000)), transform=transform, crs=self.crs)
 
-        # 1/ First, if input is a vector, we rasterize the geometry type
-        # (works with .boundary that is a LineString (.exterior exists, but is a LinearRing)
-
-        # We create a geodataframe with the geometry type
-        boundary_shp = gpd.GeoDataFrame(geometry=self.ds.__getattr__(geometry_type), crs=self.crs)
-        # We mask the pixels that make up the geometry type
-        mask_boundary = Vector(boundary_shp).create_mask(raster).squeeze()
-
-        # 2/ Now, we compute the distance matrix relative to the masked geometry type
-        if distance_unit.lower() == "georeferenced":
-            sampling = self.res
-        elif distance_unit.lower() == "pixel":
-            sampling = 1
-        else:
-            raise ValueError('Distance unit must be either "georeferenced" or "pixel".')
-
-        proximity = distance_transform_edt(~mask_boundary, sampling=sampling)
-
-        # 3/ Apply the in_and_out argument to optionally mask inside/outside
-        if in_or_out == "both":
-            return proximity
-        elif in_or_out in ["in", "out"]:
-            mask_polygon = Vector(self.ds).create_mask(raster).squeeze()
-            if in_or_out == "in":
-                proximity[~mask_polygon] = 0
-            else:
-                proximity[mask_polygon] = 0
-        else:
-            raise ValueError('The type of proximity must be one of "in", "out" or "both".')
+        proximity = gu.georaster.raster.proximity_from_vector_or_raster(
+            raster=raster, vector=self, geometry_type=geometry_type,
+            in_or_out=in_or_out, distance_unit=distance_unit
+        )
 
         return raster.copy(new_array=proximity)
 

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -405,25 +405,28 @@ the provided raster file.
         # Get a rough centroid in geographic coordinates (ignore the warning that it is not the most precise):
         with warnings.catch_warnings():
             warnings.simplefilter(action="ignore", category=UserWarning)
-            with self.ds.to_crs(epsg=4326) as shp_wgs84:
-                lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
+            shp_wgs84 = self.ds.to_crs(epsg=4326)
+            lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
+            del shp_wgs84
 
         # Get the EPSG code of the local UTM
         utm = latlon_to_utm(lat, lon)
         epsg = utm_to_epsg(utm)
 
         # Reproject the shapefile in the local UTM
-        with self.ds.to_crs(epsg=epsg) as ds_utm:
+        ds_utm = self.ds.to_crs(epsg=epsg)
 
-            # Buffer the shapefile
-            ds_buffered = ds_utm.buffer(distance=buffer_size)
+        # Buffer the shapefile
+        ds_buffered = ds_utm.buffer(distance=buffer_size)
+        del ds_utm
 
         # Revert-project the shapefile in the original CRS
-        with ds_buffered.to_crs(crs=self.ds.crs) as ds_buffered_origproj:
+        ds_buffered_origproj = ds_buffered.to_crs(crs=self.ds.crs)
+        del ds_buffered
 
-            # Return a Vector object of the buffered GeoDataFrame
-            # TODO: Clarify what is conserved in the GeoSeries and what to pass the GeoDataFrame to not lose any attributes
-            vector_buffered = Vector(gpd.GeoDataFrame(geometry=ds_buffered_origproj.geometry, crs=self.ds.crs))
+        # Return a Vector object of the buffered GeoDataFrame
+        # TODO: Clarify what is conserved in the GeoSeries and what to pass the GeoDataFrame to not lose any attributes
+        vector_buffered = Vector(gpd.GeoDataFrame(geometry=ds_buffered_origproj.geometry, crs=self.ds.crs))
 
         return vector_buffered
 
@@ -463,8 +466,9 @@ the provided raster file.
             # Get a rough centroid in geographic coordinates (ignore the warning that it is not the most precise):
             with warnings.catch_warnings():
                 warnings.simplefilter(action="ignore", category=UserWarning)
-                with self.ds.to_crs(epsg=4326) as shp_wgs84:
-                    lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
+                shp_wgs84 = self.ds.to_crs(epsg=4326)
+                lat, lon = shp_wgs84.centroid.y.values[0], shp_wgs84.centroid.x.values[0]
+                del shp_wgs84
 
             # Get the EPSG code of the local UTM
             utm = latlon_to_utm(lat, lon)

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import warnings
 from collections import abc
 from numbers import Number
-from typing import TypeVar, Literal
+from typing import Literal, TypeVar
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -15,7 +15,6 @@ import rasterio as rio
 import shapely
 from rasterio import features, warp
 from rasterio.crs import CRS
-from scipy.ndimage import distance_transform_edt
 from scipy.spatial import Voronoi
 from shapely.geometry.polygon import Polygon
 
@@ -348,17 +347,20 @@ the provided raster file.
         distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
     ) -> gu.Raster:
         """
-        Proximity to this Vector's geometry computed for each cell of a Raster grid, or for a grid size with this Vector's extent.
+        Proximity to this Vector's geometry computed for each cell of a Raster grid, or for a grid size with
+        this Vector's extent.
 
-        If passed, the Raster georeferenced grid will be used to burn the proximity. If not, a grid size can be passed to create
-        a georeferenced grid with the bounds and CRS of this Vector.
+        If passed, the Raster georeferenced grid will be used to burn the proximity. If not, a grid size can be
+        passed to create a georeferenced grid with the bounds and CRS of this Vector.
 
-        By default, the boundary of the Vector's geometry will be used. The full geometry can be used by passing "geometry",
+        By default, the boundary of the Vector's geometry will be used. The full geometry can be used by
+        passing "geometry",
         or any lower dimensional geometry attribute such as "centroid", "envelope" or "convex_hull".
         See all geometry attributes in the Shapely documentation at https://shapely.readthedocs.io/.
 
         :param raster: Raster to burn the proximity grid on.
-        :param grid_size: If no Raster is provided, grid size to use with this Vector's extent and CRS (defaults to 1000 x 1000).
+        :param grid_size: If no Raster is provided, grid size to use with this Vector's extent and CRS
+            (defaults to 1000 x 1000).
         :param geometry_type: Type of geometry to use for the proximity, defaults to 'boundary'.
         :param in_or_out: Compute proximity only 'in' or 'out'-side the polygon, or 'both'.
         :param distance_unit: Distance unit, either 'georeferenced' or 'pixel'.
@@ -383,8 +385,7 @@ the provided raster file.
             raster = gu.Raster.from_array(data=np.zeros((1000, 1000)), transform=transform, crs=self.crs)
 
         proximity = gu.georaster.raster.proximity_from_vector_or_raster(
-            raster=raster, vector=self, geometry_type=geometry_type,
-            in_or_out=in_or_out, distance_unit=distance_unit
+            raster=raster, vector=self, geometry_type=geometry_type, in_or_out=in_or_out, distance_unit=distance_unit
         )
 
         return raster.copy(new_array=proximity)

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -339,7 +339,13 @@ the provided raster file.
         new_vector.__init__(self.ds.query(expression))  # type: ignore
         return new_vector  # type: ignore
 
-    def proximity(self, raster: gu.Raster = None, geometry_type: str = "boundary", in_or_out: str = "both", distance_unit: str = 'georeferenced') -> gu.Raster:
+    def proximity(
+        self,
+        raster: gu.Raster = None,
+        geometry_type: str = "boundary",
+        in_or_out: str = "both",
+        distance_unit: str = "georeferenced",
+    ) -> gu.Raster:
         """
         Proximity to the vector's geometry computed for each cell of a raster grid.
 
@@ -360,7 +366,7 @@ the provided raster file.
             # TODO: this bit of code is common in several vector functions (rasterize, etc): move out as common code?
             # By default, use self's bounds
             if self.bounds is None:
-                raise ValueError('To automatically rasterize on the vector, bounds need to be defined.')
+                raise ValueError("To automatically rasterize on the vector, bounds need to be defined.")
 
             # Calculate raster shape
             left, bottom, right, top = self.bounds

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -486,7 +486,6 @@ class Vector:
 
         return new_bounds
 
-
     def buffer_without_overlap(self, buffer_size: int | float, metric: bool = True, plot: bool = False) -> Vector:
         """
         Returns a Vector object containing self's geometries extended by a buffer, without overlapping each other.

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -28,25 +28,30 @@ def latlon_to_utm(lat: float, lon: float) -> str:
 
     :returns: UTM zone.
     """
-    if not (isinstance(lat, (float, np.floating, int, np.integer)) and isinstance(lon, (float, np.floating, int, np.integer))):
-        raise ValueError('Latitude and longitude must be floats or integers.')
-    # The "utm" Python module excludes regions south of 80°S and north of 84°N, unpractical for global vector manipulation
+    if not (
+        isinstance(lat, (float, np.floating, int, np.integer))
+        and isinstance(lon, (float, np.floating, int, np.integer))
+    ):
+        raise ValueError("Latitude and longitude must be floats or integers.")
+    # The "utm" Python module excludes regions south of 80°S and north of 84°N,
+    # unpractical for global vector manipulation
     # utm_all = utm.from_latlon(lat,lon)
     # utm_nb=utm_all[2]
 
     # Get UTM zone from longitude without exclusions
     if -180 <= lon < 180:
-        utm_nb = int(
-            np.floor((lon + 180) / 6)) + 1  # lon=-180 refers to UTM zone 1 towards East (West corner convention)
+        utm_nb = (
+            int(np.floor((lon + 180) / 6)) + 1
+        )  # lon=-180 refers to UTM zone 1 towards East (West corner convention)
     else:
-        raise ValueError('Longitude value is out of range [-180, 180[.')
+        raise ValueError("Longitude value is out of range [-180, 180[.")
 
     if 0 <= lat < 90:  # lat=0 refers to North (South corner convention)
-        utm_zone = str(utm_nb).zfill(2) + 'N'
+        utm_zone = str(utm_nb).zfill(2) + "N"
     elif -90 <= lat < 0:
-        utm_zone = str(utm_nb).zfill(2) + 'S'
+        utm_zone = str(utm_nb).zfill(2) + "S"
     else:
-        raise ValueError('Latitude value is out of range [-90, 90[.')
+        raise ValueError("Latitude value is out of range [-90, 90[.")
 
     return utm_zone
 
@@ -60,19 +65,29 @@ def utm_to_epsg(utm: str) -> int:
     :return: EPSG of UTM zone.
     """
 
-    if not (isinstance(utm, str) and 2<=len(utm)<=3 and utm[:-1].isdigit() and 0<int(utm[:-1])<=60 and utm[-1].upper() in ['N', 'S']):
-        raise ValueError('UTM zone should be a 3-character string with 2-digit code between 01 and 60, and 1-letter north or south zone, e.g. "18S" or "54N".')
+    if not (
+        isinstance(utm, str)
+        and 2 <= len(utm) <= 3
+        and utm[:-1].isdigit()
+        and 0 < int(utm[:-1]) <= 60
+        and utm[-1].upper() in ["N", "S"]
+    ):
+        raise ValueError(
+            "UTM zone should be a 3-character string with 2-digit code between 01 and 60, "
+            'and 1-letter north or south zone, e.g. "18S" or "54N".'
+        )
 
     utm_digits = utm[:-1]
     utm_north_south = utm[-1].upper()
 
     # Code starts with 326 for North, and 327 for South, to which is added the utm zone number
-    if utm_north_south == 'N':
-        epsg = int('326' + utm_digits.zfill(2))
+    if utm_north_south == "N":
+        epsg = int("326" + utm_digits.zfill(2))
     else:
-        epsg = int('327' + utm_digits.zfill(2))
+        epsg = int("327" + utm_digits.zfill(2))
 
     return epsg
+
 
 def bounds2poly(
     boundsGeom: list[float] | rio.io.DatasetReader | Raster | Vector,

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -58,17 +58,17 @@ def utm_to_epsg(utm: str) -> int:
     :return: EPSG of UTM zone.
     """
 
-    if not (isinstance(utm, str) and len(utm) == 3 and utm[:-1].isdigit() and 0<int(utm[-1])<=60 and utm[-1].upper() in ['N', 'S']):
-        raise ValueError('UTM zone should be a 3-character string with 2-digit code between 1 and 60, and 1-letter north or south zone, e.g. "18S" or "54N".')
+    if not (isinstance(utm, str) and 2<=len(utm)<=3 and utm[:-1].isdigit() and 0<int(utm[:-1])<=60 and utm[-1].upper() in ['N', 'S']):
+        raise ValueError('UTM zone should be a 3-character string with 2-digit code between 01 and 60, and 1-letter north or south zone, e.g. "18S" or "54N".')
 
     utm_digits = utm[:-1]
     utm_north_south = utm[-1].upper()
 
     # Code starts with 326 for North, and 327 for South, to which is added the utm zone number
     if utm_north_south == 'N':
-        epsg = int('326' + utm_digits)
+        epsg = int('326' + utm_digits.zfill(2))
     else:
-        epsg = int('327' + utm_digits)
+        epsg = int('327' + utm_digits.zfill(2))
 
     return epsg
 

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -28,30 +28,20 @@ def latlon_to_utm(lat: float, lon: float) -> str:
 
     :returns: UTM zone.
     """
+
     if not (
         isinstance(lat, (float, np.floating, int, np.integer))
         and isinstance(lon, (float, np.floating, int, np.integer))
     ):
-        raise ValueError("Latitude and longitude must be floats or integers.")
-    # The "utm" Python module excludes regions south of 80°S and north of 84°N,
-    # unpractical for global vector manipulation
-    # utm_all = utm.from_latlon(lat,lon)
-    # utm_nb=utm_all[2]
+        raise TypeError("Latitude and longitude must be floats or integers.")
 
-    # Get UTM zone from longitude without exclusions
-    if -180 <= lon < 180:
-        utm_nb = (
-            int(np.floor((lon + 180) / 6)) + 1
-        )  # lon=-180 refers to UTM zone 1 towards East (West corner convention)
-    else:
+    if not -180 <= lon < 180:
         raise ValueError("Longitude value is out of range [-180, 180[.")
-
-    if 0 <= lat < 90:  # lat=0 refers to North (South corner convention)
-        utm_zone = str(utm_nb).zfill(2) + "N"
-    elif -90 <= lat < 0:
-        utm_zone = str(utm_nb).zfill(2) + "S"
-    else:
+    if not -90 <= lat < 90:
         raise ValueError("Latitude value is out of range [-90, 90[.")
+
+    # Get UTM zone from name string of crs info
+    utm_zone = pyproj.database.query_utm_crs_info("WGS 84", area_of_interest=pyproj.aoi.AreaOfInterest(lon, lat, lon, lat))[0].name.split(" ")[-1]
 
     return utm_zone
 
@@ -65,26 +55,11 @@ def utm_to_epsg(utm: str) -> int:
     :return: EPSG of UTM zone.
     """
 
-    if not (
-        isinstance(utm, str)
-        and 2 <= len(utm) <= 3
-        and utm[:-1].isdigit()
-        and 0 < int(utm[:-1]) <= 60
-        and utm[-1].upper() in ["N", "S"]
-    ):
-        raise ValueError(
-            "UTM zone should be a 3-character string with 2-digit code between 01 and 60, "
-            'and 1-letter north or south zone, e.g. "18S" or "54N".'
-        )
+    # Whether UTM is passed as single or double digits, homogenize to single-digit
+    utm = str(int(utm[:-1])) + utm[-1].upper()
 
-    utm_digits = utm[:-1]
-    utm_north_south = utm[-1].upper()
-
-    # Code starts with 326 for North, and 327 for South, to which is added the utm zone number
-    if utm_north_south == "N":
-        epsg = int("326" + utm_digits.zfill(2))
-    else:
-        epsg = int("327" + utm_digits.zfill(2))
+    # Get corresponding EPSG
+    epsg = pyproj.CRS(f"WGS 84 / UTM Zone {utm}").to_epsg()
 
     return epsg
 

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -28,6 +28,8 @@ def latlon_to_utm(lat: float, lon: float) -> str:
 
     :returns: UTM zone.
     """
+    if not (isinstance(lat, (float, np.floating, int, np.integer)) and isinstance(lon, (float, np.floating, int, np.integer))):
+        raise ValueError('Latitude and longitude must be floats or integers.')
     # The "utm" Python module excludes regions south of 80°S and north of 84°N, unpractical for global vector manipulation
     # utm_all = utm.from_latlon(lat,lon)
     # utm_nb=utm_all[2]

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -41,9 +41,11 @@ def latlon_to_utm(lat: float, lon: float) -> str:
         raise ValueError("Latitude value is out of range [-90, 90[.")
 
     # Get UTM zone from name string of crs info
-    utm_zone = pyproj.database.query_utm_crs_info("WGS 84", area_of_interest=pyproj.aoi.AreaOfInterest(lon, lat, lon, lat))[0].name.split(" ")[-1]
+    utm_zone = pyproj.database.query_utm_crs_info(
+        "WGS 84", area_of_interest=pyproj.aoi.AreaOfInterest(lon, lat, lon, lat)
+    )[0].name.split(" ")[-1]
 
-    return utm_zone
+    return str(utm_zone)
 
 
 def utm_to_epsg(utm: str) -> int:
@@ -61,7 +63,7 @@ def utm_to_epsg(utm: str) -> int:
     # Get corresponding EPSG
     epsg = pyproj.CRS(f"WGS 84 / UTM Zone {utm}").to_epsg()
 
-    return epsg
+    return int(epsg)
 
 
 def bounds2poly(

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -2174,7 +2174,6 @@ class TestArithmetic:
 
         assert not r1.equal_georeferenced_grid(self.r1_wrong_transform)
 
-
     # List of operations with two operands
     ops_2args = [
         "__add__",

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -40,28 +40,25 @@ def run_gdal_proximity(
 
     # Save input in temporary file to read with GDAL
     # (avoids the nightmare of setting nodata, transform, crs in GDAL format...)
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_path = os.path.join(temp_dir.name, "input.tif")
-    input_raster.save(temp_path)
-    ds_raster_in = gdal.Open(temp_path, gdalconst.GA_ReadOnly)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = os.path.join(temp_dir.name, "input.tif")
+        input_raster.save(temp_path)
+        ds_raster_in = gdal.Open(temp_path, gdalconst.GA_ReadOnly)
 
-    # Define GDAL options
-    proximity_options = ["DISTUNITS=" + distunits]
-    if target_values is not None:
-        proximity_options.insert(0, "VALUES=" + ",".join([str(tgt) for tgt in target_values]))
+        # Define GDAL options
+        proximity_options = ["DISTUNITS=" + distunits]
+        if target_values is not None:
+            proximity_options.insert(0, "VALUES=" + ",".join([str(tgt) for tgt in target_values]))
 
-    # Compute proximity
-    gdal.ComputeProximity(ds_raster_in.GetRasterBand(1), proxy_ds.GetRasterBand(1), proximity_options)
-    # Save array
-    proxy_array = proxy_ds.GetRasterBand(1).ReadAsArray().astype("float32")
-    proxy_array[proxy_array == -9999] = np.nan
+        # Compute proximity
+        gdal.ComputeProximity(ds_raster_in.GetRasterBand(1), proxy_ds.GetRasterBand(1), proximity_options)
+        # Save array
+        proxy_array = proxy_ds.GetRasterBand(1).ReadAsArray().astype("float32")
+        proxy_array[proxy_array == -9999] = np.nan
 
-    # Close GDAL datasets
-    proxy_ds = None
-    ds_raster_in = None
-
-    # Clean temporary directory
-    temp_dir.cleanup()
+        # Close GDAL datasets
+        proxy_ds = None
+        ds_raster_in = None
 
     return proxy_array
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1923,7 +1923,6 @@ self.set_nodata()."
         mask = img > value
         mask.polygonize(in_value=1)
 
-
     # Test all options, with both an artificial Raster (that has all target values) and a real Raster
     @pytest.mark.parametrize("distunits", ["GEO", "PIXEL"])  # type: ignore
     # 0 and 1,2,3 are especially useful for the artificial Raster, and 112 for the real Raster

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -41,7 +41,7 @@ def run_gdal_proximity(
     # Save input in temporary file to read with GDAL
     # (avoids the nightmare of setting nodata, transform, crs in GDAL format...)
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = os.path.join(temp_dir.name, "input.tif")
+        temp_path = os.path.join(temp_dir, "input.tif")
         input_raster.save(temp_path)
         ds_raster_in = gdal.Open(temp_path, gdalconst.GA_ReadOnly)
 
@@ -2127,43 +2127,52 @@ class TestArithmetic:
         Test that equal for shape, crs and transform work as expected
         """
 
+        # -- Test 1: based on a copy --
         r1 = self.r1
         r2 = r1.copy()
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
 
         # Change data
         r2.data += 1
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
 
         # Change mask (False by default)
         r2 = r1.copy()
         r2.data[0, 0] = np.ma.masked
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
 
         # Change fill_value (999999 by default)
         r2 = r1.copy()
         r2.data.fill_value = 0
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
 
         # Change dtype
         r2 = r1.copy()
         r2 = r2.astype("float32")
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
 
         # Change transform
         r2 = r1.copy()
         r2.transform = rio.transform.from_bounds(0, 0, 1, 1, self.width + 1, self.height)
-        assert r1 != r2
+        assert not r1.equal_georeferenced_grid(r2)
 
         # Change CRS
         r2 = r1.copy()
         r2.crs = rio.crs.CRS.from_epsg(4326)
-        assert r1 != r2
+        assert not r1.equal_georeferenced_grid(r2)
 
         # Change nodata
         r2 = r1.copy()
         r2.set_nodata(34)
-        assert r1 == r2
+        assert r1.equal_georeferenced_grid(r2)
+
+        # -- Test 2: based on another Raster with one different georeferenced grid attribute --
+
+        assert not r1.equal_georeferenced_grid(self.r1_wrong_crs)
+
+        assert not r1.equal_georeferenced_grid(self.r1_wrong_shape)
+
+        assert not r1.equal_georeferenced_grid(self.r1_wrong_transform)
 
 
     # List of operations with two operands

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -201,8 +201,6 @@ class TestSynthetic:
         The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.
         """
 
-
-
     def test_extract_vertices(self) -> None:
         """
         Test that extract_vertices works with simple geometries.

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -114,7 +114,7 @@ class TestVector:
     def test_proximity(self) -> None:
         """
         The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.
-        #TODO: add an artifical test as well (mirroring TODO in test_georaster)
+        #TODO: add an artificial test as well (mirroring TODO in test_georaster)
         """
 
         vector = gu.Vector(self.everest_outlines_path)
@@ -227,7 +227,6 @@ class TestSynthetic:
             # Difference between masks should always be thinner than buffer + 1
             eroded_diff = binary_erosion(diff.squeeze(), np.ones((abs(buffer) + 1, abs(buffer) + 1)))
             assert np.count_nonzero(eroded_diff) == 0
-
 
     def test_extract_vertices(self) -> None:
         """

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -111,6 +111,38 @@ class TestVector:
         # Check that some features were indeed removed
         assert np.sum(~np.array(intersects_old)) > 0
 
+    def test_proximity(self) -> None:
+        """
+        The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.
+        #TODO: add an artifical test as well (mirroring TODO in test_georaster)
+        """
+
+        vector = gu.Vector(self.everest_outlines_path)
+
+        # -- Test 1: with a Raster provided --
+        raster1 = gu.Raster(self.landsat_b4_crop_path)
+        prox1 = vector.proximity(raster=raster1)
+
+        # The proximity should have the same extent, resolution and CRS
+        assert raster1.equal_georeferenced_grid(prox1)
+
+        # With the base geometry
+        vector.proximity(raster=raster1, geometry_type="geometry")
+
+        # With another geometry option
+        vector.proximity(raster=raster1, geometry_type="centroid")
+
+        # With only inside proximity
+        vector.proximity(raster=raster1, in_or_out="in")
+
+        # -- Test 2: with no Raster provided, just grid size --
+
+        # Default grid size
+        vector.proximity()
+
+        # With specific grid size
+        vector.proximity(grid_size=(100, 100))
+
 
 class TestSynthetic:
 
@@ -196,10 +228,6 @@ class TestSynthetic:
             eroded_diff = binary_erosion(diff.squeeze(), np.ones((abs(buffer) + 1, abs(buffer) + 1)))
             assert np.count_nonzero(eroded_diff) == 0
 
-    def test_proximity(self) -> None:
-        """
-        The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.
-        """
 
     def test_extract_vertices(self) -> None:
         """

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import geopandas as gpd
-from geopandas.testing import assert_geodataframe_equal
 import numpy as np
 import pytest
+from geopandas.testing import assert_geodataframe_equal
 from scipy.ndimage import binary_erosion
 from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString
@@ -249,11 +249,23 @@ class TestSynthetic:
         # https://epsg.io/32631
         utm31_x_center = 500000
         utm31_y_center = 4649776
-        poly1_utm31 = Polygon([(utm31_x_center, utm31_y_center), (utm31_x_center+1, utm31_y_center),
-                               (utm31_x_center+1, utm31_y_center+1), (utm31_x_center, utm31_y_center+1)])
+        poly1_utm31 = Polygon(
+            [
+                (utm31_x_center, utm31_y_center),
+                (utm31_x_center + 1, utm31_y_center),
+                (utm31_x_center + 1, utm31_y_center + 1),
+                (utm31_x_center, utm31_y_center + 1),
+            ]
+        )
 
-        poly2_utm31 = Polygon([(utm31_x_center+10, utm31_y_center+10), (utm31_x_center+11, utm31_y_center+10),
-                               (utm31_x_center+11, utm31_y_center+11), (utm31_x_center+10, utm31_y_center+11)])
+        poly2_utm31 = Polygon(
+            [
+                (utm31_x_center + 10, utm31_y_center + 10),
+                (utm31_x_center + 11, utm31_y_center + 10),
+                (utm31_x_center + 11, utm31_y_center + 11),
+                (utm31_x_center + 10, utm31_y_center + 11),
+            ]
+        )
 
         # We initiate the squares of size 1x1 in a UTM projection
         two_squares = gu.Vector(gpd.GeoDataFrame(geometry=[poly1_utm31, poly2_utm31], crs="EPSG:32631"))
@@ -263,23 +275,28 @@ class TestSynthetic:
         assert two_squares.ds.area.values[1] == 1
 
         # We buffer them
-        two_squares_utm_buffered = two_squares.buffer_metric(buffer_size=1.)
+        two_squares_utm_buffered = two_squares.buffer_metric(buffer_size=1.0)
 
-        # Their area should now be 1 (square) + 4 (buffer along the sides) + 4*(pi*1**2 /4) (buffer of corners = quarter-disks)
+        # Their area should now be 1 (square) + 4 (buffer along the sides) + 4*(pi*1**2 /4)
+        # (buffer of corners = quarter-disks)
         expected_area = 1 + 4 + np.pi
         assert two_squares_utm_buffered.ds.area.values[0] == pytest.approx(expected_area, abs=0.01)
         assert two_squares_utm_buffered.ds.area.values[1] == pytest.approx(expected_area, abs=0.01)
 
         # And the new GeoDataFrame should exactly match that of one buffer from the original one
-        direct_gpd_buffer = gu.Vector(gpd.GeoDataFrame(geometry=two_squares.ds.buffer(distance=1.).geometry, crs=two_squares.crs))
+        direct_gpd_buffer = gu.Vector(
+            gpd.GeoDataFrame(geometry=two_squares.ds.buffer(distance=1.0).geometry, crs=two_squares.crs)
+        )
         assert_geodataframe_equal(direct_gpd_buffer.ds, two_squares_utm_buffered.ds)
 
         # Now, if we reproject the original vector in a non-metric system
         two_squares_geographic = gu.Vector(two_squares.ds.to_crs(epsg=4326))
         # We buffer directly the Vector object in the non-metric system
-        two_squares_geographic_buffered = two_squares_geographic.buffer_metric(buffer_size=1.)
+        two_squares_geographic_buffered = two_squares_geographic.buffer_metric(buffer_size=1.0)
         # Then, we reproject that vector in the UTM zone
-        two_squares_geographic_buffered_reproj = gu.Vector(two_squares_geographic_buffered.ds.to_crs(crs=two_squares.crs))
+        two_squares_geographic_buffered_reproj = gu.Vector(
+            two_squares_geographic_buffered.ds.to_crs(crs=two_squares.crs)
+        )
 
         # Their area should now be the same as before for each polygon
         assert two_squares_geographic_buffered_reproj.ds.area.values[0] == pytest.approx(expected_area, abs=0.01)
@@ -287,7 +304,6 @@ class TestSynthetic:
 
         # And this time, it is the reprojected GeoDataFrame that should almost match (within a tolerance of 10e-06)
         assert all(direct_gpd_buffer.ds.geom_almost_equals(two_squares_geographic_buffered_reproj.ds))
-
 
     def test_buffer_without_overlap(self) -> None:
         """

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -300,7 +300,7 @@ class TestSynthetic:
         # Check with buffers that should not overlap
         # ------------------------------------------
         buffer_size = 2
-        buffer = two_squares.buffer_without_overlap(buffer_size)
+        buffer = two_squares.buffer_without_overlap(buffer_size, metric=False)
 
         # Output should be of same size as input and same geometry type
         assert len(buffer.ds) == len(two_squares.ds)
@@ -328,7 +328,7 @@ class TestSynthetic:
         # Case 2 - Check with buffers that overlap -> this case is actually not the expected result !
         # -------------------------------
         buffer_size = 5
-        buffer = two_squares.buffer_without_overlap(buffer_size)
+        buffer = two_squares.buffer_without_overlap(buffer_size, metric=False)
 
         # Output should be of same size as input and same geometry type
         assert len(buffer.ds) == len(two_squares.ds)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -196,6 +196,13 @@ class TestSynthetic:
             eroded_diff = binary_erosion(diff.squeeze(), np.ones((abs(buffer) + 1, abs(buffer) + 1)))
             assert np.count_nonzero(eroded_diff) == 0
 
+    def test_proximity(self) -> None:
+        """
+        The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.
+        """
+
+
+
     def test_extract_vertices(self) -> None:
         """
         Test that extract_vertices works with simple geometries.

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -64,7 +64,7 @@ class TestProjTools:
             pt.utm_to_epsg("100N")
         # If type is incorrect
         with pytest.raises(TypeError):
-            pt.utm_to_epsg({'utm': '10N'})  # type: ignore
+            pt.utm_to_epsg({"utm": "10N"})  # type: ignore
         # If the code digits does not exist
         with pytest.raises(pyproj.exceptions.CRSError):
             pt.utm_to_epsg("61N")

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -2,6 +2,7 @@
 Test projtools
 """
 import numpy as np
+import pyproj.exceptions
 import pytest
 
 import geoutils as gu
@@ -21,7 +22,7 @@ class TestProjTools:
         # First: Check errors are raised when format is invalid
 
         # If format is invalid
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             pt.latlon_to_utm("1", 100)  # type: ignore
         # If values are outside limits: latitude above or below 90
         with pytest.raises(ValueError):
@@ -36,12 +37,12 @@ class TestProjTools:
 
         # Second: check that the UTM zone is correct
         # Lower left belongs to the zone, so 0, 0 should be in zone 31N
-        assert pt.latlon_to_utm(0, 0) == "31N"
+        assert pt.latlon_to_utm(0, 0) == "30N"
         # Test extreme zones
-        assert pt.latlon_to_utm(-89, -179) == "01S"
-        assert pt.latlon_to_utm(89, -179) == "01N"
-        assert pt.latlon_to_utm(-89, 179) == "60S"
-        assert pt.latlon_to_utm(89, 179) == "60N"
+        assert pt.latlon_to_utm(-79, -179) == "1S"
+        assert pt.latlon_to_utm(79, -179) == "1N"
+        assert pt.latlon_to_utm(-79, 179) == "60S"
+        assert pt.latlon_to_utm(79, 179) == "60N"
         # Test some middles zones
         assert pt.latlon_to_utm(1, -59) == "21N"
         assert pt.latlon_to_utm(1, 61) == "41N"
@@ -59,24 +60,24 @@ class TestProjTools:
         # First: Check errors are raised when format is invalid
 
         # If there isn't 2 digits for the code
-        with pytest.raises(ValueError):
+        with pytest.raises(pyproj.exceptions.CRSError):
             pt.utm_to_epsg("100N")
         # If type is incorrect
-        with pytest.raises(ValueError):
-            pt.utm_to_epsg(["1N"])  # type: ignore
+        with pytest.raises(TypeError):
+            pt.utm_to_epsg({'utm': '10N'})  # type: ignore
         # If the code digits does not exist
-        with pytest.raises(ValueError):
+        with pytest.raises(pyproj.exceptions.CRSError):
             pt.utm_to_epsg("61N")
         # If the north-south zone letter is incorrect
-        with pytest.raises(ValueError):
+        with pytest.raises(pyproj.exceptions.CRSError):
             pt.utm_to_epsg("61E")
 
         # Second: Check that the EPSG code is correct
         # https://epsg.io/32601
-        assert pt.utm_to_epsg("01N") == 32601
+        assert pt.utm_to_epsg("1N") == 32601
         # https://epsg.io/32701
-        assert pt.utm_to_epsg("01S") == 32701
-        # https://epsg.io/32660
+        assert pt.utm_to_epsg("1S") == 32701
+        # https://epsg.io/32&660
         assert pt.utm_to_epsg("60N") == 32660
         # https://epsg.io/32760
         assert pt.utm_to_epsg("60S") == 32760

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -16,6 +16,40 @@ class TestProjTools:
     landsat_rgb_path = examples.get_path("everest_landsat_rgb")
     aster_dem_path = examples.get_path("exploradores_aster_dem")
 
+    def test_utm_to_epsg(self) -> None:
+        """Check that the EPSG codes derived from UTM zones are correct"""
+
+        # First: Check errors are raised when format is invalid
+
+        # If there isn't 2 digits for the code
+        with pytest.raises(ValueError):
+            pt.utm_to_epsg('100N')
+        # If type is incorrect
+        with pytest.raises(ValueError):
+            pt.utm_to_epsg(['1N'])
+        # If the code digits does not exist
+        with pytest.raises(ValueError):
+            pt.utm_to_epsg('61N')
+        # If the north-south zone letter is incorrect
+        with pytest.raises(ValueError):
+            pt.utm_to_epsg('61E')
+
+        # Second: Check that the EPSG code is correct
+        # https://epsg.io/32601
+        assert pt.utm_to_epsg('01N') == 32601
+        # https://epsg.io/32701
+        assert pt.utm_to_epsg('01S') == 32701
+        # https://epsg.io/32660
+        assert pt.utm_to_epsg('60N') == 32660
+        # https://epsg.io/32760
+        assert pt.utm_to_epsg('60S') == 32760
+
+        # Third: Check that different format work: single digit, lower-case
+        assert pt.utm_to_epsg('1N') == pt.utm_to_epsg('01N') == pt.utm_to_epsg('01n')
+
+        assert pt.utm_to_epsg('08s') == pt.utm_to_epsg('8S') == pt.utm_to_epsg('08S')
+
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_latlon_reproject(self, example: str) -> None:
         """

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -16,6 +16,43 @@ class TestProjTools:
     landsat_rgb_path = examples.get_path("everest_landsat_rgb")
     aster_dem_path = examples.get_path("exploradores_aster_dem")
 
+    def test_latlon_to_utm(self) -> None:
+
+        # First: Check errors are raised when format is invalid
+
+        # If format is invalid
+        with pytest.raises(ValueError):
+            pt.latlon_to_utm('1', 100)
+        # If values are outside limits: latitude above or below 90
+        with pytest.raises(ValueError):
+            pt.latlon_to_utm(91, 0)
+        with pytest.raises(ValueError):
+            pt.latlon_to_utm(-91, 0)
+        # Or longitude above or below 180
+        with pytest.raises(ValueError):
+            pt.latlon_to_utm(0, -181)
+        with pytest.raises(ValueError):
+            pt.latlon_to_utm(0, 181)
+
+        # Second: check that the UTM zone is correct
+        # Lower left belongs to the zone, so 0, 0 should be in zone 31N
+        assert pt.latlon_to_utm(0, 0) == '31N'
+        # Test extreme zones
+        assert pt.latlon_to_utm(-89, -179) == '01S'
+        assert pt.latlon_to_utm(89, -179) == '01N'
+        assert pt.latlon_to_utm(-89, 179) == '60S'
+        assert pt.latlon_to_utm(89, 179) == '60N'
+        # Test some middles zones
+        assert pt.latlon_to_utm(1, -59) == '21N'
+        assert pt.latlon_to_utm(1, 61) == '41N'
+        assert pt.latlon_to_utm(-1, -121) == '10S'
+        assert pt.latlon_to_utm(-1, 119) == '50S'
+
+        # Third, check that any floating or integer type works
+        assert pt.latlon_to_utm(0.1, 0.1)
+        assert pt.latlon_to_utm(np.float32(0.1), np.float32(0.1))
+        assert pt.latlon_to_utm(np.int16(0), np.int16(0))
+
     def test_utm_to_epsg(self) -> None:
         """Check that the EPSG codes derived from UTM zones are correct"""
 
@@ -46,7 +83,6 @@ class TestProjTools:
 
         # Third: Check that different format work: single digit, lower-case
         assert pt.utm_to_epsg('1N') == pt.utm_to_epsg('01N') == pt.utm_to_epsg('01n')
-
         assert pt.utm_to_epsg('08s') == pt.utm_to_epsg('8S') == pt.utm_to_epsg('08S')
 
 

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -22,7 +22,7 @@ class TestProjTools:
 
         # If format is invalid
         with pytest.raises(ValueError):
-            pt.latlon_to_utm('1', 100)
+            pt.latlon_to_utm("1", 100)  # type: ignore
         # If values are outside limits: latitude above or below 90
         with pytest.raises(ValueError):
             pt.latlon_to_utm(91, 0)
@@ -36,17 +36,17 @@ class TestProjTools:
 
         # Second: check that the UTM zone is correct
         # Lower left belongs to the zone, so 0, 0 should be in zone 31N
-        assert pt.latlon_to_utm(0, 0) == '31N'
+        assert pt.latlon_to_utm(0, 0) == "31N"
         # Test extreme zones
-        assert pt.latlon_to_utm(-89, -179) == '01S'
-        assert pt.latlon_to_utm(89, -179) == '01N'
-        assert pt.latlon_to_utm(-89, 179) == '60S'
-        assert pt.latlon_to_utm(89, 179) == '60N'
+        assert pt.latlon_to_utm(-89, -179) == "01S"
+        assert pt.latlon_to_utm(89, -179) == "01N"
+        assert pt.latlon_to_utm(-89, 179) == "60S"
+        assert pt.latlon_to_utm(89, 179) == "60N"
         # Test some middles zones
-        assert pt.latlon_to_utm(1, -59) == '21N'
-        assert pt.latlon_to_utm(1, 61) == '41N'
-        assert pt.latlon_to_utm(-1, -121) == '10S'
-        assert pt.latlon_to_utm(-1, 119) == '50S'
+        assert pt.latlon_to_utm(1, -59) == "21N"
+        assert pt.latlon_to_utm(1, 61) == "41N"
+        assert pt.latlon_to_utm(-1, -121) == "10S"
+        assert pt.latlon_to_utm(-1, 119) == "50S"
 
         # Third, check that any floating or integer type works
         assert pt.latlon_to_utm(0.1, 0.1)
@@ -60,31 +60,30 @@ class TestProjTools:
 
         # If there isn't 2 digits for the code
         with pytest.raises(ValueError):
-            pt.utm_to_epsg('100N')
+            pt.utm_to_epsg("100N")
         # If type is incorrect
         with pytest.raises(ValueError):
-            pt.utm_to_epsg(['1N'])
+            pt.utm_to_epsg(["1N"])  # type: ignore
         # If the code digits does not exist
         with pytest.raises(ValueError):
-            pt.utm_to_epsg('61N')
+            pt.utm_to_epsg("61N")
         # If the north-south zone letter is incorrect
         with pytest.raises(ValueError):
-            pt.utm_to_epsg('61E')
+            pt.utm_to_epsg("61E")
 
         # Second: Check that the EPSG code is correct
         # https://epsg.io/32601
-        assert pt.utm_to_epsg('01N') == 32601
+        assert pt.utm_to_epsg("01N") == 32601
         # https://epsg.io/32701
-        assert pt.utm_to_epsg('01S') == 32701
+        assert pt.utm_to_epsg("01S") == 32701
         # https://epsg.io/32660
-        assert pt.utm_to_epsg('60N') == 32660
+        assert pt.utm_to_epsg("60N") == 32660
         # https://epsg.io/32760
-        assert pt.utm_to_epsg('60S') == 32760
+        assert pt.utm_to_epsg("60S") == 32760
 
         # Third: Check that different format work: single digit, lower-case
-        assert pt.utm_to_epsg('1N') == pt.utm_to_epsg('01N') == pt.utm_to_epsg('01n')
-        assert pt.utm_to_epsg('08s') == pt.utm_to_epsg('8S') == pt.utm_to_epsg('08S')
-
+        assert pt.utm_to_epsg("1N") == pt.utm_to_epsg("01N") == pt.utm_to_epsg("01n")
+        assert pt.utm_to_epsg("08s") == pt.utm_to_epsg("8S") == pt.utm_to_epsg("08S")
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_latlon_reproject(self, example: str) -> None:


### PR DESCRIPTION
## Summary

This PR adds a `proximity()` function to the `Vector` and `Raster` classes that mirrors GDAL's proximity not implemented in `rasterio` (https://github.com/rasterio/rasterio/issues/319), and a `buffer_metric()` method for the `Vector` class to avoid the trouble of reprojecting from geographic system, buffer, than reverse-projecting, based on finding a local UTM zone.
It also adds a `Raster` method `equal_georeferenced_grid` to check if two rasters have the same georeferencing.

## In details

### Proximity

The proximity is computed using `scipy.distance_transform_edt` (https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.distance_transform_edt.html).

The functioning is as follows:

- For `Raster` classes, the proximity can be either computed directly from target values of the array `self.data`, or from a `Vector` passed as argument that is automatically rasterized on `self`. For target values, the default behaviour is the same as GDAL: a list of any number of values can be passed. If none are passed, all non-zero values are targets. For the distance unit, I also implemented both "pixel" and "georeferenced", but put the default as "georeferenced" contrary to GDAL's "pixel".

- For `Vector` classes, the proximity can be computed from `self` by passing a `Raster` object to rasterize the vector on.

The resulting proximity values are thoroughly tested against GDAL Python's `gdal.ComputeProximity()` with artificial and real Raster data. All results are the same, except for very complex case where a few percentage of values (<1%) differ by ~1% (not even a floating point issue, GDAL's algorithm is simply slightly different for some cases).

Additionally, any `geometry_type` can be passed to rasterize the `Vector` object with (default: `boundary`, which is the most common). And an `in_or_out` option can be passed to include only the outside or inside proximity for a geometry that have an area (`Polygon`, `MultiPolygon`, etc). 

### Buffer metric

This function is to avoid the trouble of reprojecting a `Vector` in a local metric system for buffering without deformation, and then reverse-projecting. This involves finding the local metric system wanted, reprojecting to it, recreating a`geopandas.GeoDataFrame` object in the right CRS with the buffer `geopandas.GeoSeries`, and reverse-projecting.

For now this function only supports reprojecting in the local UTM which, for speed, is approximated by the latitude/longitude coordinates of the centroid of non-projected vector (centroid are not exactly the same depending on projections, but generally robust enough?).

Two new functions `latlon_to_utm` and `utm_to_epsg` in `projtools` help converting coordinates to UTM zone and to related EPSG (maybe there's some new stuff out there, but a couple years ago the `utm` Python package didn't allow UTM zones near poles, which was annoying, and I didn't know of any package that could interpret the UTM zone into an EPSG code).

All functions of `projtools` and the `buffer_metric` method in `Vector` are tested. I also added the `metric` argument in `buffer_without_overlap` function, which does the same procedure.

## Issues closed

This PR:

- Resolves #330,
- Resolves #267,
- Resolves #145,
- Resolves #202.

And adds tests for all.