### PR TITLE
Fix cbar alignment in `Raster.show`

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1912,8 +1912,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         vmin: float | int | None = None,
         vmax: float | int | None = None,
         alpha: float | int | None = None,
-        cb_title: str | None = None,
-        add_cb: bool = True,
+        cbar_title: str | None = None,
+        add_cbar: bool = True,
         ax: matplotlib.axes.Axes | None = None,
         **kwargs: Any,
     ) -> None | tuple[matplotlib.axes.Axes, matplotlib.colors.Colormap]:
@@ -1926,12 +1926,12 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :param cmap: The figure's colormap. Default is plt.rcParams['image.cmap'].
         :param vmin: Colorbar minimum value. Default is data min.
         :param vmax: Colorbar maximum value. Default is data min.
-        :param cb_title: Colorbar label. Default is None.
-        :param add_cb: Set to True to display a colorbar. Default is True.
+        :param cbar_title: Colorbar label. Default is None.
+        :param add_cbar: Set to True to display a colorbar. Default is True.
         :param ax: A figure ax to be used for plotting. If None, will create default figure and axes,
             and plot figure directly.
 
-        :returns: if ax is not None, returns (ax, cbar) where cbar is the colorbar (None if add_cb is False)
+        :returns: if ax is not None, returns (ax, cbar) where cbar is the colorbar (None if add_cbar is False)
 
 
         You can also pass in \*\*kwargs to be used by the underlying imshow or
@@ -1962,7 +1962,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # If multiple bands (RGB), cbar does not make sense
         if isinstance(index, abc.Sequence):
             if len(index) > 1:
-                add_cb = False
+                add_cbar = False
 
         # Create colorbar
         # Use rcParam default
@@ -2009,15 +2009,15 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         )
 
         # Add colorbar
-        if add_cb:
+        if add_cbar:
             divider = make_axes_locatable(ax0)
             cax = divider.append_axes("right", size="5%", pad=0.05)
             norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
             cbar = matplotlib.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
             cbar.solids.set_alpha(alpha)
 
-            if cb_title is not None:
-                cbar.set_label(cb_title)
+            if cbar_title is not None:
+                cbar.set_label(cbar_title)
         else:
             cbar = None
 

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -30,6 +30,7 @@ from rasterio.enums import Resampling
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
 from scipy.ndimage import distance_transform_edt, map_coordinates
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import geoutils.geovector as gv
 from geoutils._typing import AnyNumber, ArrayLike, DTypeLike
@@ -1910,6 +1911,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         cmap: matplotlib.colors.Colormap | str | None = None,
         vmin: float | int | None = None,
         vmax: float | int | None = None,
+        alpha: float | int | None = None,
         cb_title: str | None = None,
         add_cb: bool = True,
         ax: matplotlib.axes.Axes | None = None,
@@ -2002,15 +2004,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             cmap=cmap,
             vmin=vmin,
             vmax=vmax,
+            alpha=alpha,
             **kwargs,
         )
 
         # Add colorbar
         if add_cb:
-            cbar = fig.colorbar(
-                cm.ScalarMappable(norm=colors.Normalize(vmin=vmin, vmax=vmax), cmap=cmap),
-                ax=ax0,
-            )
+            divider = make_axes_locatable(ax0)
+            cax = divider.append_axes("right", size="5%", pad=0.05)
+            norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
+            cbar = matplotlib.colorbar.ColorbarBase(cax, cmap=cmap, norm=norm)
+            cbar.solids.set_alpha(alpha)
 
             if cb_title is not None:
                 cbar.set_label(cb_title)

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -24,13 +24,12 @@ import rasterio.transform
 import rasterio.warp
 import rasterio.windows
 from affine import Affine
-from matplotlib import cm, colors
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
 from scipy.ndimage import distance_transform_edt, map_coordinates
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import geoutils.geovector as gv
 from geoutils._typing import AnyNumber, ArrayLike, DTypeLike
@@ -1992,7 +1991,6 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             fig, ax0 = plt.subplots()
         elif isinstance(ax, matplotlib.axes.Axes):
             ax0 = ax
-            fig = ax.figure
         else:
             raise ValueError("ax must be a matplotlib.axes.Axes instance or None")
 

--- a/geoutils/geoviewer.py
+++ b/geoutils/geoviewer.py
@@ -230,8 +230,8 @@ def main() -> None:
         interpolation="nearest",
         vmin=vmin,
         vmax=vmax,
-        add_cb=args.nocb,
-        cb_title=args.clabel,
+        add_cbar=args.nocb,
+        cbar_title=args.clabel,
         title=args.title,
     )
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1819,7 +1819,7 @@ class TestRaster:
         r0 = gr.Raster(example)
         fig,ax = plt.subplots(figsize=(figsize,figsize))
         r0.show(ax =ax,
-                add_cb=True,
+                add_cbar=True,
                )
         fig.axes[0].set_axis_off()
         fig.axes[1].set_axis_off()

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1862,18 +1862,18 @@ class TestRaster:
             plt.close()
         assert True
 
-        # Test plotting single band B/W, add_cb
+        # Test plotting single band B/W, add_cbar
         ax = plt.subplot(111)
-        img_RGB.show(index=1, cmap="gray", ax=ax, add_cb=False, title="Plotting one band B/W")
+        img_RGB.show(index=1, cmap="gray", ax=ax, add_cbar=False, title="Plotting one band B/W")
         if DO_PLOT:
             plt.show()
         else:
             plt.close()
         assert True
 
-        # Test vmin, vmax and cb_title
+        # Test vmin, vmax and cbar_title
         ax = plt.subplot(111)
-        img.show(cmap="gray", vmin=40, vmax=220, cb_title="Custom cbar", ax=ax, title="Testing vmin, vmax and cb_title")
+        img.show(cmap="gray", vmin=40, vmax=220, cbar_title="Custom cbar", ax=ax, title="Testing vmin, vmax and cbar_title")
         if DO_PLOT:
             plt.show()
         else:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1809,31 +1809,34 @@ class TestRaster:
             assert np.dtype(rout.dtypes[0]) == dtype
             assert rout.data.dtype == dtype
 
-    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_b4_crop_path,landsat_rgb_path, aster_dem_path])  # type: ignore
-    @pytest.mark.parametrize("figsize", np.arange(2,20, 2))  # type: ignore
+    @pytest.mark.parametrize(
+        "example", [landsat_b4_path, landsat_b4_crop_path, landsat_rgb_path, aster_dem_path]
+    )  # type: ignore
+    @pytest.mark.parametrize("figsize", np.arange(2, 20, 2))  # type: ignore
     def test_show_cbar(self, example, figsize) -> None:
-        '''
+        """
         Test cbar matches plot height.
-        '''
+        """
         # Plot raster with cbar
         r0 = gr.Raster(example)
-        fig,ax = plt.subplots(figsize=(figsize,figsize))
-        r0.show(ax =ax,
-                add_cbar=True,
-               )
+        fig, ax = plt.subplots(figsize=(figsize, figsize))
+        r0.show(
+            ax=ax,
+            add_cbar=True,
+        )
         fig.axes[0].set_axis_off()
         fig.axes[1].set_axis_off()
 
         # Get size of main plot
         ax0_bbox = fig.axes[0].get_tightbbox()
-        xmin,ymin,xmax,ymax = ax0_bbox.bounds
+        xmin, ymin, xmax, ymax = ax0_bbox.bounds
         h = ymax - ymin
 
         # Get size of cbar
         ax_cbar_bbox = fig.axes[1].get_tightbbox()
-        xmin,ymin,xmax,ymax = ax_cbar_bbox.bounds
+        xmin, ymin, xmax, ymax = ax_cbar_bbox.bounds
         h_cbar = ymax - ymin
-        plt.close('all')
+        plt.close("all")
 
         # Assert height is the same
         assert h == pytest.approx(h_cbar)
@@ -1873,7 +1876,9 @@ class TestRaster:
 
         # Test vmin, vmax and cbar_title
         ax = plt.subplot(111)
-        img.show(cmap="gray", vmin=40, vmax=220, cbar_title="Custom cbar", ax=ax, title="Testing vmin, vmax and cbar_title")
+        img.show(
+            cmap="gray", vmin=40, vmax=220, cbar_title="Custom cbar", ax=ax, title="Testing vmin, vmax and cbar_title"
+        )
         if DO_PLOT:
             plt.show()
         else:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1809,7 +1809,36 @@ class TestRaster:
             assert np.dtype(rout.dtypes[0]) == dtype
             assert rout.data.dtype == dtype
 
-    def test_plot(self) -> None:
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_b4_crop_path,landsat_rgb_path, aster_dem_path])  # type: ignore
+    @pytest.mark.parametrize("figsize", np.arange(2,20, 2))  # type: ignore
+    def test_show_cbar(self, example, figsize) -> None:
+        '''
+        Test cbar matches plot height.
+        '''
+        # Plot raster with cbar
+        r0 = gr.Raster(example)
+        fig,ax = plt.subplots(figsize=(figsize,figsize))
+        r0.show(ax =ax,
+                add_cb=True,
+               )
+        fig.axes[0].set_axis_off()
+        fig.axes[1].set_axis_off()
+
+        # Get size of main plot
+        ax0_bbox = fig.axes[0].get_tightbbox()
+        xmin,ymin,xmax,ymax = ax0_bbox.bounds
+        h = ymax - ymin
+
+        # Get size of cbar
+        ax_cbar_bbox = fig.axes[1].get_tightbbox()
+        xmin,ymin,xmax,ymax = ax_cbar_bbox.bounds
+        h_cbar = ymax - ymin
+        plt.close('all')
+
+        # Assert height is the same
+        assert h == pytest.approx(h_cbar)
+
+    def test_show(self) -> None:
 
         # Read single band raster and RGB raster
         img = gr.Raster(self.landsat_b4_path)


### PR DESCRIPTION
This PR fixes the color bar alignment with the main plot when using `Raster.show()` and tests that the cbar and main plot heights are approximately equal. 

Additional changes:
- Add alpha parameter for plot and cbar to `Raster.show()`
- Rename `cb` to `cbar` to match matplotlib conventions.

