### PR TITLE
Fix bugs and write tests for `Raster.value_at_coords()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 
         # Sort imports using isort
         - repo: https://github.com/PyCQA/isort
-          rev: 5.10.1
+          rev: 5.12.0
           hooks:
                   - id: isort
                     args: [ "--profile", "black" ]

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2026,12 +2026,18 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         """
         # Check for array-like inputs
-        if not isinstance(x, (float, np.floating, int, np.integer)) and isinstance(y, (float, np.floating, int, np.integer))\
-            or isinstance(x, (float, np.floating, int, np.integer)) and not isinstance(y, (float, np.floating, int, np.integer)):
-                raise TypeError("Coordinates must be of the same type.")
+        if (
+            not isinstance(x, (float, np.floating, int, np.integer))
+            and isinstance(y, (float, np.floating, int, np.integer))
+            or isinstance(x, (float, np.floating, int, np.integer))
+            and not isinstance(y, (float, np.floating, int, np.integer))
+        ):
+            raise TypeError("Coordinates must be both numbers or both array-like.")
 
         # If for a single value, wrap in a list
-        if isinstance(x, (float, np.floating, int, np.integer)) and isinstance(y, (float, np.floating, int, np.integer)):
+        if isinstance(x, (float, np.floating, int, np.integer)) and isinstance(
+            y, (float, np.floating, int, np.integer)
+        ):
             x = [x]
             y = [y]
             # For the end of the function
@@ -2039,7 +2045,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             unwrap = False
             # Check that array-like objects are the same length
-            if len(x) != len(y):
+            if len(x) != len(y):  # type: ignore
                 raise ValueError("Coordinates must be of the same length.")
 
         # Check window parameter
@@ -2068,17 +2074,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             list_windows = []
 
         # Loop over all coordinates passed
-        for k in range(len(x)):
+        for k in range(len(x)):  # type: ignore
 
             value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], np.ndarray] | Any]
 
             if latlon:
                 from geoutils import projtools
 
-                x0, y0 = projtools.reproject_from_latlon((y[k], x[k]), self.crs)
+                x0, y0 = projtools.reproject_from_latlon((y[k], x[k]), self.crs)  # type: ignore
             else:
-                x0 = x[k]
-                y0 = y[k]
+                x0 = x[k]  # type: ignore
+                y0 = y[k]  # type: ignore
 
             # Convert coordinates to pixel space
             row, col = rio.transform.rowcol(self.transform, x0, y0, op=round)
@@ -2114,7 +2120,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             else:
                 if self.nbands == 1:
                     with rio.open(self.filename) as raster:
-                        data = raster.read(window=rio_window, fill_value=self.nodata, boundless=boundless, masked=masked)
+                        data = raster.read(
+                            window=rio_window, fill_value=self.nodata, boundless=boundless, masked=masked
+                        )
                     value = format_value(data)
                     win = data
                 else:
@@ -2139,7 +2147,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             if return_window:
                 output_win = list_windows[0]
         else:
-            output_val = list_values
+            output_val = list_values  # type: ignore
             if return_window:
                 output_win = list_windows
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2078,6 +2078,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         if self.is_loaded:
             data = self.data[slice(None) if band is None else band, row : row + height, col : col + width]
+            if not masked:
+                data = data.filled()
             value = format_value(data)
             win: np.ndarray | dict[int, np.ndarray] = data
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1994,28 +1994,26 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         Optionally, return mean of pixels within a square window.
 
-        :param x: x (or longitude) coordinate.
-        :param y: y (or latitude) coordinate.
+        :param x: x (or longitude) coordinate(s).
+        :param y: y (or latitude) coordinate(s).
         :param latlon: Set to True if coordinates provided as longitude/latitude.
         :param band: the band number to extract from.
         :param masked: If `masked` is `True` the return value will be a masked
             array. Otherwise (the default) the return value will be a
             regular array.
-        :param window: expand area around coordinate to dimensions \
-                  window * window. window must be odd.
-        :param return_window: If True when window=int, returns (mean,array) \
+        :param window: expand area around coordinate to dimensions
+            window * window. window must be odd.
+        :param return_window: If True when window=int, returns (mean,array)
             where array is the dataset extracted via the specified window size.
         :param boundless: If `True`, windows that extend beyond the dataset's extent
             are permitted and partially or completely filled arrays (with self.nodata) will
             be returned as appropriate.
         :param reducer_function: a function to apply to the values in window.
 
-        :returns: When called on a Raster or with a specific band \
-            set, return value of pixel.
-        :returns: If multiple band Raster and the band is not specified, a \
+        :returns: When called on a Raster or with a specific band set, return value of pixel.
+        :returns: If multiple band Raster and the band is not specified, a
             dictionary containing the value of the pixel in each band.
-        :returns: In addition, if return_window=True, return tuple of \
-            (values, arrays)
+        :returns: In addition, if return_window=True, return tuple of (values, arrays)
 
         :examples:
 
@@ -2027,7 +2025,24 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             (c = provided coordinate, v= value of surrounding coordinate)
 
         """
-        value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], np.ndarray] | Any]
+        # Check for array-like inputs
+        if not isinstance(x, (float, np.floating, int, np.integer)) and isinstance(y, (float, np.floating, int, np.integer))\
+            or isinstance(x, (float, np.floating, int, np.integer)) and not isinstance(y, (float, np.floating, int, np.integer)):
+                raise TypeError("Coordinates must be of the same type.")
+
+        # If for a single value, wrap in a list
+        if isinstance(x, (float, np.floating, int, np.integer)) and isinstance(y, (float, np.floating, int, np.integer)):
+            x = [x]
+            y = [y]
+            # For the end of the function
+            unwrap = True
+        else:
+            unwrap = False
+            # Check that array-like objects are the same length
+            if len(x) != len(y):
+                raise ValueError("Coordinates must be of the same length.")
+
+        # Check window parameter
         if window is not None:
             if not float(window).is_integer():
                 raise ValueError("Window must be a whole number.")
@@ -2035,6 +2050,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 raise ValueError("Window must be an odd number.")
             window = int(window)
 
+        # Define subfunction for reducing the window array
         def format_value(value: Any) -> Any:
             """Check if valid value has been extracted"""
             if type(value) in [np.ndarray, np.ma.core.MaskedArray]:
@@ -2046,65 +2062,91 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 value = None
             return value
 
-        # Need to implement latlon option later
-        if latlon:
-            from geoutils import projtools
+        # Initiate output lists
+        list_values = []
+        if return_window:
+            list_windows = []
 
-            x, y = projtools.reproject_from_latlon((y, x), self.crs)
+        # Loop over all coordinates passed
+        for k in range(len(x)):
 
-        # Convert coordinates to pixel space
-        row, col = rio.transform.rowcol(self.transform, x, y, op=round)
+            value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], np.ndarray] | Any]
 
-        # Decide what pixel coordinates to read:
-        if window is not None:
-            half_win = (window - 1) / 2
-            # Subtract start coordinates back to top left of window
-            col = col - half_win
-            row = row - half_win
-            # Offset to read to == window
-            width = window
-            height = window
-        else:
-            # Start reading at col,row and read 1px each way
-            width = 1
-            height = 1
+            if latlon:
+                from geoutils import projtools
 
-        # Make sure coordinates are int
-        col = int(col)
-        row = int(row)
-
-        # Create rasterio's window for reading
-        window = rio.windows.Window(col, row, width, height)
-
-        if self.is_loaded:
-            data = self.data[slice(None) if band is None else band, row : row + height, col : col + width]
-            if not masked:
-                data = data.filled()
-            value = format_value(data)
-            win: np.ndarray | dict[int, np.ndarray] = data
-
-        else:
-            if self.nbands == 1:
-                with rio.open(self.filename) as raster:
-                    data = raster.read(window=window, fill_value=self.nodata, boundless=boundless, masked=masked)
-                value = format_value(data)
-                win = data
+                x0, y0 = projtools.reproject_from_latlon((y[k], x[k]), self.crs)
             else:
-                value = {}
-                win = {}
-                with rio.open(self.filename) as raster:
-                    for b in self.indexes:
-                        data = raster.read(
-                            window=window, fill_value=self.nodata, boundless=boundless, masked=masked, indexes=b
-                        )
-                        val = format_value(data)
-                        value[b] = val
-                        win[b] = data  # type: ignore
+                x0 = x[k]
+                y0 = y[k]
+
+            # Convert coordinates to pixel space
+            row, col = rio.transform.rowcol(self.transform, x0, y0, op=round)
+
+            # Decide what pixel coordinates to read:
+            if window is not None:
+                half_win = (window - 1) / 2
+                # Subtract start coordinates back to top left of window
+                col = col - half_win
+                row = row - half_win
+                # Offset to read to == window
+                width = window
+                height = window
+            else:
+                # Start reading at col,row and read 1px each way
+                width = 1
+                height = 1
+
+            # Make sure coordinates are int
+            col = int(col)
+            row = int(row)
+
+            # Create rasterio's window for reading
+            rio_window = rio.windows.Window(col, row, width, height)
+
+            if self.is_loaded:
+                data = self.data[slice(None) if band is None else band, row : row + height, col : col + width]
+                if not masked:
+                    data = data.filled()
+                value = format_value(data)
+                win: np.ndarray | dict[int, np.ndarray] = data
+
+            else:
+                if self.nbands == 1:
+                    with rio.open(self.filename) as raster:
+                        data = raster.read(window=rio_window, fill_value=self.nodata, boundless=boundless, masked=masked)
+                    value = format_value(data)
+                    win = data
+                else:
+                    value = {}
+                    win = {}
+                    with rio.open(self.filename) as raster:
+                        for b in self.indexes:
+                            data = raster.read(
+                                window=rio_window, fill_value=self.nodata, boundless=boundless, masked=masked, indexes=b
+                            )
+                            val = format_value(data)
+                            value[b] = val
+                            win[b] = data  # type: ignore
+
+            list_values.append(value)
+            if return_window:
+                list_windows.append(win)
+
+        # If for a single value, unwrap output list
+        if unwrap:
+            output_val = list_values[0]
+            if return_window:
+                output_win = list_windows[0]
+        else:
+            output_val = list_values
+            if return_window:
+                output_win = list_windows
 
         if return_window:
-            return (value, win)
-
-        return value
+            return (output_val, output_win)
+        else:
+            return output_val
 
     def coords(self, offset: str = "corner", grid: bool = True) -> tuple[np.ndarray, np.ndarray]:
         """

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1340,17 +1340,17 @@ self.set_nodata()."
         # 3/ Masked argument
         r_multi.data[:, itest, jtest] = np.ma.masked
         z_not_ma = r_multi.value_at_coords(xtest0, ytest0, band=1)
-        assert np.ma.is_masked(z_not_ma)
+        assert not np.ma.is_masked(z_not_ma)
         z_ma = r_multi.value_at_coords(xtest0, ytest0, band=1, masked=True)
         assert np.ma.is_masked(z_ma)
 
         # 4/ Window argument
-        val_window, z_window = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, return_window=True)
+        val_window, z_window = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, masked=True, return_window=True)
         assert val_window == np.ma.mean(r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2]) == np.ma.mean(z_window)
         assert np.array_equal(z_window, r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2])
 
         # 5/ Reducer function argument
-        val_window2 = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, reducer_function=np.ma.median)
+        val_window2 = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, masked=True, reducer_function=np.ma.median)
         assert val_window2 == np.ma.median(r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2])
 
         # -- Tests 3: check that errors are raised when supposed for non-boolean arguments --

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1260,7 +1260,7 @@ self.set_nodata()."
 
         xmin, ymin, xmax, ymax = r.bounds
 
-        # We can test with several method for the exact indexes: interp, value_at_coords, and simple read should
+        # We can test with several method for the exact indexes: interp, and simple read should
         # give back the same values that fall right on the coordinates
         xrand = np.random.randint(low=0, high=r.width, size=(10,)) * list(r.transform)[0] + xmin
         yrand = ymax + np.random.randint(low=0, high=r.height, size=(10,)) * list(r.transform)[4]
@@ -1272,7 +1272,6 @@ self.set_nodata()."
         for k in range(len(xrand)):
             # We directly sample the values
             z_ind = img[0, int(i[k]), int(j[k])]
-            # We can also compare with the value_at_coords() functionality
             list_z_ind.append(z_ind)
 
         rpts = r.interp_points(pts, order=1)
@@ -1371,6 +1370,25 @@ self.set_nodata()."
             r.value_at_coords(xtest0, ytest0, window=4)
         # But a window that is a whole number as a float works
         r.value_at_coords(xtest0, ytest0, window=3.0)  # type: ignore
+
+        # -- Tests 4: check that passing an array-like object works
+
+        # For simple coordinates
+        x_coords = [xtest0, xtest0+100]
+        y_coords = [ytest0, ytest0-100]
+        vals = r_multi.value_at_coords(x=x_coords, y=y_coords)
+        val0, win0 = r_multi.value_at_coords(x=x_coords[0], y=y_coords[0], return_window=True)
+        val1, win1 = r_multi.value_at_coords(x=x_coords[1], y=y_coords[1], return_window=True)
+
+        assert len(vals) == len(x_coords)
+        assert vals[0] == val0
+        assert vals[1] == val1
+
+        # With a return window argument
+        vals, windows = r_multi.value_at_coords(x=x_coords, y=y_coords, return_window=True)
+        assert len(windows) == len(x_coords)
+        assert np.array_equal(windows[0], win0, equal_nan=True)
+        assert np.array_equal(windows[1], win1, equal_nan=True)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_set_nodata(self, example: str) -> None:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1374,8 +1374,8 @@ self.set_nodata()."
         # -- Tests 4: check that passing an array-like object works
 
         # For simple coordinates
-        x_coords = [xtest0, xtest0+100]
-        y_coords = [ytest0, ytest0-100]
+        x_coords = [xtest0, xtest0 + 100]
+        y_coords = [ytest0, ytest0 - 100]
         vals = r_multi.value_at_coords(x=x_coords, y=y_coords)
         val0, win0 = r_multi.value_at_coords(x=x_coords[0], y=y_coords[0], return_window=True)
         val1, win1 = r_multi.value_at_coords(x=x_coords[1], y=y_coords[1], return_window=True)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1297,7 +1297,7 @@ self.set_nodata()."
 
         # -- Tests 1: check based on indexed values --
 
-        # Open two rasters and crop the first one
+        # Open raster
         r = gr.Raster(self.landsat_b4_crop_path)
 
         # Random test point that raised an error

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1324,7 +1324,7 @@ self.set_nodata()."
         z_val_2 = r.value_at_coords(lon, lat, latlon=True)
         assert z_val == z_val_2
 
-        # 2/ Band argment
+        # 2/ Band argument
         # Get the indexes for the multi-band Raster
         r_multi = gr.Raster(self.landsat_rgb_path)
         itest, jtest = r_multi.xy2ij(xtest0, ytest0)
@@ -1345,25 +1345,32 @@ self.set_nodata()."
         assert np.ma.is_masked(z_ma)
 
         # 4/ Window argument
-        val_window, z_window = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, masked=True, return_window=True)
-        assert val_window == np.ma.mean(r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2]) == np.ma.mean(z_window)
-        assert np.array_equal(z_window, r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2])
+        val_window, z_window = r_multi.value_at_coords(
+            xtest0, ytest0, band=0, window=3, masked=True, return_window=True
+        )
+        assert (
+            val_window
+            == np.ma.mean(r_multi.data[0, itest - 1 : itest + 2, jtest - 1 : jtest + 2])
+            == np.ma.mean(z_window)
+        )
+        assert np.array_equal(z_window, r_multi.data[0, itest - 1 : itest + 2, jtest - 1 : jtest + 2])
 
         # 5/ Reducer function argument
-        val_window2 = r_multi.value_at_coords(xtest0, ytest0, band=0, window=3, masked=True, reducer_function=np.ma.median)
-        assert val_window2 == np.ma.median(r_multi.data[0, itest-1:itest+2, jtest-1:jtest+2])
+        val_window2 = r_multi.value_at_coords(
+            xtest0, ytest0, band=0, window=3, masked=True, reducer_function=np.ma.median
+        )
+        assert val_window2 == np.ma.median(r_multi.data[0, itest - 1 : itest + 2, jtest - 1 : jtest + 2])
 
         # -- Tests 3: check that errors are raised when supposed for non-boolean arguments --
 
         # Verify that passing a window that is not a whole number fails
         with pytest.raises(ValueError, match=re.escape("Window must be a whole number.")):
-            r.value_at_coords(xtest0, ytest0, window=3.5) # type: ignore
+            r.value_at_coords(xtest0, ytest0, window=3.5)  # type: ignore
         # Same for an odd number
         with pytest.raises(ValueError, match=re.escape("Window must be an odd number.")):
             r.value_at_coords(xtest0, ytest0, window=4)
         # But a window that is a whole number as a float works
-        r.value_at_coords(xtest0, ytest0, window=3.0) # type: ignore
-
+        r.value_at_coords(xtest0, ytest0, window=3.0)  # type: ignore
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_set_nodata(self, example: str) -> None:


### PR DESCRIPTION
This PR adds tests for the `value_at_coords` function, adds the functionality of passing an array-like object of coordinates, and fixes minors bugs.

It looks like  more changes than there actually is in the "Files changed". Owing to shifting blocks of code in `value_at_coords` to be either in or out of the loop (added for array-like).

There's also a setup bug with `isort` that they recommend to fix by upgrading to `5.12.0` (will need the same in xDEM): moved to #343.

Resolves #324
Resolves #245