### PR TITLE
Add support for `pathlib.Path` object as `filename` of Raster and Vector

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import math
 import os
+import pathlib
 import warnings
 from collections import abc
 from collections.abc import Iterable
 from contextlib import ExitStack
 from numbers import Number
 from typing import IO, Any, Callable, TypeVar, overload
-import pathlib
 
 import geopandas as gpd
 import matplotlib
@@ -26,9 +26,9 @@ import rasterio.windows
 from affine import Affine
 from matplotlib import cm, colors
 from rasterio.crs import CRS
+from rasterio.enums import Resampling
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
-from rasterio.enums import Resampling
 from scipy.ndimage import distance_transform_edt, map_coordinates
 
 import geoutils.geovector as gv
@@ -245,7 +245,12 @@ class Raster:
 
     def __init__(
         self,
-        filename_or_dataset: str | pathlib.Path | RasterType | rio.io.DatasetReader | rio.io.MemoryFile | dict[str, Any],
+        filename_or_dataset: str
+        | pathlib.Path
+        | RasterType
+        | rio.io.DatasetReader
+        | rio.io.MemoryFile
+        | dict[str, Any],
         bands: None | int | list[int] = None,
         load_data: bool = True,
         downsample: AnyNumber = 1,
@@ -319,7 +324,7 @@ class Raster:
             with ExitStack():
                 if isinstance(filename_or_dataset, (str, pathlib.Path)):
                     ds: rio.io.DatasetReader = rio.open(filename_or_dataset)
-                    self.filename = filename_or_dataset
+                    self.filename = str(filename_or_dataset)
                 elif isinstance(filename_or_dataset, rio.io.DatasetReader):
                     ds = filename_or_dataset
                     self.filename = filename_or_dataset.files[0]

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable
 from contextlib import ExitStack
 from numbers import Number
 from typing import IO, Any, Callable, TypeVar, overload
+import pathlib
 
 import geopandas as gpd
 import matplotlib
@@ -27,7 +28,7 @@ from matplotlib import cm, colors
 from rasterio.crs import CRS
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
-from rasterio.warp import Resampling
+from rasterio.enums import Resampling
 from scipy.ndimage import distance_transform_edt, map_coordinates
 
 import geoutils.geovector as gv
@@ -244,7 +245,7 @@ class Raster:
 
     def __init__(
         self,
-        filename_or_dataset: str | RasterType | rio.io.DatasetReader | rio.io.MemoryFile | dict[str, Any],
+        filename_or_dataset: str | pathlib.Path | RasterType | rio.io.DatasetReader | rio.io.MemoryFile | dict[str, Any],
         bands: None | int | list[int] = None,
         load_data: bool = True,
         downsample: AnyNumber = 1,
@@ -308,7 +309,7 @@ class Raster:
                 setattr(self, key, filename_or_dataset.__dict__[key])
             return
         # Image is a file on disk.
-        elif isinstance(filename_or_dataset, (str, rio.io.DatasetReader, rio.io.MemoryFile)):
+        elif isinstance(filename_or_dataset, (str, pathlib.Path, rio.io.DatasetReader, rio.io.MemoryFile)):
 
             # ExitStack is used instead of "with rio.open(filename_or_dataset) as ds:".
             # This is because we might not actually want to open it like that, so this is equivalent
@@ -316,7 +317,7 @@ class Raster:
             # "with rio.open(filename_or_dataset) as ds if isinstance(filename_or_dataset, str) else ds:"
             # This is slightly black magic, but it works!
             with ExitStack():
-                if isinstance(filename_or_dataset, str):
+                if isinstance(filename_or_dataset, (str, pathlib.Path)):
                     ds: rio.io.DatasetReader = rio.open(filename_or_dataset)
                     self.filename = filename_or_dataset
                 elif isinstance(filename_or_dataset, rio.io.DatasetReader):
@@ -1669,7 +1670,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     def save(
         self,
-        filename: str | IO[bytes],
+        filename: str | pathlib.Path | IO[bytes],
         driver: str = "GTiff",
         dtype: DTypeLike | None = None,
         nodata: AnyNumber | None = None,

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -3,11 +3,11 @@ geoutils.vectortools provides a toolset for working with vector data.
 """
 from __future__ import annotations
 
+import pathlib
 import warnings
 from collections import abc
 from numbers import Number
 from typing import Literal, TypeVar, overload
-import pathlib
 
 import geopandas as gpd
 import matplotlib.pyplot as plt

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -7,6 +7,7 @@ import warnings
 from collections import abc
 from numbers import Number
 from typing import Literal, TypeVar, overload
+import pathlib
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
@@ -30,7 +31,7 @@ class Vector:
     Create a Vector object from a fiona-supported vector dataset.
     """
 
-    def __init__(self, filename: str | gpd.GeoDataFrame):
+    def __init__(self, filename: str | pathlib.Path | gpd.GeoDataFrame):
         """
         Load a fiona-supported dataset, given a filename.
 
@@ -39,7 +40,7 @@ class Vector:
         :return: A Vector object
         """
 
-        if isinstance(filename, str):
+        if isinstance(filename, (str, pathlib.Path)):
             with warnings.catch_warnings():
                 # This warning shows up in numpy 1.21 (2021-07-09)
                 warnings.filterwarnings("ignore", ".*attribute.*array_interface.*Polygon.*")

--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -74,18 +74,18 @@ def deprecate(removal_version: str | None = None, details: str | None = None):  
     return deprecator_func
 
 
-def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
+def resampling_method_from_str(method_str: str) -> rio.enums.Resampling:
     """Get a rasterio resampling method from a string representation, e.g. "cubic_spline"."""
     # Try to match the string version of the resampling method with a rio Resampling enum name
-    for method in rio.warp.Resampling:
-        if str(method).replace("Resampling.", "") == method_str:
+    for method in rio.enums.Resampling:
+        if method.name == method_str:
             resampling_method = method
             break
     # If no match was found, raise an error.
     else:
         raise ValueError(
-            f"'{method_str}' is not a valid rasterio.warp.Resampling method. "
-            f"Valid methods: {[str(method).replace('Resampling.', '') for method in rio.warp.Resampling]}"
+            f"'{method_str}' is not a valid rasterio.enums.Resampling method. "
+            f"Valid methods: {[method.name for method in rio.enums.Resampling]}"
         )
     return resampling_method
 

--- a/geoutils/spatial_tools.py
+++ b/geoutils/spatial_tools.py
@@ -201,7 +201,7 @@ def merge_bounding_boxes(bounds: list[rio.coords.BoundingBox], resolution: float
 def stack_rasters(
     rasters: list[RasterType],
     reference: int | gu.Raster = 0,
-    resampling_method: str | rio.warp.Resampling = "bilinear",
+    resampling_method: str | rio.enums.Resampling = "bilinear",
     use_ref_bounds: bool = False,
     diff: bool = False,
     progress: bool = True,
@@ -306,7 +306,7 @@ def merge_rasters(
     rasters: list[RasterType],
     reference: int | Raster = 0,
     merge_algorithm: Callable | list[Callable] = np.nanmean,  # type: ignore
-    resampling_method: str | rio.warp.Resampling = "bilinear",
+    resampling_method: str | rio.enums.Resampling = "bilinear",
     use_ref_bounds: bool = False,
     progress: bool = True,
 ) -> RasterType:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1664,14 +1664,14 @@ self.set_nodata()."
         temp_dir = tempfile.TemporaryDirectory()
 
         # Save file to temporary file, with defaults opts
-        with NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name) as temp_file:
-            img.save(temp_file.name)
-            saved = gr.Raster(temp_file.name)
-            assert img == saved
+        temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
+        img.save(temp_file.name)
+        saved = gr.Raster(temp_file.name)
+        assert img == saved
 
-            # Try to save with a pathlib path
-            path = pathlib.Path(temp_file.name)
-            img.save(path)
+        # Try to save with a pathlib path
+        path = pathlib.Path(temp_file.name)
+        img.save(path)
 
         # Test additional options
         co_opts = {"TILED": "YES", "COMPRESS": "LZW"}

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import warnings
 from tempfile import NamedTemporaryFile, TemporaryFile
+import pathlib
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -76,15 +77,20 @@ class TestRaster:
     def test_init(self, example: str) -> None:
         """Test that all possible inputs work properly in Raster class init"""
 
-        # First, filename
-        r = gr.Raster(example)
-        assert isinstance(r, gr.Raster)
+        # First, string filename
+        r0 = gr.Raster(example)
+        assert isinstance(r0, gr.Raster)
 
-        # Second, passing a Raster itself (points back to Raster passed)
-        r2 = gr.Raster(r)
+        # Second, filename in a pathlib object
+        path = pathlib.Path(example)
+        r1 = gr.Raster(path)
+        assert isinstance(r1, gr.Raster)
+
+        # Third, passing a Raster itself (points back to Raster passed)
+        r2 = gr.Raster(r0)
         assert isinstance(r2, gr.Raster)
 
-        # Third, rio.Dataset
+        # Fourth, rio.Dataset
         ds = rio.open(example)
         r3 = gr.Raster(ds)
         assert isinstance(r3, gr.Raster)
@@ -95,15 +101,15 @@ class TestRaster:
         r4 = gr.Raster(memfile)
         assert isinstance(r4, gr.Raster)
 
-        assert r == r2 == r3 == r4
+        assert r0 == r1 == r2 == r3 == r4
 
         # The data will not be copied, immutable objects will
-        r.data[0, 0, 0] += 5
-        assert r2.data[0, 0, 0] == r.data[0, 0, 0]
+        r0.data[0, 0, 0] += 5
+        assert r2.data[0, 0, 0] == r0.data[0, 0, 0]
 
         # With r.nbands = 2
-        r._data = np.repeat(r.data, 2).reshape((2,) + r.shape)
-        assert r.nbands != r2.nbands
+        r0._data = np.repeat(r0.data, 2).reshape((2,) + r0.shape)
+        assert r0.nbands != r2.nbands
 
         # Test that loaded data are always masked_arrays (but the mask may be empty, i.e. 'False')
         assert np.ma.isMaskedArray(gr.Raster(example, masked=True).data)
@@ -1649,7 +1655,7 @@ self.set_nodata()."
         assert True
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
-    def test_saving(self, example: str) -> None:
+    def test_save(self, example: str) -> None:
 
         # Read single band raster
         img = gr.Raster(example)
@@ -1658,10 +1664,14 @@ self.set_nodata()."
         temp_dir = tempfile.TemporaryDirectory()
 
         # Save file to temporary file, with defaults opts
-        temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
-        img.save(temp_file.name)
-        saved = gr.Raster(temp_file.name)
-        assert img == saved
+        with NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name) as temp_file:
+            img.save(temp_file.name)
+            saved = gr.Raster(temp_file.name)
+            assert img == saved
+
+            # Try to save with a pathlib path
+            path = pathlib.Path(temp_file.name)
+            img.save(path)
 
         # Test additional options
         co_opts = {"TILED": "YES", "COMPRESS": "LZW"}
@@ -1865,14 +1875,14 @@ self.set_nodata()."
     def test_resampling_str(self) -> None:
         """Test that resampling methods can be given as strings instead of rio enums."""
         warnings.simplefilter("error")
-        assert resampling_method_from_str("nearest") == rio.warp.Resampling.nearest  # noqa
-        assert resampling_method_from_str("cubic_spline") == rio.warp.Resampling.cubic_spline  # noqa
+        assert resampling_method_from_str("nearest") == rio.enums.Resampling.nearest  # noqa
+        assert resampling_method_from_str("cubic_spline") == rio.enums.Resampling.cubic_spline  # noqa
 
         # Check that odd strings return the appropriate error.
         try:
             resampling_method_from_str("CUBIC_SPLINE")  # noqa
         except ValueError as exception:
-            if "not a valid rasterio.warp.Resampling method" not in str(exception):
+            if "not a valid rasterio.enums.Resampling method" not in str(exception):
                 raise exception
 
         img1 = gr.Raster(self.landsat_b4_path)
@@ -1882,7 +1892,7 @@ self.set_nodata()."
 
         # Resample the rasters using a new resampling method and see that the string and enum gives the same result.
         img3a = img1.reproject(img2, resampling="q1")
-        img3b = img1.reproject(img2, resampling=rio.warp.Resampling.q1)
+        img3b = img1.reproject(img2, resampling=rio.enums.Resampling.q1)
         assert img3a == img3b
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1669,8 +1669,9 @@ self.set_nodata()."
         saved = gr.Raster(temp_file.name)
         assert img == saved
 
-        # Try to save with a pathlib path
-        path = pathlib.Path(temp_file.name)
+        # Try to save with a pathlib path (create a new temp file for Windows)
+        temp_file_1 = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
+        path = pathlib.Path(temp_file_1.name)
         img.save(path)
 
         # Test additional options

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -4,11 +4,11 @@ Test functions for georaster
 from __future__ import annotations
 
 import os
+import pathlib
 import re
 import tempfile
 import warnings
 from tempfile import NamedTemporaryFile, TemporaryFile
-import pathlib
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import geopandas as gpd
+import pathlib
 import numpy as np
 import pytest
 from geopandas.testing import assert_geodataframe_equal
@@ -24,10 +25,24 @@ class TestVector:
     glacier_outlines = gu.Vector(GLACIER_OUTLINES_URL)
 
     def test_init(self) -> None:
+        """Test class initiation works as intended"""
 
-        vector = gu.Vector(GLACIER_OUTLINES_URL)
+        # First, with a URL filename
+        v = gu.Vector(GLACIER_OUTLINES_URL)
+        assert isinstance(v, gu.Vector)
 
-        assert isinstance(vector, gu.Vector)
+        # Second, with a string filename
+        v0 = gu.Vector(self.aster_outlines_path)
+        assert isinstance(v0, gu.Vector)
+
+        # Second, with a pathlib path
+        path = pathlib.Path(self.aster_outlines_path)
+        v1 = gu.Vector(path)
+        assert isinstance(v1, gu.Vector)
+
+        # Third, with a geopandas dataframe
+        v2 = gu.Vector(gpd.read_file(self.aster_outlines_path))
+        assert isinstance(v2, gu.Vector)
 
     def test_copy(self) -> None:
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import geopandas as gpd
 import pathlib
+
+import geopandas as gpd
 import numpy as np
 import pytest
 from geopandas.testing import assert_geodataframe_equal


### PR DESCRIPTION
Resolves #239 and adds tests.

Additionally, updates the list of resampling algorithms of `rasterio` from `rio.warp.Resampling` to `rio.enums.Resampling`, and gets the names using `.name` instead of `str()`, which fails in Python `3.11` (opened issue: https://github.com/rasterio/rasterio/issues/2750).