### PR TITLE
Fix `isort` version in `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 
         # Sort imports using isort
         - repo: https://github.com/PyCQA/isort
-          rev: 5.10.1
+          rev: 5.12.0
           hooks:
                   - id: isort
                     args: [ "--profile", "black" ]


### PR DESCRIPTION
One-line PR to update the `isort` version, that otherwise keeps failing on build when trying to run `pre-commit` on all other PRs opened or ongoing.