### PR TITLE
Add support for Python `3.11` and remove `3.8`

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     defaults:
       run:
@@ -48,7 +48,7 @@ jobs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ env.cache_date }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
       env:
-        CACHE_NUMBER: 102 # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
       id: cache
 
     # The trick below is necessary because the generic environment file does not specify a Python version, and only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ For more details, see the rest of this document.
 
 ## Development environment
 
-GeoUtils currently supports only Python versions of 3.8 and higher, see `environment.yml` for detailed dependencies.
+GeoUtils currently supports only Python versions of 3.9 and higher, see `environment.yml` for detailed dependencies.
 
 ### Setup
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -2,7 +2,7 @@ name: geoutils-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - geopandas>=0.12.0
   - matplotlib
   - pyproj

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: geoutils
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - geopandas>=0.12.0
   - matplotlib
   - pyproj

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,9 @@ classifiers =
     Topic :: Scientific/Engineering :: Image Processing
     Topic :: Scientific/Engineering :: Information Analysis
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3
     Topic :: Software Development :: Libraries :: Python Modules
     Typing :: Typed
@@ -34,7 +34,7 @@ packages = find:
 scripts = bin/geoviewer.py
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 # Avoid pinning dependencies in requirements.txt (which we don't do anyways, and we rely mostly on Conda)
 # (https://caremad.io/posts/2013/07/setup-vs-requirement/, https://github.com/pypa/setuptools/issues/1951)
 install_requires = file: requirements.txt

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -8,6 +8,7 @@ import pathlib
 import re
 import tempfile
 import warnings
+from io import StringIO
 from tempfile import TemporaryFile
 
 import matplotlib.pyplot as plt
@@ -16,7 +17,6 @@ import pytest
 import rasterio as rio
 import xarray as xr
 from pylint.lint import Run
-from io import StringIO
 from pylint.reporters.text import TextReporter
 
 import geoutils as gu
@@ -2332,7 +2332,7 @@ class TestRaster:
 
         # Run pylint and parse the stdout as a string, only test
         pylint_output = StringIO()
-        Run([temp_path], do_exit=False)
+        Run([temp_path], reporter=TextReporter(pylint_output), do_exit=False)
 
         lint_string = pylint_output.getvalue()
         print(lint_string)  # Print the output for debug purposes

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -15,7 +15,9 @@ import numpy as np
 import pytest
 import rasterio as rio
 import xarray as xr
-from pylint import epylint
+from pylint.lint import Run
+from io import StringIO
+from pylint.reporters.text import TextReporter
 
 import geoutils as gu
 import geoutils.projtools as pt
@@ -2316,7 +2318,7 @@ class TestRaster:
             [
                 "'''Sample code that should conform to pylint's standards.'''",  # Add docstring
                 "import geoutils as gu",  # Import geoutils
-                "raster = gu.Raster(gu.datasets.get_path('landsat_B4'))",  # Load a raster
+                "raster = gu.Raster(gu.examples.get_path('landsat_B4'))",  # Load a raster
             ]
             + [  # The below statements should not raise a 'no-member' (E1101) error.
                 f"{attribute.upper()} = raster.{attribute}" for attribute in attributes
@@ -2328,9 +2330,11 @@ class TestRaster:
         with open(temp_path, "w") as outfile:
             outfile.write(sample_code)
 
-        # Run pylint and parse the stdout as a string
-        lint_string = epylint.py_run(temp_path, return_std=True)[0].getvalue()
+        # Run pylint and parse the stdout as a string, only test
+        pylint_output = StringIO()
+        Run([temp_path], do_exit=False)
 
+        lint_string = pylint_output.getvalue()
         print(lint_string)  # Print the output for debug purposes
 
         # Bad linting errors are defined here. Currently just "no-member" errors

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2332,7 +2332,7 @@ class TestRaster:
 
         # Run pylint and parse the stdout as a string, only test
         pylint_output = StringIO()
-        Run([temp_path], reporter=TextReporter(pylint_output), do_exit=False)
+        Run([temp_path], reporter=TextReporter(pylint_output), exit=False)
 
         lint_string = pylint_output.getvalue()
         print(lint_string)  # Print the output for debug purposes


### PR DESCRIPTION
It's been a year since Python 3.11 is out, we can now safely add support for it (most of us probably already work on it in our local environments, as we didn't pin an upper limit on Python version in env files).