### PR TITLE
Fix `test_deprecate` to work with `setuptools_scm` versions

### DIFF
--- a/geoutils/misc.py
+++ b/geoutils/misc.py
@@ -19,7 +19,7 @@ from packaging.version import Version
 import geoutils
 
 
-def deprecate(removal_version: str | None = None, details: str | None = None):  # type: ignore
+def deprecate(removal_version: Version | None = None, details: str | None = None):  # type: ignore
     """
     Trigger a DeprecationWarning for the decorated function.
 
@@ -38,8 +38,12 @@ def deprecate(removal_version: str | None = None, details: str | None = None):  
     def deprecator_func(func):  # type: ignore
         @functools.wraps(func)
         def new_func(*args, **kwargs):  # type: ignore
+
+            # Get current base version (without dev changes)
+            current_version = Version(Version(geoutils.__version__).base_version)
+
             # True if it should warn, False if it should raise an error
-            should_warn = removal_version is None or Version(removal_version) > Version(geoutils.__version__)
+            should_warn = removal_version is None or removal_version > current_version
 
             # Add text depending on the given arguments and 'should_warn'.
             text = (

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -61,10 +61,11 @@ class TestMisc:
         current_version = geoutils.__version__
 
         # Set the removal version to be the current version plus the increment (e.g. 0.0.5 + 1 -> 0.0.6)
+        # Splitting code rc in case it is a pre-release
         removal_version = (
-            current_version.rsplit(".", 2)[0]
+            ".".join(current_version.split(".")[0:2])
             + "."
-            + str(int(current_version.rsplit(".", 2)[1]) + deprecation_increment)
+            + str(int(current_version.split(".")[2].split("rc")[0]) + deprecation_increment)
             if deprecation_increment is not None
             else None
         )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import re
 import warnings
-from copy import copy
 
 import pytest
 import yaml  # type: ignore
@@ -68,7 +67,11 @@ class TestMisc:
                 removal_version_tuple = (current_version.major, current_version.minor + deprecation_increment, 0)
             # Otherwise, increment micro version
             else:
-                removal_version_tuple = (current_version.major, current_version.minor, current_version.micro + deprecation_increment)
+                removal_version_tuple = (
+                    current_version.major,
+                    current_version.minor,
+                    current_version.micro + deprecation_increment,
+                )
 
             # Convert to version
             removal_version = Version(".".join([str(v) for v in removal_version_tuple]))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import warnings
+from copy import copy
 
 import pytest
 import yaml  # type: ignore
@@ -58,17 +59,21 @@ class TestMisc:
         """
         warnings.simplefilter("error")
 
-        current_version = geoutils.__version__
+        current_version = Version(Version(geoutils.__version__).base_version)
 
         # Set the removal version to be the current version plus the increment (e.g. 0.0.5 + 1 -> 0.0.6)
-        # Splitting code rc in case it is a pre-release
-        removal_version = (
-            ".".join(current_version.split(".")[0:2])
-            + "."
-            + str(int(current_version.split(".")[2].split("rc")[0]) + deprecation_increment)
-            if deprecation_increment is not None
-            else None
-        )
+        if deprecation_increment is not None:
+            # If the micro version is already 0 and it is a decrement, decrement minor version instead
+            if current_version.micro == 0 and deprecation_increment == -1:
+                removal_version_tuple = (current_version.major, current_version.minor + deprecation_increment, 0)
+            # Otherwise, increment micro version
+            else:
+                removal_version_tuple = (current_version.major, current_version.minor, current_version.micro + deprecation_increment)
+
+            # Convert to version
+            removal_version = Version(".".join([str(v) for v in removal_version_tuple]))
+        else:
+            removal_version = None
 
         # Define a function with no use that is marked as deprecated.
         @geoutils.misc.deprecate(removal_version, details=details)  # type: ignore
@@ -80,7 +85,7 @@ class TestMisc:
         assert Version("0.0.10") > Version("0.0.8")
 
         # If True, a warning is expected. If False, a ValueError is expected.
-        should_warn = removal_version is None or Version(removal_version) > Version(current_version)
+        should_warn = removal_version is None or removal_version > current_version
 
         # Add the expected text depending on the parametrization.
         text = (


### PR DESCRIPTION
See more details on the issue here: https://github.com/GlacioHack/geoutils/issues/427#issuecomment-1886997583

Was failing locally but not in CI because of link between `git` and `setuptools_scm` for versioning. Now using `Version` objects to have things consistent everywhere! (easy to change our deprecated mechanism in the future if we want to, by extracting a different major/minor/micro version from the Version object :smile:)

Tested locally with:
- Classic local version due to commits: ```__version__ = version = '0.0.18.dev4+g90460bf'```
- Pre-release versions that are more tricky due to `rc` suffix attached to last version number: ```__version__ = version = '0.0.17rc2.dev1+gef706f8'```

Both passing!

Resolves #427 
