### PR TITLE
Backward-compatiblity with Shapely < 2.0

### DIFF
--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -35,8 +35,8 @@ from pandas._typing import WriteBuffer
 from rasterio import features, warp
 from rasterio.crs import CRS
 from scipy.spatial import Voronoi
-from shapely.geometry.polygon import Polygon
 from shapely.geometry.base import BaseGeometry
+from shapely.geometry.polygon import Polygon
 
 import geoutils as gu
 from geoutils._typing import NDArrayBool, NDArrayNum

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -36,6 +36,7 @@ from rasterio import features, warp
 from rasterio.crs import CRS
 from scipy.spatial import Voronoi
 from shapely.geometry.polygon import Polygon
+from shapely.geometry.base import BaseGeometry
 
 import geoutils as gu
 from geoutils._typing import NDArrayBool, NDArrayNum
@@ -67,7 +68,7 @@ class Vector:
     See the API for more details.
     """
 
-    def __init__(self, filename_or_dataset: str | pathlib.Path | gpd.GeoDataFrame | gpd.GeoSeries | shapely.Geometry):
+    def __init__(self, filename_or_dataset: str | pathlib.Path | gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry):
         """
         Instantiate a vector from either a filename, a GeoPandas dataframe or series, or a Shapely geometry.
 
@@ -83,7 +84,7 @@ class Vector:
             self._ds = ds
             self._name: str | gpd.GeoDataFrame | None = filename_or_dataset
         # If GeoPandas or Shapely object is passed
-        elif isinstance(filename_or_dataset, (gpd.GeoDataFrame, gpd.GeoSeries, shapely.Geometry)):
+        elif isinstance(filename_or_dataset, (gpd.GeoDataFrame, gpd.GeoSeries, BaseGeometry)):
             self._name = None
             if isinstance(filename_or_dataset, gpd.GeoDataFrame):
                 self._ds = filename_or_dataset
@@ -300,12 +301,12 @@ class Vector:
     ############################################################################
 
     def _override_gdf_output(
-        self, other: gpd.GeoDataFrame | gpd.GeoSeries | shapely.Geometry | pd.Series | Any
+        self, other: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | pd.Series | Any
     ) -> Vector | pd.Series:
         """Parse outputs of GeoPandas functions to facilitate object manipulation."""
 
         # Raise error if output is not treated separately, should appear in tests
-        if not isinstance(other, (gpd.GeoDataFrame, gpd.GeoDataFrame, pd.Series, shapely.Geometry)):
+        if not isinstance(other, (gpd.GeoDataFrame, gpd.GeoDataFrame, pd.Series, BaseGeometry)):
             raise ValueError("Not implemented. This error should only be raised in tests.")
 
         # If a GeoDataFrame is the output, return it
@@ -315,7 +316,7 @@ class Vector:
         elif isinstance(other, gpd.GeoSeries):
             return Vector(gpd.GeoDataFrame(geometry=other))
         # If a Shapely Geometry is the output, re-encapsulate in a GeoDataFrame and return it
-        elif isinstance(other, shapely.Geometry):
+        elif isinstance(other, BaseGeometry):
             return Vector(gpd.GeoDataFrame({"geometry": [other]}, crs=self.crs))
         # If a Pandas Series is the output, append it to that of the GeoDataFrame
         else:

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -21,6 +21,7 @@ from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.polygon import Polygon
+from shapely.geometry.base import BaseGeometry
 
 import geoutils as gu
 
@@ -787,13 +788,13 @@ class TestGeoPandasMethods:
 
         # Assert output types
         assert isinstance(output_geoutils, gu.Vector)
-        assert isinstance(output_geopandas, (gpd.GeoSeries, gpd.GeoDataFrame, shapely.Geometry))
+        assert isinstance(output_geopandas, (gpd.GeoSeries, gpd.GeoDataFrame, BaseGeometry))
 
         # Separate cases depending on GeoPandas' output
         if isinstance(output_geopandas, gpd.GeoSeries):
             # Assert geoseries equality
             assert_geoseries_equal(output_geoutils.ds.geometry, output_geopandas)
-        elif isinstance(output_geopandas, shapely.Geometry):
+        elif isinstance(output_geopandas, BaseGeometry):
             assert_geodataframe_equal(
                 output_geoutils.ds, gpd.GeoDataFrame({"geometry": [output_geopandas]}, crs=vector.crs)
             )

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -13,15 +13,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyproj
 import pytest
-import shapely
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from pandas.testing import assert_series_equal
 from scipy.ndimage import binary_erosion
+from shapely.geometry.base import BaseGeometry
 from shapely.geometry.linestring import LineString
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.polygon import Polygon
-from shapely.geometry.base import BaseGeometry
 
 import geoutils as gu
 


### PR DESCRIPTION
Before the major refactoring of Shapely a year ago, `shapely.Geometry` did not exist. But we've been using for (static and dynamic) type checking in functions during the past year. It all passed in CI, as older versions of Shapely were never used.

As it's just about editing 4/5 types, I think we modify them all to the old `shapely.geometry.base.BaseGeometry` syntax so that we can be backwards-compatible for a bit longer! :slightly_smiling_face: 

Resolves #391 