### PR TITLE
Attempt to fix issue with doc building on Mac/Windows

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -29,7 +29,7 @@ dependencies:
 
   # Doc dependencies
   - sphinx
-  - pydata-sphinx-theme==0.13.3
+  - pydata-sphinx-theme
   - sphinx-book-theme>=1.0
   - sphinx-gallery
   - sphinx-design

--- a/examples/analysis/point_extraction/reduction.py
+++ b/examples/analysis/point_extraction/reduction.py
@@ -52,7 +52,7 @@ np.nanmean(vals - vals_reduced)
 coords = rast.coords(grid=True)
 x_closest = rast.copy(new_array=coords[0]).value_at_coords(x=x_coords, y=y_coords).squeeze()
 y_closest = rast.copy(new_array=coords[1]).value_at_coords(x=x_coords, y=y_coords).squeeze()
-from shapely import box
+from shapely.geometry import box
 
 geometry = [
     box(x - 2 * rast.res[0], y - 2 * rast.res[1], x + 2 * rast.res[0], y + 2 * rast.res[1])

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -13,20 +13,16 @@ class TestDocs:
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""
         # Remove the build directory if it exists.
+        if os.path.isdir(os.path.join(self.docs_dir, "build/")):
+            shutil.rmtree(os.path.join(self.docs_dir, "build/"))
 
-        # Test only on Linux
-        if platform.system() == "Linux":
-            # Remove the build directory if it exists.
-            if os.path.isdir(os.path.join(self.docs_dir, "build/")):
-                shutil.rmtree(os.path.join(self.docs_dir, "build/"))
+        return_code = sphinx.cmd.build.main(
+            [
+                "-j",
+                "1",
+                os.path.join(self.docs_dir, "source/"),
+                os.path.join(self.docs_dir, "build/"),
+            ]
+        )
 
-            return_code = sphinx.cmd.build.main(
-                [
-                    "-j",
-                    "1",
-                    os.path.join(self.docs_dir, "source/"),
-                    os.path.join(self.docs_dir, "build/"),
-                ]
-            )
-
-            assert return_code == 0
+        assert return_code == 0

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,6 +1,5 @@
 """Functions to test the documentation."""
 import os
-import platform
 import shutil
 
 import sphinx.cmd.build

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,5 +1,6 @@
 """Functions to test the documentation."""
 import os
+import platform
 import shutil
 
 import sphinx.cmd.build
@@ -11,17 +12,21 @@ class TestDocs:
 
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""
-        # Remove the build directory if it exists.
-        if os.path.isdir(os.path.join(self.docs_dir, "build/")):
-            shutil.rmtree(os.path.join(self.docs_dir, "build/"))
 
-        return_code = sphinx.cmd.build.main(
-            [
-                "-j",
-                "1",
-                os.path.join(self.docs_dir, "source/"),
-                os.path.join(self.docs_dir, "build/"),
-            ]
-        )
+        # Building the doc fails on Windows for the CLI section
+        if (platform.system() == "Linux") or (platform.system() == "Darwin"):
 
-        assert return_code == 0
+            # Remove the build directory if it exists.
+            if os.path.isdir(os.path.join(self.docs_dir, "build/")):
+                shutil.rmtree(os.path.join(self.docs_dir, "build/"))
+
+            return_code = sphinx.cmd.build.main(
+                [
+                    "-j",
+                    "1",
+                    os.path.join(self.docs_dir, "source/"),
+                    os.path.join(self.docs_dir, "build/"),
+                ]
+            )
+
+            assert return_code == 0


### PR DESCRIPTION
Attempts to fix an issue only referenced on xdem: https://github.com/GlacioHack/xdem/issues/316.

- Fix an issue of shapely backward compatibility in one of the examples 
- Re-enable `test_doc.py` for Mac -> The test now passes ! 🥳 (I'm not sure if it's related to my change or it was fixed earlier). 
- Remove the fixed version for pydata-sphinx-theme which was causing a bug with the logo (see #351)
- Doc was also building on Windows, until the new CLI doc section (#418)

Raised issue #442 for the Windows problem.
