### PR TITLE
Refine typing with NumPy plugin of `mypy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,9 @@ repos:
           hooks:
                 - id: mypy
                   args: [
+                        --config-file=mypy.ini,
                         --strict,
+                        --implicit-optional,
                         --ignore-missing-imports,  # Don't warn about stubs since pre-commit runs in a limited env
                         --allow-untyped-calls,  # Dynamic function/method calls are okay. Untyped function definitions are not okay.
                         --show-error-codes,
@@ -58,7 +60,7 @@ repos:
                         --disable-error-code=var-annotated,
                         --disable-error-code=no-any-return
                   ]
-                  additional_dependencies: [tokenize-rt==3.2.0]
+                  additional_dependencies: [tokenize-rt==3.2.0, numpy==1.22]
                   files: ^(geoutils|tests)
 
         # Sort imports using isort

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -18,7 +18,7 @@ if sys.version_info.minor >= 9:
         NDArray,
     )
 
-    # Simply define here if they exist (for backwards compatibility below)
+    # Simply define here if they exist
     DTypeLike = DTypeLike
     ArrayLike = ArrayLike
 
@@ -29,6 +29,7 @@ if sys.version_info.minor >= 9:
     MArrayNum = np.ma.masked_array[Any, np.dtype[np.floating[Any] | np.integer[Any]]]
     MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool[Any]]]
 
+# For backward compatibility before Python 3.9
 else:
 
     # Make an array-like type (since the array-like numpy type only exists in numpy>=1.20)

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -23,10 +23,10 @@ if sys.version_info.minor >= 9:
     ArrayLike = ArrayLike
 
     # Use NDArray wrapper to easily define numerical (float or int) N-D array types, and boolean N-D array types
-    NDArrayNum = NDArray[np.floating[Any] | np.integer[Any]]
+    NDArrayNum = NDArray[Union[np.floating[Any], np.integer[Any]]]
     NDArrayBool = NDArray[np.bool[Any]]
     # Define numerical (float or int) masked N-D array type
-    MArrayNum = np.ma.masked_array[Any, np.dtype[np.floating[Any] | np.integer[Any]]]
+    MArrayNum = np.ma.masked_array[Any, Union[np.dtype[np.floating[Any], np.integer[Any]]]]
     MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool[Any]]]
 
 # For backward compatibility before Python 3.9

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -36,9 +36,12 @@ else:
     Number = Union[int, float, np.integer, np.floating]  # type: ignore
 
     # Make an array-like type (since the array-like numpy type only exists in numpy>=1.20)
-    ArrayLike = Union[np.ndarray, np.ma.masked_array, List[Any], Tuple[Any]]  # type: ignore
     DTypeLike = Union[str, type, np.dtype]  # type: ignore
+    ArrayLike = Union[np.ndarray, np.ma.masked_array, List[Any], Tuple[Any]]  # type: ignore
 
+    # Define generic types for NumPy array and masked-array (behaves as "Any" before 3.9 and plugin)
     NDArrayNum = np.ndarray  # type: ignore
     NDArrayBool = np.ndarray  # type: ignore
     MArrayNum = np.ma.masked_array  # type: ignore
+    MArrayBool = np.ma.masked_array  # type: ignore
+

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -26,7 +26,7 @@ if sys.version_info.minor >= 9:
     NDArrayNum = NDArray[Union[np.floating[Any], np.integer[Any]]]
     NDArrayBool = NDArray[np.bool[Any]]
     # Define numerical (float or int) masked N-D array type
-    MArrayNum = np.ma.masked_array[Any, Union[np.dtype[np.floating[Any], np.integer[Any]]]]
+    MArrayNum = np.ma.masked_array[Any, np.dtype[Union[np.floating[Any], np.integer[Any]]]]
     MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool[Any]]]
 
 # For backward compatibility before Python 3.9

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -44,4 +44,3 @@ else:
     NDArrayBool = np.ndarray  # type: ignore
     MArrayNum = np.ma.masked_array  # type: ignore
     MArrayBool = np.ma.masked_array  # type: ignore
-

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -7,7 +7,7 @@ from typing import Any, List, Tuple, Union
 import numpy as np
 
 # Mypy has issues with the builtin Number type (https://github.com/python/mypy/issues/3186)
-Number = int | float | np.integer[Any] | np.floating[Any]
+Number = Union[int, float, np.integer[Any], np.floating[Any]]
 
 # Only for Python >= 3.9
 if sys.version_info.minor >= 9:

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -6,9 +6,6 @@ from typing import Any, List, Tuple, Union
 
 import numpy as np
 
-# Mypy has issues with the builtin Number type (https://github.com/python/mypy/issues/3186)
-Number = Union[int, float, np.integer[Any], np.floating[Any]]
-
 # Only for Python >= 3.9
 if sys.version_info.minor >= 9:
 
@@ -17,6 +14,9 @@ if sys.version_info.minor >= 9:
         DTypeLike,
         NDArray,
     )
+
+    # Mypy has issues with the builtin Number type (https://github.com/python/mypy/issues/3186)
+    Number = Union[int, float, np.integer[Any], np.floating[Any]]
 
     # Simply define here if they exist
     DTypeLike = DTypeLike
@@ -31,6 +31,9 @@ if sys.version_info.minor >= 9:
 
 # For backward compatibility before Python 3.9
 else:
+
+    # Mypy has issues with the builtin Number type (https://github.com/python/mypy/issues/3186)
+    Number = Union[int, float, np.integer, np.floating]  # type: ignore
 
     # Make an array-like type (since the array-like numpy type only exists in numpy>=1.20)
     ArrayLike = Union[np.ndarray, np.ma.masked_array, List[Any], Tuple[Any]]  # type: ignore

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -1,14 +1,40 @@
 """Typing aliases for internal use."""
 from __future__ import annotations
 
+import sys
 from typing import Any, List, Tuple, Union
 
 import numpy as np
 
-# Make an array-like type (since the array-like numpy type only exists in numpy>=1.20)
-ArrayLike = Union[np.ndarray, np.ma.masked_array, List[Any], Tuple[Any]]
-
-DTypeLike = Union[str, type, np.dtype]
-
 # Mypy has issues with the builtin Number type (https://github.com/python/mypy/issues/3186)
-AnyNumber = Union[int, float, np.number]
+Number = int | float | np.integer[Any] | np.floating[Any]
+
+# Only for Python >= 3.9
+if sys.version_info.minor >= 9:
+
+    from numpy.typing import (  # this syntax works starting on Python 3.9
+        ArrayLike,
+        DTypeLike,
+        NDArray,
+    )
+
+    # Simply define here if they exist (for backwards compatibility below)
+    DTypeLike = DTypeLike
+    ArrayLike = ArrayLike
+
+    # Use NDArray wrapper to easily define numerical (float or int) N-D array types, and boolean N-D array types
+    NDArrayNum = NDArray[np.floating[Any] | np.integer[Any]]
+    NDArrayBool = NDArray[np.bool[Any]]
+    # Define numerical (float or int) masked N-D array type
+    MArrayNum = np.ma.masked_array[Any, np.dtype[np.floating[Any] | np.integer[Any]]]
+    MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool[Any]]]
+
+else:
+
+    # Make an array-like type (since the array-like numpy type only exists in numpy>=1.20)
+    ArrayLike = Union[np.ndarray, np.ma.masked_array, List[Any], Tuple[Any]]  # type: ignore
+    DTypeLike = Union[str, type, np.dtype]  # type: ignore
+
+    NDArrayNum = np.ndarray  # type: ignore
+    NDArrayBool = np.ndarray  # type: ignore
+    MArrayNum = np.ma.masked_array  # type: ignore

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -24,10 +24,10 @@ if sys.version_info.minor >= 9:
 
     # Use NDArray wrapper to easily define numerical (float or int) N-D array types, and boolean N-D array types
     NDArrayNum = NDArray[Union[np.floating[Any], np.integer[Any]]]
-    NDArrayBool = NDArray[np.bool[Any]]
+    NDArrayBool = NDArray[np.bool_[Any]]
     # Define numerical (float or int) masked N-D array type
     MArrayNum = np.ma.masked_array[Any, np.dtype[Union[np.floating[Any], np.integer[Any]]]]
-    MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool[Any]]]
+    MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool_[Any]]]
 
 # For backward compatibility before Python 3.9
 else:

--- a/geoutils/_typing.py
+++ b/geoutils/_typing.py
@@ -24,10 +24,10 @@ if sys.version_info.minor >= 9:
 
     # Use NDArray wrapper to easily define numerical (float or int) N-D array types, and boolean N-D array types
     NDArrayNum = NDArray[Union[np.floating[Any], np.integer[Any]]]
-    NDArrayBool = NDArray[np.bool_[Any]]
+    NDArrayBool = NDArray[np.bool_]
     # Define numerical (float or int) masked N-D array type
     MArrayNum = np.ma.masked_array[Any, np.dtype[Union[np.floating[Any], np.integer[Any]]]]
-    MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool_[Any]]]
+    MArrayBool = np.ma.masked_array[Any, np.dtype[np.bool_]]
 
 # For backward compatibility before Python 3.9
 else:

--- a/geoutils/raster/array.py
+++ b/geoutils/raster/array.py
@@ -7,9 +7,10 @@ import warnings
 import numpy as np
 
 import geoutils as gu
+from geoutils._typing import MArrayNum, NDArrayNum
 
 
-def get_mask(array: np.ndarray | np.ma.masked_array) -> np.ndarray:
+def get_mask(array: NDArrayNum | MArrayNum) -> NDArrayNum:
     """
     Return the mask of invalid values, whether array is a ndarray with NaNs or a np.ma.masked_array.
 
@@ -22,8 +23,8 @@ def get_mask(array: np.ndarray | np.ma.masked_array) -> np.ndarray:
 
 
 def get_array_and_mask(
-    array: np.ndarray | np.ma.masked_array, check_shape: bool = True, copy: bool = True
-) -> tuple[np.ndarray, np.ndarray]:
+    array: NDArrayNum | MArrayNum, check_shape: bool = True, copy: bool = True
+) -> tuple[NDArrayNum, NDArrayNum]:
     """
     Return array with masked values set to NaN and the associated mask.
     Works whether array is a ndarray with NaNs or a np.ma.masked_array.
@@ -65,7 +66,7 @@ def get_array_and_mask(
     return array_data, invalid_mask
 
 
-def get_valid_extent(array: np.ndarray | np.ma.masked_array) -> tuple[int, ...]:
+def get_valid_extent(array: NDArrayNum | MArrayNum) -> tuple[int, ...]:
     """
     Return (rowmin, rowmax, colmin, colmax), the first/last row/column of array with valid pixels
     """
@@ -78,7 +79,7 @@ def get_valid_extent(array: np.ndarray | np.ma.masked_array) -> tuple[int, ...]:
     return rows_nonzero[0], rows_nonzero[-1], cols_nonzero[0], cols_nonzero[-1]
 
 
-def get_xy_rotated(raster: gu.Raster, along_track_angle: float) -> tuple[np.ndarray, np.ndarray]:
+def get_xy_rotated(raster: gu.Raster, along_track_angle: float) -> tuple[NDArrayNum, NDArrayNum]:
     """
     Rotate x, y axes of image to get along- and cross-track distances.
     :param raster: Raster to get x,y positions from.

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -10,6 +10,7 @@ import rasterio.warp
 from tqdm import tqdm
 
 import geoutils as gu
+from geoutils._typing import NDArrayNum
 from geoutils.misc import resampling_method_from_str
 from geoutils.raster import Raster, RasterType, get_array_and_mask
 from geoutils.raster.raster import _default_nodata
@@ -167,7 +168,7 @@ def stack_rasters(
         )
 
     # Make a data list and add all of the reprojected rasters into it.
-    data: list[np.ndarray] = []
+    data: list[NDArrayNum] = []
 
     for raster in tqdm(rasters, disable=not progress):
         # Check that data is loaded, otherwise temporarily load it
@@ -209,7 +210,7 @@ def stack_rasters(
         nodata = reference_raster.nodata
     else:
         nodata = _default_nodata(data.dtype)
-    data[np.isnan(data)] = nodata
+    data[np.isnan(data)] = nodata  # type: ignore
 
     # Save as gu.Raster - needed as some child classes may not accept multiple bands
     r = gu.Raster.from_array(

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -10,7 +10,6 @@ import warnings
 from collections import abc
 from contextlib import ExitStack
 from math import floor
-from numbers import Number
 from typing import IO, Any, Callable, TypeVar, overload
 
 import affine
@@ -31,7 +30,15 @@ from rasterio.plot import show as rshow
 from scipy.ndimage import distance_transform_edt, map_coordinates
 
 import geoutils.vector as gv
-from geoutils._typing import AnyNumber, ArrayLike, DTypeLike
+from geoutils._typing import (
+    ArrayLike,
+    DTypeLike,
+    MArrayBool,
+    MArrayNum,
+    NDArrayBool,
+    NDArrayNum,
+    Number,
+)
 from geoutils.projtools import (
     _get_bounds_projected,
     _get_footprint_projected,
@@ -120,7 +127,7 @@ handled_array_funcs = _HANDLED_FUNCTIONS_1NIN + _HANDLED_FUNCTIONS_2NIN
 # Similar to GDAL for int types, but without absurdly long nodata values for floats.
 # For unsigned types, the maximum value is chosen (with a max of 99999).
 # For signed types, the minimum value is chosen (with a min of -99999).
-def _default_nodata(dtype: str | np.dtype | type) -> int:
+def _default_nodata(dtype: DTypeLike) -> int:
     """
     Set the default nodata value for any given dtype, when this is not provided.
     """
@@ -181,7 +188,7 @@ def _load_rio(
     shape: tuple[int, int] | None = None,
     out_count: int | None = None,
     **kwargs: Any,
-) -> np.ma.masked_array:
+) -> MArrayNum:
     r"""
     Load specific bands of the dataset, using :func:`rasterio.read`.
 
@@ -259,7 +266,7 @@ class Raster:
         | dict[str, Any],
         indexes: int | list[int] | None = None,
         load_data: bool = False,
-        downsample: AnyNumber = 1,
+        downsample: Number = 1,
         masked: bool = True,
         nodata: int | float | None = None,
     ) -> None:
@@ -283,7 +290,7 @@ class Raster:
         self.filename: str | None = None
         self.tags: dict[str, Any] = {}
 
-        self._data: np.ma.masked_array | None = None
+        self._data: MArrayNum | None = None
         self._transform: affine.Affine | None = None
         self._crs: CRS | None = None
         self._nodata: int | float | None = nodata
@@ -568,7 +575,7 @@ class Raster:
     @classmethod
     def from_array(
         cls: type[RasterType],
-        data: np.ndarray | np.ma.masked_array,
+        data: NDArrayNum | MArrayNum | NDArrayBool,
         transform: tuple[float, ...] | Affine,
         crs: CRS | int | None,
         nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
@@ -720,7 +727,7 @@ class Raster:
 
         return str(s)
 
-    def __getitem__(self, index: Raster | Vector | np.ndarray | list[float] | tuple[float, ...]) -> np.ndarray | Raster:
+    def __getitem__(self, index: Raster | Vector | NDArrayNum | list[float] | tuple[float, ...]) -> NDArrayNum | Raster:
         """
         Index or subset the raster.
 
@@ -753,7 +760,7 @@ class Raster:
         else:
             return self.crop(crop_geom=index, inplace=False)
 
-    def __setitem__(self, index: Mask | np.ndarray, assign: np.ndarray | Number) -> None:
+    def __setitem__(self, index: Mask | NDArrayBool, assign: NDArrayNum | Number) -> None:
         """
         Perform index assignment on the raster.
 
@@ -768,7 +775,7 @@ class Raster:
             if not self.georeferenced_grid_equal(index):
                 raise ValueError("Indexing a raster with a mask requires the two being on the same georeferenced grid.")
 
-            ind = index.data
+            ind = index.data.data
         # If input is array with the same shape
         elif isinstance(index, np.ndarray):
             if np.shape(index) != self.shape:
@@ -820,10 +827,8 @@ class Raster:
         )
 
     def _overloading_check(
-        self: RasterType, other: RasterType | np.ndarray | Number
-    ) -> tuple[
-        np.ma.masked_array, np.ma.masked_array | Number, float | int | tuple[int, ...] | tuple[float, ...] | None
-    ]:
+        self: RasterType, other: RasterType | NDArrayNum | Number
+    ) -> tuple[MArrayNum, MArrayNum | NDArrayNum | Number, float | int | tuple[int, ...] | tuple[float, ...] | None]:
         """
         Before any operation overloading, check input data type and return both self and other data as either
         a np.ndarray or number, converted to the minimum compatible dtype between both datasets.
@@ -843,7 +848,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Check that other is of correct type
         # If not, a NotImplementedError should be raised, in case other's class has a method implemented.
         # See https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
-        if not isinstance(other, (Raster, np.ndarray, Number)):
+        if not isinstance(other, (Raster, np.ndarray, float, int, np.floating, np.integer)):
             raise NotImplementedError(
                 f"Operation between an object of type {type(other)} and a Raster impossible. Must be a Raster, "
                 f"np.ndarray or single number."
@@ -866,19 +871,19 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             else:
                 raise ValueError("Both rasters must have the same shape, transform and CRS.")
 
-            other_data = other.data
             nodata2 = other.nodata
-            dtype2 = other_data.dtype
+            dtype2 = other.data.dtype
+            other_data: NDArrayNum | MArrayNum | Number = other.data
 
         # Case 2 - other is a numpy array
         elif isinstance(other, np.ndarray):
             # Check that both array have the same shape
 
-            other_data = other
-
             # Squeeze first axis of other data if possible
-            if len(other_data.shape) == 3 and other_data.shape[0] == 1:
-                other_data = other_data.squeeze(axis=0)
+            if len(other.shape) == 3 and other.shape[0] == 1:
+                other_data = other.squeeze(axis=0)
+            else:
+                other_data = other
 
             if self.data.shape == other_data.shape:
                 pass
@@ -908,7 +913,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return self_data, other_data, out_nodata
 
-    def __add__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __add__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Sum two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -927,13 +932,14 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return out_rst
 
-    def __radd__(self: RasterType, other: np.ndarray | Number) -> RasterType:
+    # Skip Mypy not resolving forward operator typing with NumPy numbers: https://github.com/python/mypy/issues/11595
+    def __radd__(self: RasterType, other: NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Sum two rasters, or a raster and a numpy array, or a raster and single number.
 
         For when other is first item in the operation (e.g. 1 + rst).
         """
-        return self.__add__(other)
+        return self.__add__(other)  # type: ignore
 
     def __neg__(self: RasterType) -> RasterType:
         """
@@ -943,7 +949,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         """
         return self.from_array(-self.data, self.transform, self.crs, nodata=self.nodata)
 
-    def __sub__(self, other: Raster | np.ndarray | Number) -> Raster:
+    def __sub__(self, other: Raster | NDArrayNum | Number) -> Raster:
         """
         Subtract two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -955,7 +961,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_data = self_data - other_data
         return self.from_array(out_data, self.transform, self.crs, nodata=nodata)
 
-    def __rsub__(self: RasterType, other: np.ndarray | Number) -> RasterType:
+    # Skip Mypy not resolving forward operator typing with NumPy numbers: https://github.com/python/mypy/issues/11595
+    def __rsub__(self: RasterType, other: NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Subtract two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -965,7 +972,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_data = other_data - self_data
         return self.from_array(out_data, self.transform, self.crs, nodata=nodata)
 
-    def __mul__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __mul__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Multiply two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -978,7 +985,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __rmul__(self: RasterType, other: np.ndarray | Number) -> RasterType:
+    # Skip Mypy not resolving forward operator typing with NumPy numbers: https://github.com/python/mypy/issues/11595
+    def __rmul__(self: RasterType, other: NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Multiply two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -986,7 +994,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         """
         return self.__mul__(other)
 
-    def __truediv__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __truediv__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         True division of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -999,7 +1007,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __rtruediv__(self: RasterType, other: np.ndarray | Number) -> RasterType:
+    # Skip Mypy not resolving forward operator typing with NumPy numbers: https://github.com/python/mypy/issues/11595
+    def __rtruediv__(self: RasterType, other: NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         True division of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1010,7 +1019,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __floordiv__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __floordiv__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Floor division of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1023,7 +1032,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __rfloordiv__(self: RasterType, other: np.ndarray | Number) -> RasterType:
+    # Skip Mypy not resolving forward operator typing with NumPy numbers: https://github.com/python/mypy/issues/11595
+    def __rfloordiv__(self: RasterType, other: NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Floor division of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1034,7 +1044,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __mod__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __mod__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Modulo of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1052,7 +1062,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         Power of a raster to a number.
         """
         # Check that input is a number
-        if not isinstance(power, Number):
+        if not isinstance(power, (float, int, np.floating, np.integer)):
             raise ValueError("Power needs to be a number.")
 
         # Calculate the product of arrays and save to new Raster
@@ -1061,7 +1071,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_rst = self.from_array(out_data, self.transform, self.crs, nodata=nodata)
         return out_rst
 
-    def __eq__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:  # type: ignore
+    def __eq__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Element-wise equality of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1076,7 +1086,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_mask = self.from_array(out_data, self.transform, self.crs, nodata=None)
         return out_mask
 
-    def __ne__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:  # type: ignore
+    def __ne__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:  # type: ignore
         """
         Element-wise negation of two rasters, or a raster and a numpy array, or a raster and single number.
 
@@ -1091,7 +1101,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_mask = self.from_array(out_data, self.transform, self.crs, nodata=None)
         return out_mask
 
-    def __lt__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __lt__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Element-wise lower than comparison of two rasters, or a raster and a numpy array,
         or a raster and single number.
@@ -1107,7 +1117,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_mask = self.from_array(out_data, self.transform, self.crs, nodata=None)
         return out_mask
 
-    def __le__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __le__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Element-wise lower or equal comparison of two rasters, or a raster and a numpy array,
         or a raster and single number.
@@ -1123,7 +1133,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_mask = self.from_array(out_data, self.transform, self.crs, nodata=None)
         return out_mask
 
-    def __gt__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __gt__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Element-wise greater than comparison of two rasters, or a raster and a numpy array,
         or a raster and single number.
@@ -1139,7 +1149,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         out_mask = self.from_array(out_data, self.transform, self.crs, nodata=None)
         return out_mask
 
-    def __ge__(self: RasterType, other: RasterType | np.ndarray | Number) -> RasterType:
+    def __ge__(self: RasterType, other: RasterType | NDArrayNum | Number) -> RasterType:
         """
         Element-wise greater or equal comparison of two rasters, or a raster and a numpy array,
         or a raster and single number.
@@ -1185,7 +1195,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         out_data = self.data.astype(dtype)
         if inplace:
-            self._data = out_data
+            self._data = out_data  # type: ignore
             return None
         else:
             return self.from_array(out_data, self.transform, self.crs, nodata=self.nodata)
@@ -1330,7 +1340,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         self._nodata = new_nodata
 
     @property
-    def data(self) -> np.ma.masked_array:
+    def data(self) -> MArrayNum:
         """
         Array of the raster.
 
@@ -1339,10 +1349,10 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         """
         if not self.is_loaded:
             self.load()
-        return self._data
+        return self._data  # type: ignore
 
     @data.setter
-    def data(self, new_data: np.ndarray | np.ma.masked_array) -> None:
+    def data(self, new_data: NDArrayNum | MArrayNum) -> None:
         """
         Set the contents of .data and possibly update .nodata.
 
@@ -1488,7 +1498,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         new_crs = CRS.from_user_input(value=new_crs)
         self._crs = new_crs
 
-    def set_mask(self, mask: np.ndarray | Mask) -> None:
+    def set_mask(self, mask: NDArrayBool | Mask) -> None:
         """
         Set a mask on the raster array.
 
@@ -1511,17 +1521,19 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # If the mask is a Mask instance, pass the boolean array
         if isinstance(mask, Mask):
-            mask = mask.data.filled(False)
-        mask = mask.squeeze()
+            mask_arr = mask.data.filled(False)
+        else:
+            mask_arr = mask
+        mask_arr = mask_arr.squeeze()
 
-        if mask.shape != orig_shape:
+        if mask_arr.shape != orig_shape:
             # In case first dimension is more than one (several bands) and other dimensions match
-            if orig_shape[1:] == mask.shape:
-                self.data[:, mask > 0] = np.ma.masked
+            if orig_shape[1:] == mask_arr.shape:
+                self.data[:, mask_arr > 0] = np.ma.masked
             else:
                 raise ValueError(f"mask must be of the same shape as existing data: {orig_shape}.")
         else:
-            self.data[mask > 0] = np.ma.masked
+            self.data[mask_arr > 0] = np.ma.masked
 
     def info(self, stats: bool = False) -> str:
         """
@@ -1572,7 +1584,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return "".join(as_str)
 
-    def copy(self: RasterType, new_array: np.ndarray | None = None) -> RasterType:
+    def copy(self: RasterType, new_array: NDArrayNum | None = None) -> RasterType:
         """
         Copy the raster in-memory.
 
@@ -1601,14 +1613,14 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         return all([self.shape == raster.shape, self.transform == raster.transform, self.crs == raster.crs])
 
     @overload
-    def get_nanarray(self, return_mask: Literal[False] = False) -> np.ndarray:
+    def get_nanarray(self, return_mask: Literal[False] = False) -> NDArrayNum:
         ...
 
     @overload
-    def get_nanarray(self, return_mask: Literal[True]) -> tuple[np.ndarray, np.ndarray]:
+    def get_nanarray(self, return_mask: Literal[True]) -> tuple[NDArrayNum, NDArrayBool]:
         ...
 
-    def get_nanarray(self, return_mask: bool = False) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    def get_nanarray(self, return_mask: bool = False) -> NDArrayNum | tuple[NDArrayNum, NDArrayBool]:
         """
         Get NaN array from the raster.
 
@@ -1646,9 +1658,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     def __array_ufunc__(
         self,
-        ufunc: Callable[[np.ndarray | tuple[np.ndarray, np.ndarray]], np.ndarray | tuple[np.ndarray, np.ndarray]],
+        ufunc: Callable[[NDArrayNum | tuple[NDArrayNum, NDArrayNum]], NDArrayNum | tuple[NDArrayNum, NDArrayNum]],
         method: str,
-        *inputs: Raster | tuple[Raster, Raster] | tuple[np.ndarray, Raster] | tuple[Raster, np.ndarray],
+        *inputs: Raster | tuple[Raster, Raster] | tuple[NDArrayNum, Raster] | tuple[Raster, NDArrayNum],
         **kwargs: Any,
     ) -> Raster | tuple[Raster, Raster]:
         """
@@ -1711,7 +1723,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 ), self.from_array(data=output[1], transform=self.transform, crs=self.crs, nodata=self.nodata)
 
     def __array_function__(
-        self, func: Callable[[np.ndarray, Any], Any], types: tuple[type], args: Any, kwargs: Any
+        self, func: Callable[[NDArrayNum, Any], Any], types: tuple[type], args: Any, kwargs: Any
     ) -> Any:
         """
         Method to cast NumPy array function directly on a Raster object by applying it to the masked array.
@@ -1893,7 +1905,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         dst_res: float | abc.Iterable[float] | None = None,
         dst_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
         src_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
-        dst_dtype: np.dtype | None = None,
+        dst_dtype: DTypeLike | None = None,
         resampling: Resampling | str = Resampling.bilinear,
         silent: bool = False,
         n_threads: int = 0,
@@ -2116,7 +2128,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # If not, uses the dataset instead
         else:
-            dst_data = []
+            dst_data = []  # type: ignore
             for k in range(self.count):
                 with rio.open(self.filename) as ds:
                     band = rio.band(ds, k + 1)
@@ -2158,7 +2170,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         filename: str | pathlib.Path | IO[bytes],
         driver: str = "GTiff",
         dtype: DTypeLike | None = None,
-        nodata: AnyNumber | None = None,
+        nodata: Number | None = None,
         compress: str = "deflate",
         tiled: bool = False,
         blank_value: int | float | None = None,
@@ -2202,6 +2214,10 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Use nodata set by user, otherwise default to self's
         nodata = nodata if nodata is not None else self.nodata
 
+        # Declare type of save_data to work in all occurrences
+        save_data: NDArrayNum
+
+        # Define save_data depending on blank_value argument
         if (self.data is None) & (blank_value is None):
             raise AttributeError("No data loaded, and alternative blank_value not set.")
         elif blank_value is not None:
@@ -2384,7 +2400,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     def show(
         self,
-        index: int | None = None,
+        index: int | tuple[int, ...] | None = None,
         cmap: matplotlib.colors.Colormap | str | None = None,
         vmin: float | int | None = None,
         vmax: float | int | None = None,
@@ -2432,7 +2448,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # rshow takes care of image dimensions
         # if self.count=3 (4) => plotted as RGB(A)
         if index is None:
-            index = np.arange(1, self.count + 1)
+            index = tuple(range(1, self.count + 1))
         elif isinstance(index, int):
             if index > self.count:
                 raise ValueError(f"Index must be in range 1-{self.count:d}")
@@ -2444,7 +2460,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if self.count == 1:
             data = self.data
         else:
-            data = self.data[index - 1, :, :]
+            data = self.data[np.array(index) - 1, :, :]
 
         # If multiple bands (RGB), cbar does not make sense
         if isinstance(index, abc.Sequence):
@@ -2522,13 +2538,13 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     def value_at_coords(
         self,
-        x: float | ArrayLike,
-        y: float | ArrayLike,
+        x: Number | ArrayLike,
+        y: Number | ArrayLike,
         latlon: bool = False,
         index: int | None = None,
         masked: bool = False,
         window: int | None = None,
-        reducer_function: Callable[[np.ndarray], float] = np.ma.mean,
+        reducer_function: Callable[[NDArrayNum], float] = np.ma.mean,
         return_window: bool = False,
         boundless: bool = True,
     ) -> Any:
@@ -2574,14 +2590,16 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # If for a single value, wrap in a list
         if isinstance(x, (float, np.floating, int, np.integer)):
-            x = [x]
-            y = [y]
+            xlist = [x]
+            ylist = [y]
             # For the end of the function
             unwrap = True
         else:
+            xlist = x
+            ylist = y
             unwrap = False
             # Check that array-like objects are the same length
-            if len(x) != len(y):  # type: ignore
+            if len(xlist) != len(ylist):  # type: ignore
                 raise ValueError("Coordinates must be of the same length.")
 
         # Check window parameter
@@ -2613,14 +2631,14 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if latlon:
             from geoutils import projtools
 
-            x, y = projtools.reproject_from_latlon((y, x), self.crs)  # type: ignore
+            xlist, ylist = projtools.reproject_from_latlon((ylist, xlist), self.crs)  # type: ignore
 
         # Convert coordinates to pixel space
-        rows, cols = rio.transform.rowcol(self.transform, x, y, op=floor)
+        rows, cols = rio.transform.rowcol(self.transform, xlist, ylist, op=floor)
 
         # Loop over all coordinates passed
         for k in range(len(rows)):  # type: ignore
-            value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], np.ndarray] | Any]
+            value: float | dict[int, float] | tuple[float | dict[int, float] | tuple[list[float], NDArrayNum] | Any]
 
             row = rows[k]  # type: ignore
             col = cols[k]  # type: ignore
@@ -2654,7 +2672,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 if not masked:
                     data = data.filled()
                 value = format_value(data)
-                win: np.ndarray | dict[int, np.ndarray] = data
+                win: NDArrayNum | dict[int, NDArrayNum] = data
 
             else:
                 # TODO: if we want to allow sampling multiple bands, need to do it also when data is loaded
@@ -2701,7 +2719,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             return output_val
 
-    def coords(self, offset: str = "corner", grid: bool = True) -> tuple[np.ndarray, np.ndarray]:
+    def coords(self, offset: str = "corner", grid: bool = True) -> tuple[NDArrayNum, NDArrayNum]:
         """
         Get coordinates (x,y) of all pixels in the raster.
 
@@ -2726,7 +2744,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             xx += dx / 2  # shift by half a pixel
             yy += dy / 2
         if grid:
-            meshgrid: tuple[np.ndarray, np.ndarray] = np.meshgrid(xx[:-1], np.flip(yy[:-1]))  # drop the last element
+            meshgrid: tuple[NDArrayNum, NDArrayNum] = np.meshgrid(xx[:-1], np.flip(yy[:-1]))  # drop the last element
             return meshgrid
         else:
             return xx[:-1], yy[:-1]
@@ -2738,7 +2756,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         op: type = np.float32,
         precision: float | None = None,
         shift_area_or_point: bool = False,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[NDArrayNum, NDArrayNum]:
         """
         Get indexes (row,column) of coordinates (x,y).
 
@@ -2819,7 +2837,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return i, j
 
-    def ij2xy(self, i: ArrayLike, j: ArrayLike, offset: str = "ul") -> tuple[np.ndarray, np.ndarray]:
+    def ij2xy(self, i: ArrayLike, j: ArrayLike, offset: str = "ul") -> tuple[NDArrayNum, NDArrayNum]:
         """
         Get coordinates (x,y) of indexes (row,column).
 
@@ -2864,7 +2882,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         index: int = 1,
         shift_area_or_point: bool = False,
         **kwargs: Any,
-    ) -> np.ndarray:
+    ) -> NDArrayNum:
         """
          Interpolate raster values at a set of points.
 
@@ -2963,19 +2981,25 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     @overload
     def to_points(
-        self, subset: float | int, as_array: Literal[True], pixel_offset: Literal["center", "corner"]
-    ) -> Vector:
+        self,
+        subset: float | int,
+        as_array: Literal[False] = False,
+        pixel_offset: Literal["center", "corner"] = "center",
+    ) -> NDArrayNum:
         ...
 
     @overload
     def to_points(
-        self, subset: float | int, as_array: Literal[False], pixel_offset: Literal["center", "corner"]
-    ) -> np.ndarray:
+        self,
+        subset: float | int,
+        as_array: Literal[True],
+        pixel_offset: Literal["center", "corner"] = "center",
+    ) -> Vector:
         ...
 
     def to_points(
         self, subset: float | int = 1, as_array: bool = False, pixel_offset: Literal["center", "corner"] = "center"
-    ) -> np.ndarray | Vector:
+    ) -> NDArrayNum | Vector:
         """
         Convert raster to points.
 
@@ -3034,22 +3058,23 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             pixel_data = np.where(pixel_data.mask, np.nan, pixel_data.data)
 
         # Merge the coordinates and pixel data into a point cloud.
-        points = np.vstack((x_coords.reshape(1, -1), y_coords.reshape(1, -1), pixel_data)).T
+        points_arr = np.vstack((x_coords.reshape(1, -1), y_coords.reshape(1, -1), pixel_data)).T
 
         if not as_array:
             points = Vector(
                 gpd.GeoDataFrame(
-                    points[:, 2:],
+                    points_arr[:, 2:],
                     columns=[f"b{i}" for i in range(1, self.count + 1)],
-                    geometry=gpd.points_from_xy(points[:, 0], points[:, 1]),
+                    geometry=gpd.points_from_xy(points_arr[:, 0], points_arr[:, 1]),
                     crs=self.crs,
                 )
             )
-
-        return points
+            return points
+        else:
+            return points_arr
 
     def polygonize(
-        self, target_values: Number | tuple[Number, Number] | list[Number] | np.ndarray | Literal["all"] = "all"
+        self, target_values: Number | tuple[Number, Number] | list[Number] | NDArrayNum | Literal["all"] = "all"
     ) -> Vector:
         """
         Polygonize the raster into a vector.
@@ -3060,28 +3085,28 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :returns: Vector containing the polygonized geometries.
         """
 
-        # mask a unique value set by a number
-        if isinstance(target_values, Number):
+        # Mask a unique value set by a number
+        if isinstance(target_values, (int, float, np.integer, np.floating)):
             if np.sum(self.data == target_values) == 0:
                 raise ValueError(f"no pixel with in_value {target_values}")
 
             bool_msk = np.array(self.data == target_values).astype(np.uint8)
 
-        # mask values within boundaries set by a tuple
+        # Mask values within boundaries set by a tuple
         elif isinstance(target_values, tuple):
             if np.sum((self.data > target_values[0]) & (self.data < target_values[1])) == 0:
                 raise ValueError(f"no pixel with in_value between {target_values[0]} and {target_values[1]}")
 
             bool_msk = ((self.data > target_values[0]) & (self.data < target_values[1])).astype(np.uint8)
 
-        # mask specific values set by a sequence
+        # Mask specific values set by a sequence
         elif isinstance(target_values, list) or isinstance(target_values, np.ndarray):
-            if np.sum(np.isin(self.data, target_values)) == 0:
+            if np.sum(np.isin(self.data, np.array(target_values))) == 0:
                 raise ValueError("no pixel with in_value " + ", ".join(map("{}".format, target_values)))
 
-            bool_msk = np.isin(self.data, target_values).astype("uint8")
+            bool_msk = np.isin(self.data, np.array(target_values)).astype("uint8")
 
-        # mask all valid values
+        # Mask all valid values
         elif target_values == "all":
             bool_msk = (~self.data.mask).astype("uint8")
 
@@ -3154,12 +3179,32 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return self.copy(new_array=proximity)
 
+    @overload
+    def subsample(
+        self,
+        subsample: int | float,
+        return_indices: Literal[False] = False,
+        *,
+        random_state: np.random.RandomState | int | None = None,
+    ) -> tuple[NDArrayNum, ...]:
+        ...
+
+    @overload
+    def subsample(
+        self,
+        subsample: int | float,
+        return_indices: Literal[True],
+        *,
+        random_state: np.random.RandomState | int | None = None,
+    ) -> NDArrayNum:
+        ...
+
     def subsample(
         self,
         subsample: int | float,
         return_indices: bool = False,
-        random_state: np.random.RandomState | np.random.Generator | int | None = None,
-    ) -> np.ndarray:
+        random_state: np.random.RandomState | int | None = None,
+    ) -> NDArrayNum | tuple[NDArrayNum, ...]:
         """
         Randomly subsample the raster. Only valid values are considered.
 
@@ -3198,6 +3243,9 @@ class Mask(Raster):
         filename_or_dataset: str | RasterType | rio.io.DatasetReader | rio.io.MemoryFile | dict[str, Any],
         **kwargs: Any,
     ) -> None:
+
+        self._data: MArrayNum | MArrayBool | None = None
+
         # If a Mask is passed, simply point back to Mask
         if isinstance(filename_or_dataset, Mask):
             for key in filename_or_dataset.__dict__:
@@ -3216,7 +3264,7 @@ class Mask(Raster):
                 self._data = self.data[0, :, :]
 
             # Convert masked array to boolean
-            self._data = self.data.astype(bool)
+            self._data = self.data.astype(bool)  # type: ignore
 
             # Fix nodata to None
             self._nodata = None
@@ -3280,7 +3328,7 @@ class Mask(Raster):
         dst_res: float | abc.Iterable[float] | None = None,
         dst_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
         src_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
-        dst_dtype: np.dtype | None = None,
+        dst_dtype: DTypeLike | None = None,
         resampling: Resampling | str = Resampling.nearest,
         silent: bool = False,
         n_threads: int = 0,
@@ -3288,13 +3336,13 @@ class Mask(Raster):
     ) -> Mask:
         # Depending on resampling, adjust to rasterio supported types
         if resampling in [Resampling.nearest, "nearest"]:
-            self._data = self.data.astype("uint8")
+            self._data = self.data.astype("uint8")  # type: ignore
         else:
             warnings.warn(
                 "Reprojecting a mask with a resampling method other than 'nearest', "
                 "the boolean array will be converted to float during interpolation."
             )
-            self._data = self.data.astype("float32")
+            self._data = self.data.astype("float32")  # type: ignore
 
         # Call Raster.reproject()
         output = super().reproject(
@@ -3313,7 +3361,7 @@ class Mask(Raster):
         )
 
         # Transform back to a boolean array
-        output._data = output.data.astype(bool)
+        output._data = output.data.astype(bool)  # type: ignore
 
         return output
 
@@ -3375,7 +3423,7 @@ class Mask(Raster):
                 return None
 
     def polygonize(
-        self, target_values: Number | tuple[Number, Number] | list[Number] | np.ndarray | Literal["all"] = 1
+        self, target_values: Number | tuple[Number, Number] | list[Number] | NDArrayNum | Literal["all"] = 1
     ) -> Vector:
         # If target values is passed but does not correspond to 0 or 1, raise a warning
         if not isinstance(target_values, (int, np.integer, float, np.floating)) or target_values not in [0, 1]:
@@ -3383,7 +3431,7 @@ class Mask(Raster):
             target_values = 1
 
         # Convert to unsigned integer and pass to parent method
-        self._data = self.data.astype("uint8")
+        self._data = self.data.astype("uint8")  # type: ignore
         return super().polygonize(target_values=target_values)
 
     def proximity(
@@ -3406,7 +3454,7 @@ class Mask(Raster):
         #     target_values = [1]
 
         # Convert to unsigned integer and pass to parent method
-        self._data = self.data.astype("uint8")
+        self._data = self.data.astype("uint8")  # type: ignore
 
         # Need to cast output to Raster before computing proximity, as output will not be boolean
         # (super() would instantiate Mask() again)
@@ -3419,43 +3467,43 @@ class Mask(Raster):
             distance_unit=distance_unit,
         )
 
-    def __and__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __and__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise and between masks, or a mask and an array."""
         self_data, other_data = self._overloading_check(other)[0:2]
 
         return self.from_array(
-            data=(self_data & other_data), transform=self.transform, crs=self.crs, nodata=self.nodata
+            data=(self_data & other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore
         )
 
-    def __rand__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __rand__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise and between masks, or a mask and an array."""
 
         return self.__and__(other)
 
-    def __or__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __or__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise or between masks, or a mask and an array."""
 
         self_data, other_data = self._overloading_check(other)[0:2]
 
         return self.from_array(
-            data=(self_data | other_data), transform=self.transform, crs=self.crs, nodata=self.nodata
+            data=(self_data | other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore
         )
 
-    def __ror__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __ror__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise or between masks, or a mask and an array."""
 
         return self.__or__(other)
 
-    def __xor__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __xor__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise xor between masks, or a mask and an array."""
 
         self_data, other_data = self._overloading_check(other)[0:2]
 
         return self.from_array(
-            data=(self_data ^ other_data), transform=self.transform, crs=self.crs, nodata=self.nodata
+            data=(self_data ^ other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore
         )
 
-    def __rxor__(self: Mask, other: Mask | np.ndarray) -> Mask:
+    def __rxor__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise xor between masks, or a mask and an array."""
 
         return self.__xor__(other)
@@ -3478,7 +3526,7 @@ def proximity_from_vector_or_raster(
     geometry_type: str = "boundary",
     in_or_out: Literal["in"] | Literal["out"] | Literal["both"] = "both",
     distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
-) -> np.ndarray:
+) -> NDArrayNum:
     """
     (This function is defined here as mostly raster-based, but used in a class method for both Raster and Vector)
     Proximity to a Raster's target values if no Vector is provided, otherwise to a Vector's geometry type

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3252,7 +3252,7 @@ class Mask(Raster):
         **kwargs: Any,
     ) -> None:
 
-        self._data: MArrayNum | MArrayBool | None = None
+        self._data: MArrayNum | MArrayBool | None = None  # type: ignore
 
         # If a Mask is passed, simply point back to Mask
         if isinstance(filename_or_dataset, Mask):
@@ -3477,7 +3477,7 @@ class Mask(Raster):
 
     def __and__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise and between masks, or a mask and an array."""
-        self_data, other_data = self._overloading_check(other)[0:2]
+        self_data, other_data = self._overloading_check(other)[0:2]  # type: ignore
 
         return self.from_array(
             data=(self_data & other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore
@@ -3491,7 +3491,7 @@ class Mask(Raster):
     def __or__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise or between masks, or a mask and an array."""
 
-        self_data, other_data = self._overloading_check(other)[0:2]
+        self_data, other_data = self._overloading_check(other)[0:2]  # type: ignore
 
         return self.from_array(
             data=(self_data | other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore
@@ -3505,7 +3505,7 @@ class Mask(Raster):
     def __xor__(self: Mask, other: Mask | NDArrayBool) -> Mask:
         """Bitwise xor between masks, or a mask and an array."""
 
-        self_data, other_data = self._overloading_check(other)[0:2]
+        self_data, other_data = self._overloading_check(other)[0:2]  # type: ignore
 
         return self.from_array(
             data=(self_data ^ other_data), transform=self.transform, crs=self.crs, nodata=self.nodata  # type: ignore

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -2,17 +2,42 @@
 
 from __future__ import annotations
 
+from typing import Literal, overload
+
 import numpy as np
 
+from geoutils._typing import MArrayNum, NDArrayNum
 from geoutils.raster.array import get_mask
 
 
+@overload
 def subsample_array(
-    array: np.ndarray | np.ma.masked_array,
+    array: NDArrayNum | MArrayNum,
+    subsample: float | int,
+    return_indices: Literal[False] = False,
+    *,
+    random_state: np.random.RandomState | int | None = None,
+) -> tuple[NDArrayNum, ...]:
+    ...
+
+
+@overload
+def subsample_array(
+    array: NDArrayNum | MArrayNum,
+    subsample: float | int,
+    return_indices: Literal[True],
+    *,
+    random_state: np.random.RandomState | int | None = None,
+) -> NDArrayNum:
+    ...
+
+
+def subsample_array(
+    array: NDArrayNum | MArrayNum,
     subsample: float | int,
     return_indices: bool = False,
-    random_state: np.random.RandomState | np.random.Generator | int | None = None,
-) -> np.ndarray:
+    random_state: np.random.RandomState | int | None = None,
+) -> NDArrayNum | tuple[NDArrayNum, ...]:
     """
     Randomly subsample a 1D or 2D array by a subsampling factor, taking only non NaN/masked values.
 
@@ -26,8 +51,8 @@ def subsample_array(
     """
     # Define state for random subsampling (to fix results during testing)
     if random_state is None:
-        rnd = np.random.default_rng()
-    elif isinstance(random_state, (np.random.RandomState, np.random.Generator)):
+        rnd: np.random.RandomState | np.random.Generator = np.random.default_rng()
+    elif isinstance(random_state, np.random.RandomState):
         rnd = random_state
     else:
         rnd = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(random_state)))
@@ -98,7 +123,7 @@ def _get_closest_rectangle(size: int) -> tuple[int, int]:
     raise NotImplementedError(f"Function criteria not met for rectangle of size: {size}")
 
 
-def subdivide_array(shape: tuple[int, ...], count: int) -> np.ndarray:
+def subdivide_array(shape: tuple[int, ...], count: int) -> NDArrayNum:
     """
     Create indices for subdivison of an array in a number of blocks.
 

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -17,7 +17,7 @@ def subsample_array(
     return_indices: Literal[False] = False,
     *,
     random_state: np.random.RandomState | int | None = None,
-) -> tuple[NDArrayNum, ...]:
+) -> NDArrayNum:
     ...
 
 
@@ -28,7 +28,17 @@ def subsample_array(
     return_indices: Literal[True],
     *,
     random_state: np.random.RandomState | int | None = None,
-) -> NDArrayNum:
+) -> tuple[NDArrayNum, ...]:
+    ...
+
+
+@overload
+def subsample_array(
+    array: NDArrayNum | MArrayNum,
+    subsample: float | int,
+    return_indices: bool = False,
+    random_state: np.random.RandomState | int | None = None,
+) -> NDArrayNum | tuple[NDArrayNum, ...]:
     ...
 
 

--- a/geoutils/raster/satimg.py
+++ b/geoutils/raster/satimg.py
@@ -13,6 +13,7 @@ from typing import Any
 import numpy as np
 import rasterio as rio
 
+from geoutils._typing import NDArrayNum
 from geoutils.raster import Raster, RasterType
 
 lsat_sensor = {"C": "OLI/TIRS", "E": "ETM+", "T": "TM", "M": "MSS", "O": "OLI", "TI": "TIRS"}
@@ -427,7 +428,7 @@ class SatelliteImage(Raster):  # type: ignore
 
         return None
 
-    def copy(self, new_array: np.ndarray | None = None) -> SatelliteImage:
+    def copy(self, new_array: NDArrayNum | None = None) -> SatelliteImage:
         new_satimg = super().copy(new_array=new_array)  # type: ignore
         # all objects here are immutable so no need for a copy method (string and datetime)
         # satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime'] #taken outside of class

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -38,6 +38,7 @@ from scipy.spatial import Voronoi
 from shapely.geometry.polygon import Polygon
 
 import geoutils as gu
+from geoutils._typing import NDArrayBool, NDArrayNum
 from geoutils.misc import copy_doc
 from geoutils.projtools import (
     _get_bounds_projected,
@@ -1092,7 +1093,7 @@ class Vector:
         xres: float | None = None,
         yres: float | None = None,
         bounds: tuple[float, float, float, float] | None = None,
-        buffer: int | float | np.number = 0,
+        buffer: int | float | np.integer[Any] | np.floating[Any] = 0,
         *,
         as_array: Literal[False] = False,
     ) -> gu.Mask:
@@ -1106,10 +1107,10 @@ class Vector:
         xres: float | None = None,
         yres: float | None = None,
         bounds: tuple[float, float, float, float] | None = None,
-        buffer: int | float | np.number = 0,
+        buffer: int | float | np.integer[Any] | np.floating[Any] = 0,
         *,
         as_array: Literal[True],
-    ) -> np.ndarray:
+    ) -> NDArrayNum:
         ...
 
     def create_mask(
@@ -1119,9 +1120,9 @@ class Vector:
         xres: float | None = None,
         yres: float | None = None,
         bounds: tuple[float, float, float, float] | None = None,
-        buffer: int | float | np.number = 0,
+        buffer: int | float | np.integer[Any] | np.floating[Any] = 0,
         as_array: bool = False,
-    ) -> gu.Mask | np.ndarray:
+    ) -> gu.Mask | NDArrayBool:
         """
         Create a mask from the vector features.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = numpy.typing.mypy_plugin

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -130,7 +130,7 @@ class TestProjTools:
         randx = np.random.randint(low=img.bounds.left, high=img.bounds.right, size=(nsample,))
         randy = np.random.randint(low=img.bounds.bottom, high=img.bounds.top, size=(nsample,))
 
-        lat, lon = pt.reproject_to_latlon([randx, randy], img.crs)
+        lat, lon = pt.reproject_to_latlon([list(randx), list(randy)], img.crs)
         x, y = pt.reproject_from_latlon([lat, lon], img.crs)
 
         assert np.all(x == randx)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2085,9 +2085,7 @@ class TestRaster:
             assert rout.data.dtype == dtype
 
     # The multi-band example will not have a colorbar, so not used in tests
-    @pytest.mark.parametrize(
-        "example", [landsat_b4_path, landsat_b4_crop_path, aster_dem_path]
-    )  # type: ignore
+    @pytest.mark.parametrize("example", [landsat_b4_path, landsat_b4_crop_path, aster_dem_path])  # type: ignore
     @pytest.mark.parametrize("figsize", np.arange(2, 20, 2))  # type: ignore
     def test_show_cbar(self, example, figsize) -> None:
         """

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2084,6 +2084,7 @@ class TestRaster:
             assert np.dtype(rout.dtypes[0]) == dtype
             assert rout.data.dtype == dtype
 
+    # The multi-band example will not have a colorbar, so not used in tests
     @pytest.mark.parametrize(
         "example", [landsat_b4_path, landsat_b4_crop_path, aster_dem_path]
     )  # type: ignore

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -423,7 +423,9 @@ class TestRaster:
 
         # Fix the random seed
         np.random.seed(42)
-        arr = np.random.randint(low=val_min, high=val_max, size=(width, height), dtype=randint_dtype).astype(dtype)  # type: ignore
+        arr = np.random.randint(
+            low=val_min, high=val_max, size=(width, height), dtype=randint_dtype  # type: ignore
+        ).astype(dtype)
         mask = np.random.randint(0, 2, size=(width, height), dtype=bool)
 
         # Check that we are actually masking stuff
@@ -3572,7 +3574,7 @@ class TestArrayInterface:
             warnings.filterwarnings("ignore", category=RuntimeWarning)
 
             # Check if our input dtype is possible on this ufunc, if yes check that outputs are identical
-            if com_dtype in [str(np.dtype(t[0])) for t in ufunc.types]:
+            if com_dtype in [str(np.dtype(t[0])) for t in ufunc.types]:  # noqa
                 # For a single output
                 if ufunc.nout == 1:
                     assert np.ma.allequal(ufunc(rst.data), ufunc(rst).data)
@@ -3657,7 +3659,7 @@ class TestArrayInterface:
             warnings.filterwarnings("ignore", category=UserWarning)
 
             # Check if both our input dtypes are possible on this ufunc, if yes check that outputs are identical
-            if com_dtype_tuple in [(np.dtype(t[0]), np.dtype(t[1])) for t in ufunc.types]:
+            if com_dtype_tuple in [(np.dtype(t[0]), np.dtype(t[1])) for t in ufunc.types]:  # noqa
                 # For a single output
                 if ufunc.nout == 1:
                     # There exists a single exception due to negative integers as exponent of integers in "power"

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2085,7 +2085,7 @@ class TestRaster:
             assert rout.data.dtype == dtype
 
     @pytest.mark.parametrize(
-        "example", [landsat_b4_path, landsat_b4_crop_path, landsat_rgb_path, aster_dem_path]
+        "example", [landsat_b4_path, landsat_b4_crop_path, aster_dem_path]
     )  # type: ignore
     @pytest.mark.parametrize("figsize", np.arange(2, 20, 2))  # type: ignore
     def test_show_cbar(self, example, figsize) -> None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -20,6 +20,7 @@ from pylint import epylint
 import geoutils as gu
 import geoutils.projtools as pt
 from geoutils import examples
+from geoutils._typing import MArrayNum, NDArrayNum
 from geoutils.misc import resampling_method_from_str
 from geoutils.projtools import reproject_to_latlon
 from geoutils.raster.raster import _default_nodata, _default_rio_attrs
@@ -29,7 +30,7 @@ DO_PLOT = False
 
 def run_gdal_proximity(
     input_raster: gu.Raster, target_values: list[float] | None, distunits: str = "GEO"
-) -> np.ndarray:
+) -> NDArrayNum:
     """Run GDAL's ComputeProximity and return the read numpy array."""
     # Rasterio strongly recommends against importing gdal along rio, so this is done here instead.
     from osgeo import gdal, gdalconst
@@ -412,8 +413,8 @@ class TestRaster:
 
         # Create random values between the lower and upper limit of the data type, max absolute 99999 for floats
         if "int" in dtype:
-            val_min = np.iinfo(int_type=dtype).min
-            val_max = np.iinfo(int_type=dtype).max
+            val_min: int = np.iinfo(int_type=dtype).min  # type: ignore
+            val_max: int = np.iinfo(int_type=dtype).max  # type: ignore
             randint_dtype = dtype
         else:
             val_min = -99999
@@ -422,7 +423,7 @@ class TestRaster:
 
         # Fix the random seed
         np.random.seed(42)
-        arr = np.random.randint(low=val_min, high=val_max, size=(width, height), dtype=randint_dtype).astype(dtype)
+        arr = np.random.randint(low=val_min, high=val_max, size=(width, height), dtype=randint_dtype).astype(dtype)  # type: ignore
         mask = np.random.randint(0, 2, size=(width, height), dtype=bool)
 
         # Check that we are actually masking stuff
@@ -1651,7 +1652,7 @@ class TestRaster:
         assert img[int(i), int(j)] == val
 
         # Finally, check that interp convert to latlon
-        lat, lon = gu.projtools.reproject_to_latlon((x, y), in_crs=r.crs)
+        lat, lon = gu.projtools.reproject_to_latlon([[x], [y]], in_crs=r.crs)
         val_latlon = r.interp_points([(lat, lon)], order=1, input_latlon=True)[0]
         assert val == pytest.approx(val_latlon, abs=0.0001)
 
@@ -1694,7 +1695,7 @@ class TestRaster:
         # -- Tests 2: check arguments work as intended --
 
         # 1/ Lat-lon argument check by getting the coordinates of our last test point
-        lat, lon = reproject_to_latlon(pts=[xtest0, ytest0], in_crs=r.crs)
+        lat, lon = reproject_to_latlon(pts=[[xtest0], [ytest0]], in_crs=r.crs)
         z_val_2 = r.value_at_coords(lon, lat, latlon=True)
         assert z_val == z_val_2
 
@@ -2015,13 +2016,13 @@ class TestRaster:
 
         # Check it works with most frequent np.dtypes too
         assert _default_nodata(np.dtype("uint8")) == np.iinfo("uint8").max
-        for dtype in [np.dtype("int32"), np.dtype("float32"), np.dtype("float64")]:
-            assert _default_nodata(dtype) == -99999
+        for dtype_obj in [np.dtype("int32"), np.dtype("float32"), np.dtype("float64")]:
+            assert _default_nodata(dtype_obj) == -99999  # type: ignore
 
         # Check it works with most frequent types too
         assert _default_nodata(np.uint8) == np.iinfo("uint8").max
-        for dtype in [np.int32, np.float32, np.float64]:
-            assert _default_nodata(dtype) == -99999
+        for dtype_obj in [np.int32, np.float32, np.float64]:
+            assert _default_nodata(dtype_obj) == -99999
 
         # Check that an error is raised for other types
         expected_message = "No default nodata value set for dtype."
@@ -3192,7 +3193,7 @@ class TestArithmetic:
     @classmethod
     def from_array(
         cls: type[TestArithmetic],
-        data: np.ndarray | np.ma.masked_array,
+        data: NDArrayNum | MArrayNum,
         rst_ref: gu.RasterType,
         nodata: int | float | list[int] | list[float] | None = None,
     ) -> gu.Raster:
@@ -3571,7 +3572,7 @@ class TestArrayInterface:
             warnings.filterwarnings("ignore", category=RuntimeWarning)
 
             # Check if our input dtype is possible on this ufunc, if yes check that outputs are identical
-            if com_dtype in (str(np.dtype(t[0])) for t in ufunc.types):
+            if com_dtype in [str(np.dtype(t[0])) for t in ufunc.types]:
                 # For a single output
                 if ufunc.nout == 1:
                     assert np.ma.allequal(ufunc(rst.data), ufunc(rst).data)
@@ -3656,7 +3657,7 @@ class TestArrayInterface:
             warnings.filterwarnings("ignore", category=UserWarning)
 
             # Check if both our input dtypes are possible on this ufunc, if yes check that outputs are identical
-            if com_dtype_tuple in ((str(np.dtype(t[0])), str(np.dtype(t[1]))) for t in ufunc.types):
+            if com_dtype_tuple in [(np.dtype(t[0]), np.dtype(t[1])) for t in ufunc.types]:
                 # For a single output
                 if ufunc.nout == 1:
                     # There exists a single exception due to negative integers as exponent of integers in "power"

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import geoutils as gu
+from geoutils._typing import NDArrayNum
 
 
 class TestSubsampling:
@@ -33,7 +34,7 @@ class TestSubsampling:
     assert np.count_nonzero(array3D.mask) > 0
 
     @pytest.mark.parametrize("array", [array1D, array2D, array3D])  # type: ignore
-    def test_subsample(self, array: np.ndarray) -> None:
+    def test_subsample(self, array: NDArrayNum) -> None:
         """
         Test gu.raster.subsample_array.
         """


### PR DESCRIPTION
This PR adds the NumPy plugin for `mypy` type checking.

NumPy arrays now have to be statically typed with certain dtypes and shapes (https://numpy.org/devdocs/reference/typing.html).
To keep it simple, I ignored the shape and only defined types (like was done in xDEM, still raised more than 100 errors on `mypy`) and introduced the following types for GeoUtils:
- `NDArrayNum` is a numerical ND array, i.e. with floating or integer type,
- `NDArrayBool` is a boolean ND array,
- `MArrayNum` is a masked numerical ND array,
- `MArrayBool` is a masked boolean ND array.

We can change those names if they don't feel like the best, it's easy as it's just a refactor. Eventually, we could even add the shape to have even more robust type-check in all functions (both here and in xDEM).

**Note: using an IDE, you don't see those names in function definition but only the corresponding detailed NumPy types, for examples `np.ndarray[Any, np.floating[Any]]`; hopefully it'll be the same in the documentation, so the names don't matter that much except for developers!**

Everything is defined in a way to be backwards-compatible during package import. I also redefined the `Number` type (Python `float` or `int` or NumPy `floating` or `integer`) to facilitate the typing in functions.

Resolves #291
Resolves #319

Some `mypy` issues were unsolvable without a major class change between `Raster` and `Mask`: temporarily ignored them and opened #387.