### PR TITLE
Small fixes

### DIFF
--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -305,7 +305,7 @@ def reproject_shape(inshape: BaseGeometry, in_crs: CRS, out_crs: CRS) -> BaseGeo
 
     :returns: Reprojected geometry
     """
-    reproj = pyproj.Transformer.from_crs(in_crs, out_crs, always_xy=True, skip_equivalent=True).transform
+    reproj = pyproj.Transformer.from_crs(in_crs, out_crs, always_xy=True).transform
     return shapely.ops.transform(reproj, inshape)
 
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2140,17 +2140,31 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return dst_r
 
-    def shift(self, xoff: float, yoff: float) -> None:
+    def shift(self,
+              xoff: float,
+              yoff: float,
+              distance_unit: Literal["georeferenced"] | Literal["pixel"] = "georeferenced") -> None:
         """
         Shift the raster by a (x,y) offset.
 
+        The shifting only updates the geotransform (no resampling is performed).
+
         :param xoff: Translation x offset.
         :param yoff: Translation y offset.
-
-
+        :param distance_unit: Distance unit, either 'georeferenced' (default) or 'pixel'.
         """
+        if distance_unit not in ["georeferenced", "pixel"]:
+            raise ValueError("Argument 'distance_unit' should be either 'pixel' or 'georeferenced'.")
+
+        # Get transform
         dx, b, xmin, d, dy, ymax = list(self.transform)[:6]
 
+        # Convert pixel offsets to georeferenced units
+        if distance_unit == "pixel":
+            xoff *= self.res[0]
+            yoff *= self.res[1]
+
+        # Overwrite transform by shifted transform
         self.transform = rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)
 
     def save(

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2140,10 +2140,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return dst_r
 
-    def shift(self,
-              xoff: float,
-              yoff: float,
-              distance_unit: Literal["georeferenced"] | Literal["pixel"] = "georeferenced") -> None:
+    def shift(
+        self, xoff: float, yoff: float, distance_unit: Literal["georeferenced"] | Literal["pixel"] = "georeferenced"
+    ) -> None:
         """
         Shift the raster by a (x,y) offset.
 


### PR DESCRIPTION
This PR:
- Resolves #377 by adding a `distance_unit` argument to `Raster.shift()` who can be either "pixel" or "georeferenced" (mirroring the `proximity()` functionality),
- Resolves #376 by removing `skip_equivalent`.