### PR TITLE
 Fix documentation rendering due to Pydata theme update

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -29,7 +29,8 @@ dependencies:
 
   # Doc dependencies
   - sphinx
-  - sphinx-book-theme
+  - pydata-sphinx-theme==0.13.3
+  - sphinx-book-theme>=1.0
   - sphinx-gallery
   - sphinx-design
   - sphinx-autodoc-typehints


### PR DESCRIPTION
Mirrors https://github.com/GlacioHack/xdem/pull/451
Also updates action version numbers for `pre-commit` (failing during CI otherwise), as done in https://github.com/GlacioHack/xdem/pull/411)

Fixes the wrong rendering of the documentation since the pydate-sphinx-theme 0.14 by forcing 0.13 (see issue https://github.com/executablebooks/sphinx-book-theme/issues/761).

We should be able to update soon, sphinx-book-theme is catching up with a pre-release: https://github.com/executablebooks/sphinx-book-theme/releases.
Opened https://github.com/GlacioHack/xdem/issues/452
