### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ the functionalities of these packages through interfacing or composition, and qu
 
 ## Documentation
 
-For installation, quick start, gallery examples, a full feature description or a search through the API, see GeoUtils' documentation at:
-https://geoutils.readthedocs.io.
+For a quick start, full feature description or search through the API, see GeoUtils' documentation at: https://geoutils.readthedocs.io.
 
 ## Installation
 

--- a/doc/source/core_py_ops.md
+++ b/doc/source/core_py_ops.md
@@ -1,6 +1,5 @@
 ---
 file_format: mystnb
-file_format: mystnb
 jupytext:
   formats: md:myst
   text_representation:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -578,7 +578,6 @@ class Raster:
             0.0, y_res, top_left_y) or an affine.Affine object.
         :param crs: Coordinate reference system. Either a rasterio CRS,
             or an EPSG integer.
-
         :param nodata: Nodata value.
 
         :returns: Raster created from the provided array and georeferencing.
@@ -3243,7 +3242,7 @@ class Mask(Raster):
         return str(s)
 
     def _repr_html_(self) -> str:
-        """Convert mask to HTML representation for notebooks and docs"""
+        """Convert mask to HTML representation for notebooks and doc"""
 
         # If data not loaded, return and string and avoid calling .data
         if not self.is_loaded:

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -11,7 +11,7 @@ class TestDocs:
     n_threads = os.getenv("N_CPUS")
 
     def test_build(self) -> None:
-        """Try building the docs and see if it works."""
+        """Try building the doc and see if it works."""
         # Remove the build directory if it exists.
 
         # Test only on Linux


### PR DESCRIPTION
Renaming `test_docs` into `test_doc` for consistency, and fixing minor errors in documentation.