### PR TITLE
Force `geopandas>0.12` to avoid import failure

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - geopandas>=0.10.0
+  - geopandas>=0.12.0
   - matplotlib
   - pyproj
   - rasterio>=1.3

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - geopandas>=0.10.0
+  - geopandas>=0.12.0
   - matplotlib
   - pyproj
   - rasterio>=1.3


### PR DESCRIPTION
Resolves #373 