### PR TITLE
Change default behaviour of crop to inplace=False

### DIFF
--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -85,7 +85,7 @@ For convenience and consistency, nearly all of these methods can be passed solel
 # Print initial bounds of the raster
 print(rast.bounds)
 # Crop raster to vector's extent
-rast.crop(vect)
+rast = rast.crop(vect)
 # Print bounds of cropped raster
 print(rast.bounds)
 ```

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -253,12 +253,12 @@ See {ref}`core-match-ref` for more details.
 ```
 
 The {func}`~geoutils.Raster.crop` function can also be passed a {class}`list` or {class}`tuple` of bounds (`xmin`, `ymin`, `xmax`, `ymax`). By default,
-{func}`~geoutils.Raster.crop` is done in-place.
+{func}`~geoutils.Raster.crop` returns a new Raster.
 For more details, see the {ref}`specific section and function descriptions in the API<api-geo-handle>`.
 
 ```{code-cell} ipython3
 # Crop raster to smaller bounds
-rast_crop = rast.crop(crop_geom=(0.3, 0.3, 1, 1), inplace=False)
+rast_crop = rast.crop(crop_geom=(0.3, 0.3, 1, 1))
 print(rast_crop.bounds)
 ```
 

--- a/doc/source/vector_class.md
+++ b/doc/source/vector_class.md
@@ -165,12 +165,12 @@ See {ref}`core-match-ref` for more details.
 
 The {func}`~geoutils.Vector.crop` function can also be passed a {class}`list` or {class}`tuple` of bounds (`xmin`, `ymin`, `xmax`, `ymax`).
 
-By default, {func}`~geoutils.Vector.crop` is done in-place and keeps all intersecting geometries. It can also be passed the `clip` argument to clip
+By default, {func}`~geoutils.Vector.crop` returns a new {class}`~geoutils.Vector` which keeps all intersecting geometries. It can also be passed the `clip` argument to clip
 intersecting geometries to the extent.
 
 ```{code-cell} ipython3
 # Crop vector to smaller bounds
-vect_crop = vect.crop(crop_geom=(-73.5, -46.6, -73.4, -46.5), inplace=False, clip=True)
+vect_crop = vect.crop(crop_geom=(-73.5, -46.6, -73.4, -46.5), clip=True)
 print(vect_crop.info())
 ```
 

--- a/examples/handling/georeferencing/crop_raster.py
+++ b/examples/handling/georeferencing/crop_raster.py
@@ -30,7 +30,7 @@ vect.show(ref_crs=rast, fc="none", ec="k", lw=2)
 # **First option:** using the vector as a reference to match, we reproject the raster. We simply have to pass the :class:`~geoutils.Vector`
 # as single argument to :func:`~geoutils.Raster.crop`. See :ref:`core-match-ref` for more details.
 
-rast.crop(vect)
+rast.crop(vect, inplace=True)
 
 # %%
 # Now the bounds should be the same as that of the vector (within the size of a pixel as the grid was not warped).
@@ -46,7 +46,7 @@ vect.show(ref_crs=rast, fc="none", ec="k", lw=2)
 # **Second option:** we can pass other ``crop_geom`` argument to :func:`~geoutils.Raster.crop`, including another :class:`~geoutils.Raster` or a
 # simple :class:`tuple` of bounds. For instance, we can re-crop the raster to be smaller than the vector.
 
-rast.crop((rast.bounds.left + 1000, rast.bounds.bottom, rast.bounds.right, rast.bounds.top - 500))
+rast.crop((rast.bounds.left + 1000, rast.bounds.bottom, rast.bounds.right, rast.bounds.top - 500), inplace=True)
 
 rast.show(ax="new", cmap="Purples")
 vect.show(ref_crs=rast, fc="none", ec="k", lw=2)

--- a/examples/handling/georeferencing/crop_vector.py
+++ b/examples/handling/georeferencing/crop_vector.py
@@ -24,7 +24,7 @@ vect.show(ref_crs=rast, fc="none", ec="tab:purple", lw=3)
 # **First option:** using the raster as a reference to match, we crop the vector. We simply have to pass the :class:`~geoutils.Raster` as single argument to
 # :func:`~geoutils.Vector.crop`. See :ref:`core-match-ref` for more details.
 
-vect.crop(rast)
+vect.crop(rast, inplace=True)
 
 # %%
 # .. note::
@@ -47,7 +47,9 @@ vect.show(ref_crs=rast, fc="none", ec="tab:purple", lw=3)
 # simple :class:`tuple` of bounds.
 
 bounds = rast.get_bounds_projected(out_crs=vect.crs)
-vect.crop(crop_geom=(bounds.left + 0.5 * (bounds.right - bounds.left), bounds.bottom, bounds.right, bounds.top))
+vect.crop(
+    crop_geom=(bounds.left + 0.5 * (bounds.right - bounds.left), bounds.bottom, bounds.right, bounds.top), inplace=True
+)
 
 rast.show(ax="new", cmap="Greys_r", alpha=0.7)
 vect.show(ref_crs=rast, fc="none", ec="tab:purple", lw=3)

--- a/geoutils/projtools.py
+++ b/geoutils/projtools.py
@@ -59,6 +59,9 @@ def utm_to_epsg(utm: str) -> int:
     :return: EPSG of UTM zone.
     """
 
+    if not isinstance(utm, str):
+        raise TypeError("UTM zone must be a str.")
+
     # Whether UTM is passed as single or double digits, homogenize to single-digit
     utm = str(int(utm[:-1])) + utm[-1].upper()
 

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -77,7 +77,7 @@ def load_multiple_rasters(
             )
             # Ensure bounds align with the original ones, to avoid resampling at this stage
             new_bounds = gu.projtools.align_bounds(rst.transform, new_bounds)
-            rst.crop(new_bounds, mode="match_pixel")
+            rst = rst.crop(new_bounds, mode="match_pixel")
 
     # Optionally, reproject all rasters to the reference grid
     if reproject:

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -77,7 +77,7 @@ def load_multiple_rasters(
             )
             # Ensure bounds align with the original ones, to avoid resampling at this stage
             new_bounds = gu.projtools.align_bounds(rst.transform, new_bounds)
-            rst = rst.crop(new_bounds, mode="match_pixel")
+            rst.crop(new_bounds, mode="match_pixel", inplace=True)
 
     # Optionally, reproject all rasters to the reference grid
     if reproject:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1800,6 +1800,18 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
     # Note the star is needed because of the default argument 'mode' preceding non default arg 'inplace'
     # Then the final overload must be duplicated
+    # Also note that in the first overload, only "inplace: Literal[False]" does not work. The ellipsis is
+    # essential, otherwise MyPy gives incompatible return type Optional[Raster].
+    @overload
+    def crop(
+        self: RasterType,
+        crop_geom: RasterType | Vector | list[float] | tuple[float, ...],
+        mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
+        *,
+        inplace: Literal[False] = ...,
+    ) -> RasterType:
+        ...
+
     @overload
     def crop(
         self: RasterType,
@@ -1807,7 +1819,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
         *,
         inplace: Literal[True],
-    ) -> RasterType:
+    ) -> None:
         ...
 
     @overload
@@ -1816,25 +1828,17 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         crop_geom: RasterType | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
         *,
-        inplace: Literal[False],
-    ) -> RasterType:
-        ...
-
-    @overload
-    def crop(
-        self: RasterType,
-        crop_geom: RasterType | Vector | list[float] | tuple[float, ...],
-        mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
-        inplace: bool = False,
-    ) -> RasterType:
+        inplace: bool = ...,
+    ) -> RasterType | None:
         ...
 
     def crop(
         self: RasterType,
         crop_geom: RasterType | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
+        *,
         inplace: bool = False,
-    ) -> RasterType:
+    ) -> RasterType | None:
         """
         Crop the raster to a given extent.
 
@@ -3398,7 +3402,7 @@ class Mask(Raster):
         crop_geom: Mask | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
         *,
-        inplace: Literal[True],
+        inplace: Literal[False] = ...,
     ) -> Mask:
         ...
 
@@ -3408,8 +3412,8 @@ class Mask(Raster):
         crop_geom: Mask | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
         *,
-        inplace: Literal[False],
-    ) -> Mask:
+        inplace: Literal[True],
+    ) -> None:
         ...
 
     @overload
@@ -3417,16 +3421,18 @@ class Mask(Raster):
         self: Mask,
         crop_geom: Mask | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
-        inplace: bool = True,
-    ) -> Mask:
+        *,
+        inplace: bool = ...,
+    ) -> Mask | None:
         ...
 
     def crop(
         self: Mask,
         crop_geom: Mask | Vector | list[float] | tuple[float, ...],
         mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
+        *,
         inplace: bool = False,
-    ) -> Mask:
+    ) -> Mask | None:
         # If there is resampling involved during cropping, encapsulate type as in reproject()
         if mode == "match_extent":
             raise ValueError(NotImplementedError)

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -732,7 +732,7 @@ class Vector:
         """
 
         if isinstance(key, (gu.Raster, Vector)):
-            return self.crop(crop_geom=key, clip=False, inplace=False)
+            return self.crop(crop_geom=key, clip=False)
         else:
             return self._override_gdf_output(self.ds.__getitem__(key))
 
@@ -971,6 +971,16 @@ class Vector:
         crop_geom: gu.Raster | Vector | list[float] | tuple[float, ...],
         clip: bool,
         *,
+        inplace: Literal[False] = ...,
+    ) -> VectorType:
+        ...
+
+    @overload
+    def crop(
+        self: VectorType,
+        crop_geom: gu.Raster | Vector | list[float] | tuple[float, ...],
+        clip: bool,
+        *,
         inplace: Literal[True],
     ) -> None:
         ...
@@ -981,17 +991,7 @@ class Vector:
         crop_geom: gu.Raster | Vector | list[float] | tuple[float, ...],
         clip: bool,
         *,
-        inplace: Literal[False],
-    ) -> VectorType:
-        ...
-
-    @overload
-    def crop(
-        self: VectorType,
-        crop_geom: gu.Raster | Vector | list[float] | tuple[float, ...],
-        clip: bool,
-        *,
-        inplace: bool = True,
+        inplace: bool = ...,
     ) -> VectorType | None:
         ...
 
@@ -999,7 +999,8 @@ class Vector:
         self: VectorType,
         crop_geom: gu.Raster | Vector | list[float] | tuple[float, ...],
         clip: bool = False,
-        inplace: bool = True,
+        *,
+        inplace: bool = False,
     ) -> VectorType | None:
         """
         Crop the vector to given extent.

--- a/tests/test_multiraster.py
+++ b/tests/test_multiraster.py
@@ -38,13 +38,15 @@ class stack_merge_images:
         self.img1.crop(
             rio.coords.BoundingBox(
                 right=x_midpoint + img.res[0] * 3, left=img.bounds.left, top=img.bounds.top, bottom=img.bounds.bottom
-            )
+            ),
+            inplace=True,
         )
         self.img2 = img.copy()
         self.img2.crop(
             rio.coords.BoundingBox(
                 left=x_midpoint - img.res[0] * 3, right=img.bounds.right, top=img.bounds.top, bottom=img.bounds.bottom
-            )
+            ),
+            inplace=True,
         )
         if different_crs:
             self.img2 = self.img2.reproject(dst_crs=different_crs)
@@ -57,7 +59,8 @@ class stack_merge_images:
                 right=img.bounds.right - img.res[0] * 2,
                 top=img.bounds.top,
                 bottom=img.bounds.bottom,
-            )
+            ),
+            inplace=True,
         )
 
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -933,15 +933,15 @@ class TestRaster:
         # -- Test with crop_geom being a list/tuple -- ##
         crop_geom: list[float] = list(r.bounds)
 
-        # Test inplace unloaded cropping conserves the shape
-        r.crop(crop_geom=[crop_geom[0] + r.res[0], crop_geom[1], crop_geom[2], crop_geom[3]])
+        # Test unloaded inplace cropping conserves the shape
+        r.crop(crop_geom=[crop_geom[0] + r.res[0], crop_geom[1], crop_geom[2], crop_geom[3]], inplace=True)
         assert len(r.data.shape) == 2
 
         r = gu.Raster(raster_path)
 
         # Test with same bounds -> should be the same #
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert r_cropped.raster_equal(r)
 
         # Test with bracket call
@@ -953,28 +953,28 @@ class TestRaster:
 
         # Left
         crop_geom2 = [crop_geom[0] + rand_int * r.res[0], crop_geom[1], crop_geom[2], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert list(r_cropped.bounds) == crop_geom2
         assert np.array_equal(r.data[:, rand_int:].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[:, rand_int:].mask, r_cropped.data.mask)
 
         # Right
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2] - rand_int * r.res[0], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert list(r_cropped.bounds) == crop_geom2
         assert np.array_equal(r.data[:, :-rand_int].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[:, :-rand_int].mask, r_cropped.data.mask)
 
         # Bottom
         crop_geom2 = [crop_geom[0], crop_geom[1] + rand_int * abs(r.res[1]), crop_geom[2], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert list(r_cropped.bounds) == crop_geom2
         assert np.array_equal(r.data[:-rand_int, :].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[:-rand_int, :].mask, r_cropped.data.mask)
 
         # Top
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2], crop_geom[3] - rand_int * abs(r.res[1])]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert list(r_cropped.bounds) == crop_geom2
         assert np.array_equal(r.data[rand_int:, :].data, r_cropped.data, equal_nan=True)
         assert np.array_equal(r.data[rand_int:, :].mask, r_cropped.data.mask)
@@ -986,13 +986,13 @@ class TestRaster:
             crop_geom[2],
             crop_geom[3] - rand_int * r.res[0],
         )
-        r_cropped = r.crop(crop_geom3, inplace=False)
+        r_cropped = r.crop(crop_geom3)
         assert list(r_cropped.bounds) == list(crop_geom3)
         assert np.array_equal(r.data[rand_int:, :].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[rand_int:, :].mask, r_cropped.data.mask)
 
         # -- Test with crop_geom being a Raster -- #
-        r_cropped2 = r.crop(r_cropped, inplace=False)
+        r_cropped2 = r.crop(r_cropped)
         assert r_cropped2.raster_equal(r_cropped)
 
         # Check that bound reprojection is done automatically if the CRS differ
@@ -1001,19 +1001,19 @@ class TestRaster:
                 "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
             )
             r_cropped_reproj = r_cropped.reproject(dst_crs=3857)
-        r_cropped3 = r.crop(r_cropped_reproj, inplace=False)
+        r_cropped3 = r.crop(r_cropped_reproj)
 
         # Original CRS bounds can be deformed during transformation, but result should be equivalent to this
-        r_cropped4 = r.crop(crop_geom=r_cropped_reproj.get_bounds_projected(out_crs=r.crs), inplace=False)
+        r_cropped4 = r.crop(crop_geom=r_cropped_reproj.get_bounds_projected(out_crs=r.crs))
         assert r_cropped3.raster_equal(r_cropped4)
 
         # Check with bracket call
         r_cropped5 = r[r_cropped_reproj]
         assert r_cropped4.raster_equal(r_cropped5)
 
-        # -- Test with inplace=True (Default) -- #
+        # -- Test with inplace=True -- #
         r_copy = r.copy()
-        r_copy.crop(r_cropped)
+        r_copy.crop(r_cropped, inplace=True)
         assert r_copy.raster_equal(r_cropped)
 
         # - Test cropping each side with a non integer pixel, mode='match_pixel' - #
@@ -1021,28 +1021,28 @@ class TestRaster:
 
         # left
         crop_geom2 = [crop_geom[0] + rand_float * r.res[0], crop_geom[1], crop_geom[2], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert r.shape[1] - (r_cropped.bounds.right - r_cropped.bounds.left) / r.res[0] == int(rand_float)
         assert np.array_equal(r.data[:, int(rand_float) :].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[:, int(rand_float) :].mask, r_cropped.data.mask)
 
         # right
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2] - rand_float * r.res[0], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert r.shape[1] - (r_cropped.bounds.right - r_cropped.bounds.left) / r.res[0] == int(rand_float)
         assert np.array_equal(r.data[:, : -int(rand_float)].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[:, : -int(rand_float)].mask, r_cropped.data.mask)
 
         # bottom
         crop_geom2 = [crop_geom[0], crop_geom[1] + rand_float * abs(r.res[1]), crop_geom[2], crop_geom[3]]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert r.shape[0] - (r_cropped.bounds.top - r_cropped.bounds.bottom) / r.res[1] == int(rand_float)
         assert np.array_equal(r.data[: -int(rand_float), :].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[: -int(rand_float), :].mask, r_cropped.data.mask)
 
         # top
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2], crop_geom[3] - rand_float * abs(r.res[1])]
-        r_cropped = r.crop(crop_geom2, inplace=False)
+        r_cropped = r.crop(crop_geom2)
         assert r.shape[0] - (r_cropped.bounds.top - r_cropped.bounds.bottom) / r.res[1] == int(rand_float)
         assert np.array_equal(r.data[int(rand_float) :, :].data, r_cropped.data.data, equal_nan=True)
         assert np.array_equal(r.data[int(rand_float) :, :].mask, r_cropped.data.mask)
@@ -1063,7 +1063,7 @@ class TestRaster:
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
             )
-            r_cropped = r.crop(crop_geom2, inplace=False, mode="match_extent")
+            r_cropped = r.crop(crop_geom2, mode="match_extent")
 
         assert list(r_cropped.bounds) == crop_geom2
         # The change in resolution should be less than what would occur with +/- 1 pixel
@@ -1076,7 +1076,7 @@ class TestRaster:
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="For reprojection, dst_nodata must be set.*"
             )
-            r_cropped2 = r.crop(r_cropped, inplace=False, mode="match_extent")
+            r_cropped2 = r.crop(r_cropped, mode="match_extent")
         assert r_cropped2.raster_equal(r_cropped)
 
         # -- Test with crop_geom being a Vector -- #
@@ -1084,7 +1084,7 @@ class TestRaster:
 
         # First, we reproject manually the outline
         outlines_reproj = gu.Vector(outlines.ds.to_crs(r.crs))
-        r_cropped = r.crop(outlines_reproj, inplace=False)
+        r_cropped = r.crop(outlines_reproj)
 
         # Calculate intersection of the two bounding boxes and make sure crop has same bounds
         win_outlines = rio.windows.from_bounds(*outlines_reproj.bounds, transform=r.transform)
@@ -1094,7 +1094,7 @@ class TestRaster:
         assert list(r_cropped.bounds) == list(new_bounds)
 
         # Second, we check that bound reprojection is done automatically if the CRS differ
-        r_cropped2 = r.crop(outlines, inplace=False)
+        r_cropped2 = r.crop(outlines)
         assert list(r_cropped2.bounds) == list(new_bounds)
 
         # Finally, we check with a bracket call
@@ -2810,7 +2810,7 @@ class TestMask:
     def test_crop(self, mask: gu.Mask) -> None:
         # Test with same bounds -> should be the same #
         crop_geom = mask.bounds
-        mask_cropped = mask.crop(crop_geom, inplace=False)
+        mask_cropped = mask.crop(crop_geom)
         assert mask_cropped.raster_equal(mask)
 
         # Check if instance is respected
@@ -2825,35 +2825,35 @@ class TestMask:
 
         # Left
         crop_geom2 = [crop_geom[0] + rand_int * mask.res[0], crop_geom[1], crop_geom[2], crop_geom[3]]
-        mask_cropped = mask.crop(crop_geom2, inplace=False)
+        mask_cropped = mask.crop(crop_geom2)
         assert list(mask_cropped.bounds) == crop_geom2
         assert np.array_equal(mask.data[:, rand_int:].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:, rand_int:].mask, mask_cropped.data.mask)
 
         # Right
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2] - rand_int * mask.res[0], crop_geom[3]]
-        mask_cropped = mask.crop(crop_geom2, inplace=False)
+        mask_cropped = mask.crop(crop_geom2)
         assert list(mask_cropped.bounds) == crop_geom2
         assert np.array_equal(mask.data[:, :-rand_int].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:, :-rand_int].mask, mask_cropped.data.mask)
 
         # Bottom
         crop_geom2 = [crop_geom[0], crop_geom[1] + rand_int * abs(mask.res[1]), crop_geom[2], crop_geom[3]]
-        mask_cropped = mask.crop(crop_geom2, inplace=False)
+        mask_cropped = mask.crop(crop_geom2)
         assert list(mask_cropped.bounds) == crop_geom2
         assert np.array_equal(mask.data[:-rand_int, :].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:-rand_int, :].mask, mask_cropped.data.mask)
 
         # Top
         crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2], crop_geom[3] - rand_int * abs(mask.res[1])]
-        mask_cropped = mask.crop(crop_geom2, inplace=False)
+        mask_cropped = mask.crop(crop_geom2)
         assert list(mask_cropped.bounds) == crop_geom2
         assert np.array_equal(mask.data[rand_int:, :].data, mask_cropped.data, equal_nan=True)
         assert np.array_equal(mask.data[rand_int:, :].mask, mask_cropped.data.mask)
 
         # Test inplace
         mask_orig = mask.copy()
-        mask.crop(crop_geom2)
+        mask.crop(crop_geom2, inplace=True)
         assert list(mask.bounds) == crop_geom2
         assert np.array_equal(mask_orig.data[rand_int:, :].data, mask.data, equal_nan=True)
         assert np.array_equal(mask_orig.data[rand_int:, :].mask, mask.data.mask)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -204,12 +204,17 @@ class TestVector:
 
         # Crop
         outlines_new = outlines.copy()
-        outlines_new.crop(crop_geom=rst)
+        outlines_new.crop(crop_geom=rst, inplace=True)
+
+        # Check default behaviour - crop and return copy
+        outlines_copy = outlines.crop(crop_geom=rst)
 
         # Crop by passing bounds
         outlines_new_bounds = outlines.copy()
-        outlines_new_bounds.crop(crop_geom=list(rst.bounds))
+        outlines_new_bounds.crop(crop_geom=list(rst.bounds), inplace=True)
         assert_geodataframe_equal(outlines_new.ds, outlines_new_bounds.ds)
+        # Check the return-by-copy as well
+        assert_geodataframe_equal(outlines_copy.ds, outlines_new_bounds.ds)
 
         # Check with bracket call
         outlines_new2 = outlines_new[rst]
@@ -235,7 +240,7 @@ class TestVector:
 
         # Check that error is raised when cropGeom argument is invalid
         with pytest.raises(TypeError, match="Crop geometry must be a Raster, Vector, or list of coordinates."):
-            outlines.crop(1)  # type: ignore
+            outlines.crop(1, inplace=True)  # type: ignore
 
     def test_proximity(self) -> None:
         """


### PR DESCRIPTION
**This PR creates breaking changes to the API**

Resolves part of #432:  `Raster.crop()` is now `inplace=False` by default. This aligns its functionality with `Raster.reproject()` and with other projects more generally such as xarray.

The PR also fixes a bug in `test_projtools:test_utm_to_epsg`. A KeyError was being returned by `proj_tools.utm_to_epsg()`:

```python 
        with pytest.raises(TypeError):
            pt.utm_to_epsg({"utm": "10N"})  # type: ignore
```

This is now fixed by requiring a `str` type in `utm_to_epsg()`, allowing all tests to pass locally on my machine.
