### PR TITLE
Fix `Raster.reproject()` floating precision of output `res` on large grids

### DIFF
--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1634,9 +1634,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             # TODO: open issue on Rasterio?
             rounded_a = round(dst_transform.a, 10)
             rounded_e = round(dst_transform.a, 10)
-            dst_transform = rio.transform.Affine(rounded_a, dst_transform.b, dst_transform.c,
-                                                 dst_transform.d, rounded_e, dst_transform.f,
-                                                 dst_transform.g, dst_transform.h, dst_transform.i)
+            dst_transform = rio.transform.Affine(
+                rounded_a,
+                dst_transform.b,
+                dst_transform.c,
+                dst_transform.d,
+                rounded_e,
+                dst_transform.f,
+                dst_transform.g,
+                dst_transform.h,
+                dst_transform.i,
+            )
 
             # Specify the output bounds and shape, let rasterio handle the rest
             reproj_kwargs.update({"dst_transform": dst_transform})

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1633,7 +1633,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             # Ensure resolution is nicely rounded after 10 digits
             # TODO: open issue on Rasterio?
             rounded_a = round(dst_transform.a, 10)
-            rounded_e = round(dst_transform.a, 10)
+            rounded_e = round(dst_transform.e, 10)
             dst_transform = rio.transform.Affine(
                 rounded_a,
                 dst_transform.b,

--- a/geoutils/georaster/raster.py
+++ b/geoutils/georaster/raster.py
@@ -1630,6 +1630,14 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             # Calculate associated transform
             dst_transform = rio.transform.from_bounds(*dst_bounds, width=dst_size[0], height=dst_size[1])
 
+            # Ensure resolution is nicely rounded after 10 digits
+            # TODO: open issue on Rasterio?
+            rounded_a = round(dst_transform.a, 10)
+            rounded_e = round(dst_transform.a, 10)
+            dst_transform = rio.transform.Affine(rounded_a, dst_transform.b, dst_transform.c,
+                                                 dst_transform.d, rounded_e, dst_transform.f,
+                                                 dst_transform.g, dst_transform.h, dst_transform.i)
+
             # Specify the output bounds and shape, let rasterio handle the rest
             reproj_kwargs.update({"dst_transform": dst_transform})
             dst_data = np.ones((self.count, dst_size[1], dst_size[0]), dtype=dst_dtype)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1142,6 +1142,7 @@ class TestRaster:
         nodata = -9999.0
         rst = gu.Raster.from_array(data=data, transform=transform, crs=crs, nodata=nodata)
 
+        # This large grid geotransform is taken from https://cdn.proj.org/us_nga_egm08_25.tif
         data2 = np.zeros(shape=(4321, 8640), dtype="uint8")
         transform2 = rio.transform.Affine(
             0.041666666666666664, 0.0, -180.02083333333334, 0.0, -0.041666666666666664, 90.02083333333333

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1134,7 +1134,8 @@ class TestRaster:
             assert np.shape(out_img.data) == (n, 500, 500)
             assert (out_img.count, *out_img.shape) == (n, 500, 500)
 
-        # Test that the rounding of resolution is correct for large rasters (we take an example that used to fail, see issue #354)
+        # Test that the rounding of resolution is correct for large rasters
+        # (we take an example that used to fail, see issue #354)
         data = np.zeros(shape=(5741, 2959), dtype="uint8")
         transform = rio.transform.Affine(20.0, 0.0, 238286.29553975424, 0.0, -20.0, 6995453.456051373)
         crs = rio.CRS.from_epsg(32633)
@@ -1142,14 +1143,15 @@ class TestRaster:
         rst = gu.Raster.from_array(data=data, transform=transform, crs=crs, nodata=nodata)
 
         data2 = np.zeros(shape=(4321, 8640), dtype="uint8")
-        transform2 = rio.transform.Affine(0.041666666666666664, 0.0, -180.02083333333334, 0.0, -0.041666666666666664, 90.02083333333333)
+        transform2 = rio.transform.Affine(
+            0.041666666666666664, 0.0, -180.02083333333334, 0.0, -0.041666666666666664, 90.02083333333333
+        )
         crs2 = rio.CRS.from_epsg(4979)
         rst2 = gu.Raster.from_array(data=data2, transform=transform2, crs=crs2, nodata=None)
 
         rst2_reproj = rst2.reproject(rst)
         # This used to be 19.999999999999999 due to floating point precision
         assert rst2_reproj.res == (20.0, 20.0)
-
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_intersection(self, example: list[str]) -> None:


### PR DESCRIPTION
Resolves #354 (now provides directly the transform when a reference raster is passed)
Adds a test that fails with the previous behaviour

The issue is only fixed when passing a reference to match! 
Still present when passing `dst_bounds` and `dst_res` (or `dst_size`) manually... Seems to arise from floating precision in transform estimation of Rasterio. Not sure how we could fix that.