### PR TITLE
Fix `coverage` failure

### DIFF
--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -11,7 +11,7 @@ class TestDocs:
     n_threads = os.getenv("N_CPUS")
 
     def test_build(self) -> None:
-        """Try building the doc and see if it works."""
+        """Try building the documentation and see if it works."""
         # Remove the build directory if it exists.
 
         # Test only on Linux


### PR DESCRIPTION
We have a failing of coverage push to Coveralls on the main branch (dropped to 0%). While it wasn't the case on other PRs. Can't seem to be able to fix it by rerunning GitHub Actions of the main branch.

Let's try here.