### PR TITLE
Update setup.py requirements to geopandas >= 0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "rasterio",
-        "geopandas >= 0.10.0",
+        "geopandas >= 0.12.0",
         "pyproj",
         "scipy",
         "typing-extensions; python_version < '3.8'",


### PR DESCRIPTION
The minimum geopandas version was recently updated to 0.12.0. As mentioned in my comment in  #373, however, this was not written in the setup.py (meaning pip installs didn't work properly) nor in the conda-forge feedstock. This fixes the `setup.py` part, and I'll open a PR in the feedstock.