### PR TITLE
Fix save with "uint8" `dtype` for `Mask` class

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2189,7 +2189,6 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         :returns: None.
         """
-        dtype = self.data.dtype if dtype is None else dtype
 
         if co_opts is None:
             co_opts = {}
@@ -2212,7 +2211,12 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             save_data = self.data
 
-            # if masked array, save with masked values replaced by nodata
+            # If the raster is a mask, convert to uint8 before saving and force nodata to 255
+            if save_data.dtype == bool:
+                save_data = save_data.astype("uint8")
+                nodata = 255
+
+            # If masked array, save with masked values replaced by nodata
             if isinstance(save_data, np.ma.masked_array):
                 # In this case, nodata=None is not compatible, so revert to default values, only if masked values exist
                 if (nodata is None) & (np.count_nonzero(save_data.mask) > 0):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2857,6 +2857,12 @@ class TestMask:
         saved = gu.Raster(temp_file)
         assert mask.astype("uint8").raster_equal(saved)
 
+        # Clean up temporary folder - fails on Windows
+        try:
+            temp_dir.cleanup()
+        except (NotADirectoryError, PermissionError):
+            pass
+
 
 class TestArithmetic:
     """

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2857,6 +2857,7 @@ class TestMask:
         saved = gu.Raster(temp_file)
         assert mask.astype("uint8").raster_equal(saved)
 
+
 class TestArithmetic:
     """
     Test that all arithmetic overloading functions work as expected.

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2599,6 +2599,8 @@ class TestMask:
     mask_landsat_b4 = gu.Raster(landsat_b4_path) > 125
     # Mask with nodata
     mask_aster_dem = gu.Raster(aster_dem_path) > 2000
+    # Mask from an outline
+    mask_everest = gu.Vector(everest_outlines_path).create_mask(gu.Raster(landsat_b4_path))
 
     @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])  # type: ignore
     def test_init(self, example: str) -> None:
@@ -2731,7 +2733,7 @@ class TestMask:
         assert np.array_equal(mask.data.data, rst.data.data >= 1)
         assert np.array_equal(mask.data.mask, rst.data.mask)
 
-    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_reproject(self, mask: gu.Mask) -> None:
         # Test 1: with a classic resampling (bilinear)
 
@@ -2757,7 +2759,7 @@ class TestMask:
         ):
             mask.reproject(resampling="bilinear")
 
-    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_crop(self, mask: gu.Mask) -> None:
         # Test with same bounds -> should be the same #
         crop_geom = mask.bounds
@@ -2818,7 +2820,7 @@ class TestMask:
         # mask_orig.crop(crop_geom2, mode="match_extent")
         # assert mask_cropped.raster_equal(mask_orig)
 
-    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_polygonize(self, mask: gu.Mask) -> None:
         # Run default
         vect = mask.polygonize()
@@ -2834,7 +2836,7 @@ class TestMask:
         with pytest.warns(UserWarning, match="In-value converted to 1 for polygonizing boolean mask."):
             mask.polygonize(target_values=2)
 
-    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_proximity(self, mask: gu.Mask) -> None:
         # Run default
         rast = mask.proximity()
@@ -2844,7 +2846,7 @@ class TestMask:
         # A mask is a raster, so also need to check this
         assert not isinstance(rast, gu.Mask)
 
-    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_save(self, mask: gu.Mask) -> None:
         """Test saving for masks"""
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2844,6 +2844,18 @@ class TestMask:
         # A mask is a raster, so also need to check this
         assert not isinstance(rast, gu.Mask)
 
+    @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem])  # type: ignore
+    def test_save(self, mask: gu.Mask) -> None:
+        """Test saving for masks"""
+
+        # Temporary folder
+        temp_dir = tempfile.TemporaryDirectory()
+
+        # Save file to temporary file, with defaults opts
+        temp_file = os.path.join(temp_dir.name, "test.tif")
+        mask.save(temp_file)
+        saved = gu.Raster(temp_file)
+        assert mask.astype("uint8").raster_equal(saved)
 
 class TestArithmetic:
     """


### PR DESCRIPTION
Trying to properly force this behaviour for the `Mask` class.

Resolves #379