### PR TITLE
Update with NumPy 1.25

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib
   - pyproj
   - rasterio>=1.3
-  - numpy=1.24
+  - numpy
   - scipy
   - tqdm
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib
   - pyproj
   - rasterio>=1.3
-  - numpy=1.24
+  - numpy
   - scipy
   - tqdm
   - xarray

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -77,6 +77,8 @@ _HANDLED_FUNCTIONS_1NIN = (
     ]
     + [
         "sum",
+        "amax",
+        "amin",
         "max",
         "min",
         "argmax",

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -893,7 +893,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             dtype2 = rio.dtypes.get_minimum_dtype(other_data)
 
         # Figure out output dtype
-        out_dtype = np.find_common_type([dtype1, dtype2], [])
+        out_dtype = np.promote_types(dtype1, dtype2)
 
         # Figure output nodata
         out_nodata = None
@@ -3091,7 +3091,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         gpd_dtypes = ["uint8", "uint16", "int16", "int32", "float32"]
         list_common_dtype_index = []
         for gpd_type in gpd_dtypes:
-            polygonize_dtype = np.find_common_type([gpd_type, self.dtypes[0]], [])
+            polygonize_dtype = np.promote_types(gpd_type, self.dtypes[0])
             if str(polygonize_dtype) in gpd_dtypes:
                 list_common_dtype_index.append(gpd_dtypes.index(gpd_type))
         if len(list_common_dtype_index) == 0:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -77,8 +77,8 @@ _HANDLED_FUNCTIONS_1NIN = (
     ]
     + [
         "sum",
-        "amax",
-        "amin",
+        "max",
+        "min",
         "argmax",
         "argmin",
         "mean",

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3562,8 +3562,8 @@ class TestArrayInterface:
         try:
             com_dtype = np.promote_types(dtype, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        # (TypeError needed for backwards compatibility)
-        except (TypeError, np.exceptions.DTypePromotionError):
+        # (TypeError needed for backwards compatibility; also exceptions.DTypePromotionError for NumPy 1.25 and above)
+        except TypeError:
             com_dtype = np.dtype("O")
 
         # Catch warnings
@@ -3626,15 +3626,15 @@ class TestArrayInterface:
         try:
             com_dtype1 = np.promote_types(dtype1, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        # (TypeError needed for backwards compatibility)
-        except (TypeError, np.exceptions.DTypePromotionError):
+        # (TypeError needed for backwards compatibility; also exceptions.DTypePromotionError for NumPy 1.25 and above)
+        except TypeError:
             com_dtype1 = np.dtype("O")
 
         try:
             com_dtype2 = np.promote_types(dtype2, ufunc.types[0][1])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        # (TypeError needed for backwards compatibility)
-        except (TypeError, np.exceptions.DTypePromotionError):
+        # (TypeError needed for backwards compatibility; also exceptions.DTypePromotionError for NumPy 1.25 and above)
+        except TypeError:
             com_dtype2 = np.dtype("O")
 
         # If the two input types can be the same type, pass a tuple with the common type of both
@@ -3642,7 +3642,7 @@ class TestArrayInterface:
         if all(t[0] == t[1] for t in ufunc.types if not any(x in t[0:2] for x in ["m", "M", "q", "Q"])):
             try:
                 com_dtype_both = np.promote_types(com_dtype1, com_dtype2)
-            except (TypeError, np.exceptions.DTypePromotionError):
+            except TypeError:
                 com_dtype_both = np.dtype("O")
             com_dtype_tuple = (com_dtype_both, com_dtype_both)
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3562,7 +3562,7 @@ class TestArrayInterface:
         try:
             com_dtype = np.promote_types(dtype, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.exceptions.DTypePromotionError:
+        except np.DTypePromotionError:
             com_dtype = np.dtype("O")
 
         # Catch warnings
@@ -3625,13 +3625,13 @@ class TestArrayInterface:
         try:
             com_dtype1 = np.promote_types(dtype1, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.exceptions.DTypePromotionError:
+        except np.DTypePromotionError:
             com_dtype1 = np.dtype("O")
 
         try:
             com_dtype2 = np.promote_types(dtype2, ufunc.types[0][1])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.exceptions.DTypePromotionError:
+        except np.DTypePromotionError:
             com_dtype2 = np.dtype("O")
 
         # If the two input types can be the same type, pass a tuple with the common type of both
@@ -3639,7 +3639,7 @@ class TestArrayInterface:
         if all(t[0] == t[1] for t in ufunc.types if not any(x in t[0:2] for x in ["m", "M", "q", "Q"])):
             try:
                 com_dtype_both = np.promote_types(com_dtype1, com_dtype2)
-            except np.exceptions.DTypePromotionError:
+            except np.DTypePromotionError:
                 com_dtype_both = np.dtype("O")
             com_dtype_tuple = (com_dtype_both, com_dtype_both)
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3562,7 +3562,8 @@ class TestArrayInterface:
         try:
             com_dtype = np.promote_types(dtype, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.DTypePromotionError:
+        # (TypeError needed for backwards compatibility)
+        except (TypeError, np.exceptions.DTypePromotionError):
             com_dtype = np.dtype("O")
 
         # Catch warnings
@@ -3625,13 +3626,15 @@ class TestArrayInterface:
         try:
             com_dtype1 = np.promote_types(dtype1, ufunc.types[0][0])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.DTypePromotionError:
+        # (TypeError needed for backwards compatibility)
+        except (TypeError, np.exceptions.DTypePromotionError):
             com_dtype1 = np.dtype("O")
 
         try:
             com_dtype2 = np.promote_types(dtype2, ufunc.types[0][1])
         # The promote_types function raises an error for object dtypes (previously returned by find_common_dtypes)
-        except np.DTypePromotionError:
+        # (TypeError needed for backwards compatibility)
+        except (TypeError, np.exceptions.DTypePromotionError):
             com_dtype2 = np.dtype("O")
 
         # If the two input types can be the same type, pass a tuple with the common type of both
@@ -3639,7 +3642,7 @@ class TestArrayInterface:
         if all(t[0] == t[1] for t in ufunc.types if not any(x in t[0:2] for x in ["m", "M", "q", "Q"])):
             try:
                 com_dtype_both = np.promote_types(com_dtype1, com_dtype2)
-            except np.DTypePromotionError:
+            except (TypeError, np.exceptions.DTypePromotionError):
                 com_dtype_both = np.dtype("O")
             com_dtype_tuple = (com_dtype_both, com_dtype_both)
 


### PR DESCRIPTION
In short:
- Replacing `np.find_common_dtypes` that is deprecated: to get the same behaviour, now using `np.promote_dtypes` in a `try`/`except` to catch promotion errors with datetimes and return an object dtype (see https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations),
- Ignoring `int64` and `uint64` casting rules in `ufunc` tests, which were recently added.

Resolves #381 