### PR TITLE
Add `Mask` subclass

### DIFF
--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -4,7 +4,7 @@ GeoUtils is a python package of raster and vector tools.
 
 from geoutils import spatial_tools  # noqa
 from geoutils import examples, georaster, geovector, projtools, satimg  # noqa
-from geoutils.georaster import Raster, Mask  # noqa
+from geoutils.georaster import Mask, Raster  # noqa
 from geoutils.geovector import Vector  # noqa
 from geoutils.satimg import SatelliteImage  # noqa
 

--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -4,7 +4,7 @@ GeoUtils is a python package of raster and vector tools.
 
 from geoutils import spatial_tools  # noqa
 from geoutils import examples, georaster, geovector, projtools, satimg  # noqa
-from geoutils.georaster import Raster  # noqa
+from geoutils.georaster import Raster, Mask  # noqa
 from geoutils.geovector import Vector  # noqa
 from geoutils.satimg import SatelliteImage  # noqa
 

--- a/geoutils/georaster/__init__.py
+++ b/geoutils/georaster/__init__.py
@@ -1,3 +1,3 @@
-from geoutils.georaster.raster import Raster, RasterType  # noqa isort:skip
+from geoutils.georaster.raster import Raster, RasterType, Mask  # noqa isort:skip
 
 __all__ = ["RasterType", "Raster"]

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -549,7 +549,7 @@ class Raster:
         else:
             return self.crop(cropGeom=value, inplace=False)
 
-    def __eq__(self, other: object) -> bool:
+    def raster_equal(self, other: object) -> bool:
         """Check if a Raster masked array's data (including masked values), mask, fill_value and dtype are equal,
         as well as the Raster's nodata, and georeferencing."""
 
@@ -566,9 +566,6 @@ class Raster:
                 self.nodata == other.nodata,
             ]
         )
-
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
 
     def _overloading_check(
         self: RasterType, other: RasterType | np.ndarray | Number

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -2806,7 +2806,7 @@ class Mask(Raster):
             super().__init__(filename_or_dataset, **kwargs)
 
             # If nbands larger than one, use only first band and raise a warning
-            if self.nbands > 1:
+            if self.count > 1:
                 warnings.warn(
                     category=UserWarning,
                     message="Multi-band raster provided to create a Mask, only the first band will be used.",
@@ -2815,9 +2815,6 @@ class Mask(Raster):
 
             # Convert masked array to boolean
             self._data = self.data.astype(bool)
-
-            # Fix nband to one
-            self._nbands = 1
 
             # Fix nodata to None
             self._nodata = None

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -86,10 +86,24 @@ _HANDLED_FUNCTIONS_1NIN = (
         "quantile",
     ]
     + ["sort", "count_nonzero", "unique"]
-    + ["all", "any", "isfinite", "isinf", "isnan", "logical_not"])
+    + ["all", "any", "isfinite", "isinf", "isnan", "logical_not"]
+)
 
-_HANDLED_FUNCTIONS_2NIN = (["logical_and", "logical_or", "logical_xor", "allclose","isclose","array_equal","array_equiv","greater",
-                            "greater_equal",  "less", "less_equal",  "equal", "not_equal"])
+_HANDLED_FUNCTIONS_2NIN = [
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "allclose",
+    "isclose",
+    "array_equal",
+    "array_equiv",
+    "greater",
+    "greater_equal",
+    "less",
+    "less_equal",
+    "equal",
+    "not_equal",
+]
 
 
 # Function to set the default nodata values for any given dtype
@@ -1385,7 +1399,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             return func(first_arg, *args[1:], **kwargs)  # type: ignore
         else:
             second_arg = args[1].data
-            return func(first_arg, second_arg, *args[2:], **kwargs) # type: ignore
+            return func(first_arg, second_arg, *args[2:], **kwargs)  # type: ignore
 
     # Note the star is needed because of the default argument 'mode' preceding non default arg 'inplace'
     # Then the final overload must be duplicated

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -249,7 +249,7 @@ class Vector:
         if rst is not None:
             mask = mask.reshape((rst.count, rst.height, rst.width))  # type: ignore
 
-        return gu.Mask.from_array(data=mask, transform=transform, crs=crs, nodata=None)
+        return gu.Raster.from_array(data=mask, transform=transform, crs=crs, nodata=None)
 
     def rasterize(
         self,

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -423,7 +423,7 @@ class Vector:
             raise ValueError("in_value must be a single number or an iterable with same length as self.ds.geometry")
 
         # We return a mask if there is a single value to burn and this value is 1
-        if isinstance(in_value, Number) and in_value == 1:
+        if isinstance(in_value, (int, np.integer, float, np.floating)) and in_value == 1:
             output = gu.Mask.from_array(data=mask, transform=transform, crs=crs, nodata=None)
 
         # Otherwise we return a Raster if there are several values to burn

--- a/geoutils/geovector.py
+++ b/geoutils/geovector.py
@@ -358,7 +358,7 @@ class Vector:
         else:
             raise ValueError("in_value must be a single number or an iterable with same length as self.ds.geometry")
 
-        # We return a mask if there is a single value to burn and this value is ojne
+        # We return a mask if there is a single value to burn and this value is 1
         if isinstance(in_value, Number) and in_value == 1:
             output = gu.Mask.from_array(data=mask, transform=transform, crs=crs, nodata=None)
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -2310,7 +2310,7 @@ class TestMask:
         # Check the nodata
         assert mask.nodata is None
         # Check the nbands metadata
-        assert mask.nbands == 1
+        assert mask.count == 1
 
         # Check that a mask object is sent back from its own init
         mask2 = gu.Mask(mask)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -2288,8 +2288,8 @@ class TestMask:
     arr_mask = np.random.randint(0, 2, size=(1, width, height), dtype=bool)
     mask_ma = np.ma.masked_array(data=arr, mask=arr_mask)
 
-    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])
-    def test_init(self, example: str):
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])  # type: ignore
+    def test_init(self, example: str) -> None:
         """Test that Mask subclass initialization function as intended."""
 
         # A warning should be raised when the raster is a multi-band
@@ -2316,7 +2316,7 @@ class TestMask:
         mask2 = gu.Mask(mask)
         assert mask.raster_equal(mask2)
 
-    def test_from_array(self):
+    def test_from_array(self) -> None:
         """Test that Raster.__init__ casts to Mask with dict input of from_array() and a boolean data array."""
 
         mask_rst = gu.Raster.from_array(data=self.mask_ma, transform=self.transform, crs=None, nodata=None)
@@ -2336,9 +2336,9 @@ class TestMask:
         "__ge__",
     ]
 
-    @pytest.mark.parametrize("op", ops_logical)
-    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])
-    def test_logical_casting_real(self, example: str, op: str):
+    @pytest.mark.parametrize("op", ops_logical)  # type: ignore
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
+    def test_logical_casting_real(self, example: str, op: str) -> None:
         """
         Test that logical operations cast Raster object to Mask on real data
         (synthetic done in TestArithmetic).
@@ -2352,8 +2352,8 @@ class TestMask:
         assert np.array_equal(mask.data.data, getattr(rst.data.data, op)(1))
         assert np.array_equal(mask.data.mask, rst.data.mask)
 
-    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])
-    def test_implicit_logical_casting_real(self, example: str):
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
+    def test_implicit_logical_casting_real(self, example: str) -> None:
         """
         Test that implicit logical operations on real data
         (synthetic done in TestArithmetic).

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -2809,7 +2809,6 @@ class TestArrayInterface:
     # - sorting and counting;
     # Most other math functions are already universal functions
 
-
     # Separate between two lists (single input and double input) for testing
     handled_functions_2in = gu.georaster.raster._HANDLED_FUNCTIONS_2NIN
     handled_functions_1in = gu.georaster.raster._HANDLED_FUNCTIONS_1NIN

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -101,7 +101,9 @@ class TestRaster:
         r4 = gr.Raster(memfile)
         assert isinstance(r4, gr.Raster)
 
-        assert all([r0.raster_equal(r1), r0.raster_equal(r1), r0.raster_equal(r2), r0.raster_equal(r3), r0.raster_equal(r4)])
+        assert all(
+            [r0.raster_equal(r1), r0.raster_equal(r1), r0.raster_equal(r2), r0.raster_equal(r3), r0.raster_equal(r4)]
+        )
 
         # The data will not be copied, immutable objects will
         r0.data[0, 0, 0] += 5
@@ -2092,14 +2094,15 @@ class TestMask:
 
     @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])
     def test_init(self, example: str):
-        """Test that Mask subclass intialization function as intended."""
+        """Test that Mask subclass initialization function as intended."""
 
         # A warning should be raised when the raster is a multi-band
         if "rgb" not in os.path.basename(example):
             mask = gu.Mask(example)
         else:
-            with pytest.warns(UserWarning, match="Multi-band raster provided to create a Mask, "
-                                                 "only the first band will be used."):
+            with pytest.warns(
+                UserWarning, match="Multi-band raster provided to create a Mask, only the first band will be used."
+            ):
                 mask = gu.Mask(example)
 
         # Check the masked array type
@@ -2806,14 +2809,10 @@ class TestArrayInterface:
     # - sorting and counting;
     # Most other math functions are already universal functions
 
-    # The full list exists in Raster
-    handled_functions = gu.georaster.raster._HANDLED_FUNCTIONS
 
     # Separate between two lists (single input and double input) for testing
-    handled_functions_2in = ["logical_and", "logical_or", "logical_xor", "logical_not", "all_close", "isclose", "array_equal", "array_equiv",
-                             "greater", "greater_equal", "less", "less_equal", "equal", "not_equal"]
-
-    handled_functions_1in = [hf for hf in handled_functions if hf not in handled_functions_2in]
+    handled_functions_2in = gu.georaster.raster._HANDLED_FUNCTIONS_2NIN
+    handled_functions_1in = gu.georaster.raster._HANDLED_FUNCTIONS_1NIN
 
     # Details below:
     # NaN functions: [f for f in np.lib.nanfunctions.__all__]
@@ -2987,7 +2986,9 @@ class TestArrayInterface:
     )  # type: ignore
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
     def test_array_functions_1nin(self, arrfunc_str: str, dtype: str, nodata_init: None | str) -> None:
-        """Test that single-input array functions that we support give the same output as they would on the masked array"""
+        """
+        Test that single-input array functions that we support give the same output as they would on the masked array.
+        """
 
         # We set the default nodata
         if nodata_init == "type_default":
@@ -3046,9 +3047,11 @@ class TestArrayInterface:
     @pytest.mark.parametrize("nodata1_init", [None, "type_default"])  # type: ignore
     @pytest.mark.parametrize("nodata2_init", [None, "type_default"])  # type: ignore
     def test_array_functions_2nin(
-            self, arrfunc_str: str, nodata1_init: None | str, nodata2_init: str, dtype1: str, dtype2: str
+        self, arrfunc_str: str, nodata1_init: None | str, nodata2_init: str, dtype1: str, dtype2: str
     ) -> None:
-        """Test that double-input array functions that we support give the same output as they would on the masked array"""
+        """
+        Test that double-input array functions that we support give the same output as they would on the masked array.
+        """
 
         # We set the default nodatas
         if nodata1_init == "type_default":
@@ -3077,4 +3080,3 @@ class TestArrayInterface:
             output_ma = arrfunc(rst1.data, rst2.data)
 
             assert np.ma.allequal(output_rst, output_ma)
-

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -101,7 +101,7 @@ class TestRaster:
         r4 = gr.Raster(memfile)
         assert isinstance(r4, gr.Raster)
 
-        assert r0 == r1 == r2 == r3 == r4
+        assert all([r0.raster_equal(r1), r0.raster_equal(r1), r0.raster_equal(r2), r0.raster_equal(r3), r0.raster_equal(r4)])
 
         # The data will not be copied, immutable objects will
         r0.data[0, 0, 0] += 5
@@ -428,7 +428,7 @@ class TestRaster:
         # Check that modifying the NaN array does not back-propagate to the original array (np.ma.filled returns a view
         # when there is no invalid data, but in this case get_nanarray should copy the data).
         rst_arr += 5
-        assert rst == rst_copy
+        assert rst.raster_equal(rst_copy)
 
         # -- Then, we test with a mask returned --
         rst_arr, mask = rst.get_nanarray(return_mask=True)
@@ -438,7 +438,7 @@ class TestRaster:
         # Also check for back-propagation here with the mask and array
         rst_arr += 5
         mask = ~mask
-        assert rst == rst_copy
+        assert rst.raster_equal(rst_copy)
 
     def test_downsampling(self) -> None:
         """
@@ -600,7 +600,7 @@ class TestRaster:
 
         # First, we pass the new array as the masked array, mask and data of the new Raster object should be identical
         r2 = r.copy(new_array=r.data)
-        assert r == r2
+        assert r.raster_equal(r2)
 
         # When passing the new array as a NaN ndarray, only the valid data is equal, because masked data is NaN in one
         # case, and -9999 in the other
@@ -611,7 +611,7 @@ class TestRaster:
         # be perfectly equal
         if r2.nodata is not None:
             r2.data.data[np.isnan(r2.data.data)] = r2.nodata
-        assert r == r2
+        assert r.raster_equal(r2)
 
         # -- Fifth test: check that the new_array argument works when providing a new dtype ##
         if "int" in r.dtypes[0]:
@@ -701,11 +701,11 @@ class TestRaster:
         # Test with same bounds -> should be the same #
         cropGeom2 = [cropGeom[0], cropGeom[1], cropGeom[2], cropGeom[3]]
         r_cropped = r.crop(cropGeom2, inplace=False)
-        assert r_cropped == r
+        assert r_cropped.raster_equal(r)
 
         # Test with bracket call
         r_cropped_getitem = r[cropGeom2]
-        assert r_cropped_getitem == r_cropped
+        assert r_cropped_getitem.raster_equal(r_cropped)
 
         # - Test cropping each side by a random integer of pixels - #
         rand_int = np.random.randint(1, min(r.shape) - 1)
@@ -752,7 +752,7 @@ class TestRaster:
 
         # -- Test with CropGeom being a Raster -- #
         r_cropped2 = r.crop(r_cropped, inplace=False)
-        assert r_cropped2 == r_cropped
+        assert r_cropped2.raster_equal(r_cropped)
 
         # Check that bound reprojection is done automatically if the CRS differ
         with warnings.catch_warnings():
@@ -764,16 +764,16 @@ class TestRaster:
 
         # Original CRS bounds can be deformed during transformation, but result should be equivalent to this
         r_cropped4 = r.crop(cropGeom=r_cropped_reproj.get_bounds_projected(out_crs=r.crs), inplace=False)
-        assert r_cropped3 == r_cropped4
+        assert r_cropped3.raster_equal(r_cropped4)
 
         # Check with bracket call
         r_cropped5 = r[r_cropped_reproj]
-        assert r_cropped4 == r_cropped5
+        assert r_cropped4.raster_equal(r_cropped5)
 
         # -- Test with inplace=True (Default) -- #
         r_copy = r.copy()
         r_copy.crop(r_cropped)
-        assert r_copy == r_cropped
+        assert r_copy.raster_equal(r_cropped)
 
         # - Test cropping each side with a non integer pixel, mode='match_pixel' - #
         rand_float = np.random.randint(1, min(r.shape) - 1) + 0.25
@@ -836,7 +836,7 @@ class TestRaster:
                 "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
             )
             r_cropped2 = r.crop(r_cropped, inplace=False, mode="match_extent")
-        assert r_cropped2 == r_cropped
+        assert r_cropped2.raster_equal(r_cropped)
 
         # -- Test with CropGeom being a Vector -- #
         outlines = gu.Vector(outlines_path)
@@ -1069,7 +1069,7 @@ self.set_nodata()."
         r3 = r.reproject(dst_crs=out_crs, dst_nodata=0)
         r = gr.Raster(example, load_data=False)
         r4 = r.reproject(dst_crs=out_crs, dst_nodata=0)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test that reproject does not fail with resolution as np.integer or np.float types, single value or tuple
         astype_funcs = [int, np.int32, float, np.float64]
@@ -1534,7 +1534,7 @@ self.set_nodata()."
             r.set_nodata(_default_nodata(r.dtypes[0]))
             r_copy.nodata = _default_nodata(r.dtypes[0])
 
-        assert r == r_copy
+        assert r.raster_equal(r_copy)
 
     def test_default_nodata(self) -> None:
         """
@@ -1667,7 +1667,7 @@ self.set_nodata()."
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
         img.save(temp_file.name)
         saved = gr.Raster(temp_file.name)
-        assert img == saved
+        assert img.raster_equal(saved)
 
         # Try to save with a pathlib path (create a new temp file for Windows)
         temp_file_1 = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
@@ -1680,7 +1680,7 @@ self.set_nodata()."
         temp_file = NamedTemporaryFile(mode="w", delete=False, dir=temp_dir.name)
         img.save(temp_file.name, co_opts=co_opts, metadata=metadata)
         saved = gr.Raster(temp_file.name)
-        assert img == saved
+        assert img.raster_equal(saved)
         assert saved.tags["Type"] == "test"
 
         # Test that nodata value is enforced when masking - since value 0 is not used, data should be unchanged
@@ -1764,7 +1764,7 @@ self.set_nodata()."
         # -> most tests already performed in test_copy, no need for more
         img = gr.Raster(self.landsat_b4_path)
         out_img = gr.Raster.from_array(img.data, img.transform, img.crs, nodata=img.nodata)
-        assert out_img == img
+        assert out_img.raster_equal(img)
 
         # Test that changes to data are taken into account
         bias = 5
@@ -1840,15 +1840,15 @@ self.set_nodata()."
         blue2, green2 = img.split_bands(copy=False, subset=[2, 1])
 
         # Check that the subset functionality works as expected.
-        assert red == red2
-        assert green == green2
-        assert blue == blue2
+        assert red.raster_equal(red2)
+        assert green.raster_equal(green2)
+        assert blue.raster_equal(blue2)
 
         # Check that the red channel and the rgb data shares memory
         assert np.shares_memory(red.data, img.data)
 
         # Check that the red band data is not equal to the full RGB data.
-        assert red != img
+        assert not red.raster_equal(img)
 
         # Test that the red band corresponds to the first band of the img
         assert np.array_equal(
@@ -1894,7 +1894,7 @@ self.set_nodata()."
         # Resample the rasters using a new resampling method and see that the string and enum gives the same result.
         img3a = img1.reproject(img2, resampling="q1")
         img3b = img1.reproject(img2, resampling=rio.enums.Resampling.q1)
-        assert img3a == img3b
+        assert img3a.raster_equal(img3b)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_polygonize(self, example: str) -> None:
@@ -2073,37 +2073,130 @@ self.set_nodata()."
         assert points_frame.crs == img2.crs
 
 
-@pytest.mark.parametrize("dtype", ["float32", "uint8", "int32"])  # type: ignore
-def test_numpy_functions(dtype: str) -> None:
-    """Test how rasters can be used as/with numpy arrays."""
-    warnings.simplefilter("error")
+class TestMask:
+    # Real data
+    landsat_b4_path = examples.get_path("everest_landsat_b4")
+    landsat_b4_crop_path = examples.get_path("everest_landsat_b4_cropped")
+    landsat_rgb_path = examples.get_path("everest_landsat_rgb")
+    everest_outlines_path = examples.get_path("everest_rgi_outlines")
+    aster_dem_path = examples.get_path("exploradores_aster_dem")
+    aster_outlines_path = examples.get_path("exploradores_rgi_outlines")
 
-    # Create an array of unique values starting at 0 and ending at 24
-    array = np.arange(25, dtype=dtype).reshape((1, 5, 5))
-    # Create an associated dummy transform
-    transform = rio.transform.from_origin(0, 5, 1, 1)
+    # Synthetic data
+    width = height = 5
+    transform = rio.transform.from_bounds(0, 0, 1, 1, width, height)
+    np.random.seed(42)
+    arr = np.random.randint(low=0, high=2, size=(1, width, height), dtype=bool)
+    arr_mask = np.random.randint(0, 2, size=(1, width, height), dtype=bool)
+    mask_ma = np.ma.masked_array(data=arr, mask=arr_mask)
 
-    # Create a raster from the array
-    raster = gu.Raster.from_array(array, transform=transform, crs=4326)
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])
+    def test_init(self, example: str):
+        """Test that Mask subclass intialization function as intended."""
 
-    # Test some ufuncs
-    assert np.median(raster) == 12.0
-    assert np.mean(raster) == 12.0
+        # A warning should be raised when the raster is a multi-band
+        if "rgb" not in os.path.basename(example):
+            mask = gu.Mask(example)
+        else:
+            with pytest.warns(UserWarning, match="Multi-band raster provided to create a Mask, "
+                                                 "only the first band will be used."):
+                mask = gu.Mask(example)
 
-    # Check that rasters don't become arrays when using simple arithmetic.
-    assert isinstance(raster + 1, gr.Raster)
+        # Check the masked array type
+        assert mask.data.dtype == "bool"
+        # Check output is the correct instance
+        assert isinstance(mask, gu.Mask)
+        # Check the dtypes metadata
+        assert mask.dtypes[0] == "bool"
+        # Check the nodata
+        assert mask.nodata is None
+        # Check the nbands metadata
+        assert mask.nbands == 1
 
-    # Test the data setter method by creating a new array
-    raster.data = array + 2
+        # Check that a mask object is sent back from its own init
+        mask2 = gu.Mask(mask)
+        assert mask.raster_equal(mask2)
 
-    # Check that the median updated accordingly.
-    assert np.median(raster) == 14.0
+    def test_from_array(self):
+        """Test that Raster.__init__ casts to Mask with dict input of from_array() and a boolean data array."""
 
-    # Test
-    raster += array
+        mask_rst = gu.Raster.from_array(data=self.mask_ma, transform=self.transform, crs=None, nodata=None)
 
-    assert isinstance(raster, gr.Raster)
-    assert np.median(raster) == 26.0
+        assert isinstance(mask_rst, gu.Mask)
+        assert mask_rst.transform == self.transform
+        assert mask_rst.crs is None
+        assert mask_rst.nodata is None
+
+    # List all logical operators which will cast Rasters into Masks
+    ops_logical = [
+        "__lt__",
+        "__le__",
+        "__eq__",
+        "__ne__",
+        "__gt__",
+        "__ge__",
+    ]
+
+    @pytest.mark.parametrize("op", ops_logical)
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])
+    def test_logical_casting_real(self, example: str, op: str):
+        """
+        Test that logical operations cast Raster object to Mask on real data
+        (synthetic done in TestArithmetic).
+        """
+
+        rst = gu.Raster(example)
+
+        # Logical operations should cast to a Mask object, preserving the mask
+        mask = getattr(rst, op)(1)
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, getattr(rst.data.data, op)(1))
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])
+    def test_implicit_logical_casting_real(self, example: str):
+        """
+        Test that implicit logical operations on real data
+        (synthetic done in TestArithmetic).
+        """
+
+        rst = gu.Raster(example)
+
+        # Equality
+        mask = rst == 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data == 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+        # Non-equality
+        mask = rst != 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data != 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+        # Lower than
+        mask = rst < 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data < 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+        # Lower equal
+        mask = rst <= 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data <= 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+        # Greater than
+        mask = rst > 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data > 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
+
+        # Greater equal
+        mask = rst >= 1
+        assert isinstance(mask, gu.Mask)
+        assert np.array_equal(mask.data.data, rst.data.data >= 1)
+        assert np.array_equal(mask.data.mask, rst.data.mask)
 
 
 class TestArithmetic:
@@ -2163,47 +2256,47 @@ class TestArithmetic:
         np.random.randint(1, 255, (height, width)).astype("float32"), transform=transform, crs=None
     )
 
-    def test_equal(self) -> None:
+    def test_raster_equal(self) -> None:
         """
-        Test that __eq__ and __ne__ work as expected
+        Test that raster_equal() works as expected.
         """
         r1 = self.r1
         r2 = r1.copy()
-        assert r1 == r2
+        assert r1.raster_equal(r2)
 
         # Change data
         r2.data += 1
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change mask (False by default)
         r2 = r1.copy()
         r2.data[0, 0] = np.ma.masked
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change fill_value (999999 by default)
         r2 = r1.copy()
         r2.data.fill_value = 0
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change dtype
         r2 = r1.copy()
         r2 = r2.astype("float32")
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change transform
         r2 = r1.copy()
         r2.transform = rio.transform.from_bounds(0, 0, 1, 1, self.width + 1, self.height)
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change CRS
         r2 = r1.copy()
         r2.crs = rio.crs.CRS.from_epsg(4326)
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
         # Change nodata
         r2 = r1.copy()
         r2.set_nodata(34)
-        assert r1 != r2
+        assert r1.raster_equal(r2)
 
     def test_equal_georeferenced_grid(self) -> None:
         """
@@ -2311,8 +2404,8 @@ class TestArithmetic:
         r2_copy = r2.copy()
         r3 = getattr(r1, op)(r2)
         assert isinstance(r3, gr.Raster)
-        assert r1 == r1_copy
-        assert r2 == r2_copy
+        assert r1.raster_equal(r1_copy)
+        assert r2.raster_equal(r2_copy)
 
         # Test with different dtypes
         r1 = self.r1_f32
@@ -2397,37 +2490,37 @@ class TestArithmetic:
         # Test with uint8 rasters
         r3 = getattr(self.r1, op1)(self.r2)
         r4 = getattr(self.r1, op2)(self.r2)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with different dtypes
         r3 = getattr(self.r1_f32, op1)(self.r2)
         r4 = getattr(self.r1_f32, op2)(self.r2)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with nodata set
         r3 = getattr(self.r1_nodata, op1)(self.r2)
         r4 = getattr(self.r1_nodata, op2)(self.r2)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with zeros values (e.g. division)
         r3 = getattr(self.r1, op1)(self.r2_zero)
         r4 = getattr(self.r1, op2)(self.r2_zero)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with a numpy array
         r3 = getattr(self.r1, op1)(array)
         r4 = getattr(self.r1, op2)(array)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with an integer
         r3 = getattr(self.r1, op1)(intval)
         r4 = getattr(self.r1, op2)(intval)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
         # Test with a float value
         r3 = getattr(self.r1, op1)(floatval)
         r4 = getattr(self.r1, op2)(floatval)
-        assert r3 == r4
+        assert r3.raster_equal(r4)
 
     @classmethod
     def from_array(
@@ -2446,7 +2539,7 @@ class TestArithmetic:
 
     def test_ops_2args_implicit(self) -> None:
         """
-        Test certain arithmetic overloading when called with symbols (+, -, *, /, //, %)
+        Test certain arithmetic overloading when called with symbols (+, -, *, /, //, %).
         """
         warnings.filterwarnings("ignore", message="invalid value encountered")
 
@@ -2459,65 +2552,140 @@ class TestArithmetic:
         floatval = 3.14
 
         # Addition
-        assert r1 + r2 == self.from_array(r1.data + r2.data, rst_ref=r1)
-        assert r1_f32 + r2 == self.from_array(r1_f32.data + r2.data, rst_ref=r1)
-        assert array_3d + r2 == self.from_array(array_3d + r2.data, rst_ref=r2)
-        assert r2 + array_3d == self.from_array(r2.data + array_3d, rst_ref=r2)
-        assert array_2d + r2 == self.from_array(array_2d[np.newaxis, :, :] + r2.data, rst_ref=r2)
-        assert r2 + array_2d == self.from_array(r2.data + array_2d[np.newaxis, :, :], rst_ref=r2)
-        assert r1 + floatval == self.from_array(r1.data + floatval, rst_ref=r1)
-        assert floatval + r1 == self.from_array(floatval + r1.data, rst_ref=r1)
-        assert r1 + r2 == r2 + r1
+        assert (r1 + r2).raster_equal(self.from_array(r1.data + r2.data, rst_ref=r1))
+        assert (r1_f32 + r2).raster_equal(self.from_array(r1_f32.data + r2.data, rst_ref=r1))
+        assert (array_3d + r2).raster_equal(self.from_array(array_3d + r2.data, rst_ref=r2))
+        assert (r2 + array_3d).raster_equal(self.from_array(r2.data + array_3d, rst_ref=r2))
+        assert (array_2d + r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] + r2.data, rst_ref=r2))
+        assert (r2 + array_2d).raster_equal(self.from_array(r2.data + array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 + floatval).raster_equal(self.from_array(r1.data + floatval, rst_ref=r1))
+        assert (floatval + r1).raster_equal(self.from_array(floatval + r1.data, rst_ref=r1))
+        assert (r1 + r2).raster_equal(r2 + r1)
 
         # Multiplication
-        assert r1 * r2 == self.from_array(r1.data * r2.data, rst_ref=r1)
-        assert r1_f32 * r2 == self.from_array(r1_f32.data * r2.data, rst_ref=r1)
-        assert array_3d * r2 == self.from_array(array_3d * r2.data, rst_ref=r2)
-        assert r2 * array_3d == self.from_array(r2.data * array_3d, rst_ref=r2)
-        assert array_2d * r2 == self.from_array(array_2d[np.newaxis, :, :] * r2.data, rst_ref=r2)
-        assert r2 * array_2d == self.from_array(r2.data * array_2d[np.newaxis, :, :], rst_ref=r2)
-        assert r1 * floatval == self.from_array(r1.data * floatval, rst_ref=r1)
-        assert floatval * r1 == self.from_array(floatval * r1.data, rst_ref=r1)
-        assert r1 * r2 == r2 * r1
+        assert (r1 * r2).raster_equal(self.from_array(r1.data * r2.data, rst_ref=r1))
+        assert (r1_f32 * r2).raster_equal(self.from_array(r1_f32.data * r2.data, rst_ref=r1))
+        assert (array_3d * r2).raster_equal(self.from_array(array_3d * r2.data, rst_ref=r2))
+        assert (r2 * array_3d).raster_equal(self.from_array(r2.data * array_3d, rst_ref=r2))
+        assert (array_2d * r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] * r2.data, rst_ref=r2))
+        assert (r2 * array_2d).raster_equal(self.from_array(r2.data * array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 * floatval).raster_equal(self.from_array(r1.data * floatval, rst_ref=r1))
+        assert (floatval * r1).raster_equal(self.from_array(floatval * r1.data, rst_ref=r1))
+        assert (r1 * r2).raster_equal(r2 * r1)
 
         # Subtraction
-        assert r1 - r2 == self.from_array(r1.data - r2.data, rst_ref=r1)
-        assert r1_f32 - r2 == self.from_array(r1_f32.data - r2.data, rst_ref=r1)
-        assert array_3d - r2 == self.from_array(array_3d - r2.data, rst_ref=r2)
-        assert r2 - array_3d == self.from_array(r2.data - array_3d, rst_ref=r2)
-        assert array_2d - r2 == self.from_array(array_2d[np.newaxis, :, :] - r2.data, rst_ref=r2)
-        assert r2 - array_2d == self.from_array(r2.data - array_2d[np.newaxis, :, :], rst_ref=r2)
-        assert r1 - floatval == self.from_array(r1.data - floatval, rst_ref=r1)
-        assert floatval - r1 == self.from_array(floatval - r1.data, rst_ref=r1)
+        assert (r1 - r2).raster_equal(self.from_array(r1.data - r2.data, rst_ref=r1))
+        assert (r1_f32 - r2).raster_equal(self.from_array(r1_f32.data - r2.data, rst_ref=r1))
+        assert (array_3d - r2).raster_equal(self.from_array(array_3d - r2.data, rst_ref=r2))
+        assert (r2 - array_3d).raster_equal(self.from_array(r2.data - array_3d, rst_ref=r2))
+        assert (array_2d - r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] - r2.data, rst_ref=r2))
+        assert (r2 - array_2d).raster_equal(self.from_array(r2.data - array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 - floatval).raster_equal(self.from_array(r1.data - floatval, rst_ref=r1))
+        assert (floatval - r1).raster_equal(self.from_array(floatval - r1.data, rst_ref=r1))
 
         # True division
-        assert r1 / r2 == self.from_array(r1.data / r2.data, rst_ref=r1)
-        assert r1_f32 / r2 == self.from_array(r1_f32.data / r2.data, rst_ref=r1)
-        assert array_3d / r2 == self.from_array(array_3d / r2.data, rst_ref=r2)
-        assert r2 / array_3d == self.from_array(r2.data / array_3d, rst_ref=r2)
-        assert array_2d / r2 == self.from_array(array_2d[np.newaxis, :, :] / r2.data, rst_ref=r1)
-        assert r2 / array_2d == self.from_array(r2.data / array_2d[np.newaxis, :, :], rst_ref=r2)
-        assert r1 / floatval == self.from_array(r1.data / floatval, rst_ref=r1)
-        assert floatval / r1 == self.from_array(floatval / r1.data, rst_ref=r1)
+        assert (r1 / r2).raster_equal(self.from_array(r1.data / r2.data, rst_ref=r1))
+        assert (r1_f32 / r2).raster_equal(self.from_array(r1_f32.data / r2.data, rst_ref=r1))
+        assert (array_3d / r2).raster_equal(self.from_array(array_3d / r2.data, rst_ref=r2))
+        assert (r2 / array_3d).raster_equal(self.from_array(r2.data / array_3d, rst_ref=r2))
+        assert (array_2d / r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] / r2.data, rst_ref=r1))
+        assert (r2 / array_2d).raster_equal(self.from_array(r2.data / array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 / floatval).raster_equal(self.from_array(r1.data / floatval, rst_ref=r1))
+        assert (floatval / r1).raster_equal(self.from_array(floatval / r1.data, rst_ref=r1))
 
         # Floor division
-        assert r1 // r2 == self.from_array(r1.data // r2.data, rst_ref=r1)
-        assert r1_f32 // r2 == self.from_array(r1_f32.data // r2.data, rst_ref=r1)
-        assert array_3d // r2 == self.from_array(array_3d // r2.data, rst_ref=r1)
-        assert r2 // array_3d == self.from_array(r2.data // array_3d, rst_ref=r1)
-        assert array_2d // r2 == self.from_array(array_2d[np.newaxis, :, :] // r2.data, rst_ref=r1)
-        assert r2 // array_2d == self.from_array(r2.data // array_2d[np.newaxis, :, :], rst_ref=r1)
-        assert r1 // floatval == self.from_array(r1.data // floatval, rst_ref=r1)
-        assert floatval // r1 == self.from_array(floatval // r1.data, rst_ref=r1)
+        assert (r1 // r2).raster_equal(self.from_array(r1.data // r2.data, rst_ref=r1))
+        assert (r1_f32 // r2).raster_equal(self.from_array(r1_f32.data // r2.data, rst_ref=r1))
+        assert (array_3d // r2).raster_equal(self.from_array(array_3d // r2.data, rst_ref=r1))
+        assert (r2 // array_3d).raster_equal(self.from_array(r2.data // array_3d, rst_ref=r1))
+        assert (array_2d // r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] // r2.data, rst_ref=r1))
+        assert (r2 // array_2d).raster_equal(self.from_array(r2.data // array_2d[np.newaxis, :, :], rst_ref=r1))
+        assert (r1 // floatval).raster_equal(self.from_array(r1.data // floatval, rst_ref=r1))
+        assert (floatval // r1).raster_equal(self.from_array(floatval // r1.data, rst_ref=r1))
 
         # Modulo
-        assert r1 % r2 == self.from_array(r1.data % r2.data, rst_ref=r1)
-        assert r1_f32 % r2 == self.from_array(r1_f32.data % r2.data, rst_ref=r1)
-        assert array_3d % r2 == self.from_array(array_3d % r2.data, rst_ref=r1)
-        assert r2 % array_3d == self.from_array(r2.data % array_3d, rst_ref=r1)
-        assert array_2d % r2 == self.from_array(array_2d[np.newaxis, :, :] % r2.data, rst_ref=r1)
-        assert r2 % array_2d == self.from_array(r2.data % array_2d[np.newaxis, :, :], rst_ref=r1)
-        assert r1 % floatval == self.from_array(r1.data % floatval, rst_ref=r1)
+        assert (r1 % r2).raster_equal(self.from_array(r1.data % r2.data, rst_ref=r1))
+        assert (r1_f32 % r2).raster_equal(self.from_array(r1_f32.data % r2.data, rst_ref=r1))
+        assert (array_3d % r2).raster_equal(self.from_array(array_3d % r2.data, rst_ref=r1))
+        assert (r2 % array_3d).raster_equal(self.from_array(r2.data % array_3d, rst_ref=r1))
+        assert (array_2d % r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] % r2.data, rst_ref=r1))
+        assert (r2 % array_2d).raster_equal(self.from_array(r2.data % array_2d[np.newaxis, :, :], rst_ref=r1))
+        assert (r1 % floatval).raster_equal(self.from_array(r1.data % floatval, rst_ref=r1))
+
+    def test_ops_logical_implicit(self) -> None:
+        """
+        Test logical arithmetic overloading when called with symbols (==, !=, <, <=, >, >=).
+        """
+        warnings.filterwarnings("ignore", message="invalid value encountered")
+
+        # Test various inputs: Raster with different dtypes, np.ndarray with 2D or 3D shape, single number
+        r1 = self.r1
+        r1_f32 = self.r1_f32
+        r2 = self.r2
+        array_3d = np.random.randint(1, 255, (1, self.height, self.width)).astype("uint8")
+        array_2d = np.random.randint(1, 255, (self.height, self.width)).astype("uint8")
+        floatval = 3.14
+
+        # Equality
+        assert (r1 == r2).raster_equal(self.from_array(r1.data == r2.data, rst_ref=r1))
+        assert (r1_f32 == r2).raster_equal(self.from_array(r1_f32.data == r2.data, rst_ref=r1))
+        assert (array_3d == r2).raster_equal(self.from_array(array_3d == r2.data, rst_ref=r2))
+        assert (r2 == array_3d).raster_equal(self.from_array(r2.data == array_3d, rst_ref=r2))
+        assert (array_2d == r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] == r2.data, rst_ref=r2))
+        assert (r2 == array_2d).raster_equal(self.from_array(r2.data == array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 == floatval).raster_equal(self.from_array(r1.data == floatval, rst_ref=r1))
+        assert (floatval == r1).raster_equal(self.from_array(floatval == r1.data, rst_ref=r1))
+        assert (r1 == r2).raster_equal(r2 == r1)
+
+        # Non-equality
+        assert (r1 != r2).raster_equal(self.from_array(r1.data != r2.data, rst_ref=r1))
+        assert (r1_f32 != r2).raster_equal(self.from_array(r1_f32.data != r2.data, rst_ref=r1))
+        assert (array_3d != r2).raster_equal(self.from_array(array_3d != r2.data, rst_ref=r2))
+        assert (r2 != array_3d).raster_equal(self.from_array(r2.data != array_3d, rst_ref=r2))
+        assert (array_2d != r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] != r2.data, rst_ref=r2))
+        assert (r2 != array_2d).raster_equal(self.from_array(r2.data != array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 != floatval).raster_equal(self.from_array(r1.data != floatval, rst_ref=r1))
+        assert (floatval != r1).raster_equal(self.from_array(floatval != r1.data, rst_ref=r1))
+        assert (r1 != r2).raster_equal(r2 != r1)
+
+        # Lower than
+        assert (r1 < r2).raster_equal(self.from_array(r1.data < r2.data, rst_ref=r1))
+        assert (r1_f32 < r2).raster_equal(self.from_array(r1_f32.data < r2.data, rst_ref=r1))
+        assert (array_3d < r2).raster_equal(self.from_array(array_3d < r2.data, rst_ref=r2))
+        assert (r2 < array_3d).raster_equal(self.from_array(r2.data < array_3d, rst_ref=r2))
+        assert (array_2d < r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] < r2.data, rst_ref=r2))
+        assert (r2 < array_2d).raster_equal(self.from_array(r2.data < array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 < floatval).raster_equal(self.from_array(r1.data < floatval, rst_ref=r1))
+        assert (floatval < r1).raster_equal(self.from_array(floatval < r1.data, rst_ref=r1))
+
+        # Lower equal
+        assert (r1 <= r2).raster_equal(self.from_array(r1.data <= r2.data, rst_ref=r1))
+        assert (r1_f32 <= r2).raster_equal(self.from_array(r1_f32.data <= r2.data, rst_ref=r1))
+        assert (array_3d <= r2).raster_equal(self.from_array(array_3d <= r2.data, rst_ref=r2))
+        assert (r2 <= array_3d).raster_equal(self.from_array(r2.data <= array_3d, rst_ref=r2))
+        assert (array_2d <= r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] <= r2.data, rst_ref=r1))
+        assert (r2 <= array_2d).raster_equal(self.from_array(r2.data <= array_2d[np.newaxis, :, :], rst_ref=r2))
+        assert (r1 <= floatval).raster_equal(self.from_array(r1.data <= floatval, rst_ref=r1))
+        assert (floatval <= r1).raster_equal(self.from_array(floatval <= r1.data, rst_ref=r1))
+
+        # Greater than
+        assert (r1 > r2).raster_equal(self.from_array(r1.data > r2.data, rst_ref=r1))
+        assert (r1_f32 > r2).raster_equal(self.from_array(r1_f32.data > r2.data, rst_ref=r1))
+        assert (array_3d > r2).raster_equal(self.from_array(array_3d > r2.data, rst_ref=r1))
+        assert (r2 > array_3d).raster_equal(self.from_array(r2.data > array_3d, rst_ref=r1))
+        assert (array_2d > r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] > r2.data, rst_ref=r1))
+        assert (r2 > array_2d).raster_equal(self.from_array(r2.data > array_2d[np.newaxis, :, :], rst_ref=r1))
+        assert (r1 > floatval).raster_equal(self.from_array(r1.data > floatval, rst_ref=r1))
+        assert (floatval > r1).raster_equal(self.from_array(floatval > r1.data, rst_ref=r1))
+
+        # Greater equal
+        assert (r1 >= r2).raster_equal(self.from_array(r1.data >= r2.data, rst_ref=r1))
+        assert (r1_f32 >= r2).raster_equal(self.from_array(r1_f32.data >= r2.data, rst_ref=r1))
+        assert (array_3d >= r2).raster_equal(self.from_array(array_3d >= r2.data, rst_ref=r1))
+        assert (r2 >= array_3d).raster_equal(self.from_array(r2.data >= array_3d, rst_ref=r1))
+        assert (array_2d >= r2).raster_equal(self.from_array(array_2d[np.newaxis, :, :] >= r2.data, rst_ref=r1))
+        assert (r2 >= array_2d).raster_equal(self.from_array(r2.data >= array_2d[np.newaxis, :, :], rst_ref=r1))
+        assert (r1 >= floatval).raster_equal(self.from_array(r1.data >= floatval, rst_ref=r1))
 
     @pytest.mark.parametrize("op", ops_2args)  # type: ignore
     def test_raise_errors(self, op: str) -> None:
@@ -2548,6 +2716,38 @@ class TestArithmetic:
         if power > 0:  # Integers to negative integer powers are not allowed.
             assert self.r1**power == self.from_array(self.r1.data**power, rst_ref=self.r1)
         assert self.r1_f32**power == self.from_array(self.r1_f32.data**power, rst_ref=self.r1_f32)
+
+    @pytest.mark.parametrize("dtype", ["float32", "uint8", "int32"])  # type: ignore
+    def test_numpy_functions(self, dtype: str) -> None:
+        """Test how rasters can be used as/with numpy arrays."""
+        warnings.simplefilter("error")
+
+        # Create an array of unique values starting at 0 and ending at 24
+        array = np.arange(25, dtype=dtype).reshape((1, 5, 5))
+        # Create an associated dummy transform
+        transform = rio.transform.from_origin(0, 5, 1, 1)
+
+        # Create a raster from the array
+        raster = gu.Raster.from_array(array, transform=transform, crs=4326)
+
+        # Test some ufuncs
+        assert np.median(raster) == 12.0
+        assert np.mean(raster) == 12.0
+
+        # Check that rasters don't become arrays when using simple arithmetic.
+        assert isinstance(raster + 1, gr.Raster)
+
+        # Test the data setter method by creating a new array
+        raster.data = array + 2
+
+        # Check that the median updated accordingly.
+        assert np.median(raster) == 14.0
+
+        # Test
+        raster += array
+
+        assert isinstance(raster, gr.Raster)
+        assert np.median(raster) == 26.0
 
 
 class TestArrayInterface:
@@ -2826,4 +3026,4 @@ class TestArrayInterface:
             if isinstance(output_rst, np.ndarray):
                 assert np.ma.allequal(output_rst, output_ma)
             else:
-                assert output_rst == output_ma
+                assert output_rst.raster_equal(output_ma)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -207,7 +207,7 @@ class TestSynthetic:
         """
         # First with given res and bounds -> Should be a 21 x 21 array with 0 everywhere except center pixel
         vector = self.vector.copy()
-        out_mask = vector.create_mask(xres=1, bounds=(0, 0, 21, 21))
+        out_mask = vector.create_mask(xres=1, bounds=(0, 0, 21, 21)).get_nanarray()
         ref_mask = np.zeros((21, 21), dtype="bool")
         ref_mask[10, 10] = True
         assert out_mask.shape == (21, 21)
@@ -220,22 +220,22 @@ class TestSynthetic:
 
         # Then with a gu.Raster as reference, single band
         rst = gu.Raster.from_array(np.zeros((21, 21)), transform=(1.0, 0.0, 0.0, 0.0, -1.0, 21.0), crs="EPSG:4326")
-        out_mask = vector.create_mask(rst)
-        assert out_mask.shape == (1, 21, 21)
+        out_mask = vector.create_mask(rst).get_nanarray()
+        assert out_mask.shape == (21, 21)
 
         # With gu.Raster, 2 bands -> fails...
         # rst = gu.Raster.from_array(np.zeros((2, 21, 21)), transform=(1., 0., 0., 0., -1., 21.), crs='EPSG:4326')
         # out_mask = vector.create_mask(rst)
 
         # Test that buffer = 0 works
-        out_mask_buff = vector.create_mask(rst, buffer=0)
+        out_mask_buff = vector.create_mask(rst, buffer=0).get_nanarray()
         assert np.all(ref_mask == out_mask_buff)
 
         # Test that buffer > 0 works
         rst = gu.Raster.from_array(np.zeros((21, 21)), transform=(1.0, 0.0, 0.0, 0.0, -1.0, 21.0), crs="EPSG:4326")
-        out_mask = vector.create_mask(rst)
+        out_mask = vector.create_mask(rst).get_nanarray()
         for buffer in np.arange(1, 8):
-            out_mask_buff = vector.create_mask(rst, buffer=buffer)
+            out_mask_buff = vector.create_mask(rst, buffer=buffer).get_nanarray()
             diff = out_mask_buff & ~out_mask
             assert np.count_nonzero(diff) > 0
             # Difference between masks should always be thinner than buffer + 1
@@ -244,9 +244,9 @@ class TestSynthetic:
 
         # Test that buffer < 0 works
         vector_5 = self.vector_5
-        out_mask = vector_5.create_mask(rst)
+        out_mask = vector_5.create_mask(rst).get_nanarray()
         for buffer in np.arange(-1, -3, -1):
-            out_mask_buff = vector_5.create_mask(rst, buffer=buffer)
+            out_mask_buff = vector_5.create_mask(rst, buffer=buffer).get_nanarray()
             diff = ~out_mask_buff & out_mask
             assert np.count_nonzero(diff) > 0
             # Difference between masks should always be thinner than buffer + 1

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -42,7 +42,8 @@ class TestSatelliteImage:
         img3 = si.SatelliteImage(r)
         assert isinstance(img3, si.SatelliteImage)
 
-        assert img == img2 == img3
+        assert img.raster_equal(img2)
+        assert img.raster_equal(img3)
 
     @pytest.mark.parametrize("example", [landsat_b4, aster_dem])  # type: ignore
     def test_silent(self, example: str) -> None:


### PR DESCRIPTION
This PR:

- Adds the `Mask` class,
- Casts any boolean array passed to `Raster.from_array()` into a `Mask`,
- Makes `__array_function__` interface compatible with logical functions, automatically cast into a `Mask`
- Changes output of `Vector.create_mask()` and `rasterize()` with certain parameters to `Mask`,
- Changes `__eq__` into `raster_equal()`.

Write new tests for all.

Resolves #316