### PR TITLE
Declare `geoutils.raster` sub-package explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ xdem =
 [options.packages.find]
 include =
     geoutils
-    raster
+    geoutils.raster
 
 [options.extras_require]
 opt =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ python_requires = >=3.8
 install_requires = file: requirements.txt
 
 [options.package_data]
-xdem =
+geoutils =
     py.typed
 
 [options.packages.find]


### PR DESCRIPTION
Trying to fix the `conda-forge` build, getting the same issue as here: https://github.com/GlacioHack/xdem/issues/394

Likely triggered by the changes in #398 