### PR TITLE
Homogenize API arguments

### DIFF
--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -222,8 +222,8 @@ print(rast.bounds)
 ```{code-cell} ipython3
 # Reproject to smaller bounds and higher resolution
 rast_reproj = rast.reproject(
-    dst_res=0.1,
-    dst_bounds={"left": 0, "bottom": 0, "right": 0.75, "top": 0.75},
+    res=0.1,
+    bounds={"left": 0, "bottom": 0, "right": 0.75, "top": 0.75},
     resampling="cubic")
 rast_reproj
 ```

--- a/examples/analysis/point_extraction/interpolation.py
+++ b/examples/analysis/point_extraction/interpolation.py
@@ -28,7 +28,7 @@ np.random.seed(42)
 x_coords = np.random.uniform(rast.bounds.left + 50, rast.bounds.right - 50, 50)
 y_coords = np.random.uniform(rast.bounds.bottom + 50, rast.bounds.top - 50, 50)
 
-vals = rast.interp_points(pts=list(zip(x_coords, y_coords)))
+vals = rast.interp_points(points=list(zip(x_coords, y_coords)))
 
 # %%
 # Replace by Vector function once done
@@ -50,7 +50,7 @@ rast.tags["AREA_OR_POINT"] = "Point"
 # %%
 # We can interpolate again by shifting according to our interpretation, and changing the resampling algorithm (default to "linear").
 
-vals_shifted = rast.interp_points(pts=list(zip(x_coords, y_coords)), shift_area_or_point=True, mode="quintic")
+vals_shifted = rast.interp_points(points=list(zip(x_coords, y_coords)), shift_area_or_point=True, mode="quintic")
 np.nanmean(vals - vals_shifted)
 
 # %%

--- a/examples/handling/georeferencing/reproj_raster.py
+++ b/examples/handling/georeferencing/reproj_raster.py
@@ -58,5 +58,5 @@ rast2.show(ax="new", cmap="Blues")
 # Ensure the right nodata value is set
 rast2.set_nodata(0)
 # Pass the desired georeferencing parameters
-rast2_warped = rast2.reproject(dst_size=(100, 100), dst_crs=32645)
+rast2_warped = rast2.reproject(size=(100, 100), crs=32645)
 print(rast2_warped.info())

--- a/examples/handling/georeferencing/reproj_vector.py
+++ b/examples/handling/georeferencing/reproj_vector.py
@@ -41,5 +41,5 @@ vect_reproj.show(ax="new", fc="none", ec="tab:purple", lw=3)
 # :class:`int`).
 
 # Reproject in UTM zone 45N.
-vect_reproj = vect.reproject(dst_crs=32645)
+vect_reproj = vect.reproject(crs=32645)
 vect_reproj

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -94,9 +94,7 @@ def load_multiple_rasters(
 
         # Reproject all rasters
         for index, rst in enumerate(output_rst):
-            out_rst = rst.reproject(
-                dst_crs=ref_rst.crs, dst_bounds=new_bounds, dst_res=ref_rst.res, silent=True, **kwargs
-            )
+            out_rst = rst.reproject(crs=ref_rst.crs, bounds=new_bounds, res=ref_rst.res, silent=True, **kwargs)
             if not out_rst.is_loaded:
                 out_rst.load()
             output_rst[index] = out_rst
@@ -178,11 +176,11 @@ def stack_rasters(
         nodata = reference_raster.nodata or gu.raster.raster._default_nodata(reference_raster.data.dtype)
         # Reproject to reference grid
         reprojected_raster = raster.reproject(
-            dst_bounds=dst_bounds,
-            dst_res=reference_raster.res,
-            dst_crs=reference_raster.crs,
-            dst_dtype=reference_raster.data.dtype,
-            dst_nodata=reference_raster.nodata,
+            bounds=dst_bounds,
+            res=reference_raster.res,
+            crs=reference_raster.crs,
+            dtype=reference_raster.data.dtype,
+            nodata=reference_raster.nodata,
             silent=True,
         )
         reprojected_raster.set_nodata(nodata)

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -44,7 +44,7 @@ from geoutils.projtools import (
     _get_footprint_projected,
     _get_utm_ups_crs,
 )
-from geoutils.raster.sampling import subsample_array
+from geoutils.raster.sampling import sample_array
 from geoutils.vector import Vector
 
 # If python38 or above, Literal is builtin. Otherwise, use typing_extensions
@@ -208,7 +208,7 @@ def _load_rio(
     :param masked: Whether the mask should be read (if any exists) to use the nodata to mask values.
     :param transform: Create a window from the given transform (to read only parts of the raster)
     :param shape: Expected shape of the read ndarray. Must be given together with the `transform` argument.
-    :param out_count: Specify the count for a subsampled version (to be used with kwargs out_shape).
+    :param out_count: Specify the count for a downsampled version (to be used with kwargs out_shape).
 
     :raises ValueError: If only one of ``transform`` and ``shape`` are given.
 
@@ -217,7 +217,7 @@ def _load_rio(
     \*\*kwargs: any additional arguments to rasterio.io.DatasetReader.read.
     Useful ones are:
     .. hlist::
-    * out_shape : to load a subsampled version, always use with out_count
+    * out_shape : to load a downsampled version, always use with out_count
     * window : to load a cropped version
     * resampling : to set the resampling algorithm
     """
@@ -3208,9 +3208,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         return self.copy(new_array=proximity)
 
     @overload
-    def subsample(
+    def sample(
         self,
-        subsample: int | float,
+        sample: int | float,
         return_indices: Literal[False] = False,
         *,
         random_state: np.random.RandomState | int | None = None,
@@ -3218,9 +3218,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         ...
 
     @overload
-    def subsample(
+    def sample(
         self,
-        subsample: int | float,
+        sample: int | float,
         return_indices: Literal[True],
         *,
         random_state: np.random.RandomState | int | None = None,
@@ -3228,33 +3228,31 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         ...
 
     @overload
-    def subsample(
+    def sample(
         self,
-        subsample: float | int,
+        sample: float | int,
         return_indices: bool = False,
         random_state: np.random.RandomState | int | None = None,
     ) -> NDArrayNum | tuple[NDArrayNum, ...]:
         ...
 
-    def subsample(
+    def sample(
         self,
-        subsample: float | int,
+        sample: float | int,
         return_indices: bool = False,
         random_state: np.random.RandomState | int | None = None,
     ) -> NDArrayNum | tuple[NDArrayNum, ...]:
         """
-        Randomly subsample the raster. Only valid values are considered.
+        Randomly sample the raster. Only valid values are considered.
 
-        :param subsample: If <= 1, a fraction of the total pixels to extract. If > 1, the number of pixels.
+        :param sample: If <= 1, a fraction of the total pixels to extract. If > 1, the number of pixels.
         :param return_indices: Whether to return the extracted indices only.
         :param random_state: Random state or seed number.
 
-        :return: Array of subsampled valid values, or array of subsampled indices.
+        :return: Array of sampled valid values, or array of sampled indices.
         """
 
-        return subsample_array(
-            array=self.data, subsample=subsample, return_indices=return_indices, random_state=random_state
-        )
+        return sample_array(array=self.data, sample=sample, return_indices=return_indices, random_state=random_state)
 
 
 class Mask(Raster):

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2383,7 +2383,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             raise NotImplementedError("This is not implemented yet.")
 
-    def intersection(self, rst: str | Raster, match_ref: bool = True) -> tuple[float, float, float, float]:
+    def intersection(self, raster: str | Raster, match_ref: bool = True) -> tuple[float, float, float, float]:
         """
         Returns the bounding box of intersection between this image and another.
 
@@ -2398,15 +2398,15 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         """
         from geoutils import projtools
 
-        # If input rst is string, open as Raster
-        if isinstance(rst, str):
-            rst = Raster(rst, load_data=False)
+        # If input raster is string, open as Raster
+        if isinstance(raster, str):
+            raster = Raster(raster, load_data=False)
 
-        # Reproject the bounds of rst to self's
-        rst_bounds_sameproj = rst.get_bounds_projected(self.crs)
+        # Reproject the bounds of raster to self's
+        raster_bounds_sameproj = raster.get_bounds_projected(self.crs)
 
         # Calculate intersection of bounding boxes
-        intersection = projtools.merge_bounds([self.bounds, rst_bounds_sameproj], merging_algorithm="intersection")
+        intersection = projtools.merge_bounds([self.bounds, raster_bounds_sameproj], merging_algorithm="intersection")
 
         # Check that intersection is not void (changed to NaN instead of empty tuple end 2022)
         if intersection == () or all(math.isnan(i) for i in intersection):

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3030,7 +3030,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         """
         Convert raster to a table of coordinates and their corresponding values.
 
-        Optionally, randomly sub-sample the raster.
+        Optionally, randomly sample the raster.
 
         If 'sample' is either 1, or is equal to the pixel count, all points are returned in order.
         If 'sample' is smaller than 1 (for fractions), or smaller than the pixel count, a random sample

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -11,9 +11,9 @@ from geoutils.raster.array import get_mask
 
 
 @overload
-def subsample_array(
+def sample_array(
     array: NDArrayNum | MArrayNum,
-    subsample: float | int,
+    sample: float | int,
     return_indices: Literal[False] = False,
     *,
     random_state: np.random.RandomState | int | None = None,
@@ -22,9 +22,9 @@ def subsample_array(
 
 
 @overload
-def subsample_array(
+def sample_array(
     array: NDArrayNum | MArrayNum,
-    subsample: float | int,
+    sample: float | int,
     return_indices: Literal[True],
     *,
     random_state: np.random.RandomState | int | None = None,
@@ -33,33 +33,33 @@ def subsample_array(
 
 
 @overload
-def subsample_array(
+def sample_array(
     array: NDArrayNum | MArrayNum,
-    subsample: float | int,
+    sample: float | int,
     return_indices: bool = False,
     random_state: np.random.RandomState | int | None = None,
 ) -> NDArrayNum | tuple[NDArrayNum, ...]:
     ...
 
 
-def subsample_array(
+def sample_array(
     array: NDArrayNum | MArrayNum,
-    subsample: float | int,
+    sample: float | int,
     return_indices: bool = False,
     random_state: np.random.RandomState | int | None = None,
 ) -> NDArrayNum | tuple[NDArrayNum, ...]:
     """
-    Randomly subsample a 1D or 2D array by a subsampling factor, taking only non NaN/masked values.
+    Randomly sample a 1D or 2D array by a sampling factor, taking only non NaN/masked values.
 
     :param array: Input array.
-    :param subsample: If <= 1, will be considered a fraction of valid pixels to extract.
+    :param sample: If <= 1, will be considered a fraction of valid pixels to extract.
     If > 1 will be considered the number of pixels to extract.
     :param return_indices: If set to True, will return the extracted indices only.
     :param random_state: Random state, or seed number to use for random calculations (for testing)
 
-    :returns: The subsampled array (1D) or the indices to extract (same shape as input array)
+    :returns: The sampled array (1D) or the indices to extract (same shape as input array)
     """
-    # Define state for random subsampling (to fix results during testing)
+    # Define state for random sampling (to fix results during testing)
     if random_state is None:
         rnd: np.random.RandomState | np.random.Generator = np.random.default_rng()
     elif isinstance(random_state, np.random.RandomState):
@@ -72,12 +72,12 @@ def subsample_array(
     valids = np.argwhere(~mask.flatten()).squeeze()
 
     # Get number of points to extract
-    if (subsample <= 1) & (subsample > 0):
-        npoints = int(subsample * np.count_nonzero(~mask))
-    elif subsample > 1:
-        npoints = int(subsample)
+    if (sample <= 1) & (sample > 0):
+        npoints = int(sample * np.count_nonzero(~mask))
+    elif sample > 1:
+        npoints = int(sample)
     else:
-        raise ValueError("`subsample` must be > 0")
+        raise ValueError("`sample` must be > 0")
 
     # Checks that array and npoints are correct
     assert np.ndim(valids) == 1, "Something is wrong with array dimension, check input data and shape"

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -1348,13 +1348,13 @@ class Vector:
 
     @classmethod
     def from_bounds_projected(
-        cls, raster_or_vector: gu.Raster | VectorType, out_crs: CRS | None = None, densify_pts: int = 5000
+        cls, raster_or_vector: gu.Raster | VectorType, out_crs: CRS | None = None, densify_points: int = 5000
     ) -> VectorType:
         """Create a vector polygon from projected bounds of a raster or vector.
 
         :param raster_or_vector: A raster or vector
         :param out_crs: In which CRS to compute the bounds
-        :param densify_pts: Maximum points to be added between image corners to account for nonlinear edges.
+        :param densify_points: Maximum points to be added between image corners to account for nonlinear edges.
             Reduce if time computation is really critical (ms) or increase if extent is not accurate enough.
         """
 
@@ -1362,7 +1362,7 @@ class Vector:
             out_crs = raster_or_vector.crs
 
         df = _get_footprint_projected(
-            raster_or_vector.bounds, in_crs=raster_or_vector.crs, out_crs=out_crs, densify_pts=densify_pts
+            raster_or_vector.bounds, in_crs=raster_or_vector.crs, out_crs=out_crs, densify_points=densify_points
         )
 
         return cls(df)  # type: ignore
@@ -1467,21 +1467,21 @@ class Vector:
 
         return vector_buffered
 
-    def get_bounds_projected(self, out_crs: CRS, densify_pts: int = 5000) -> rio.coords.BoundingBox:
+    def get_bounds_projected(self, out_crs: CRS, densify_points: int = 5000) -> rio.coords.BoundingBox:
         """
         Get vector bounds projected in a specified CRS.
 
         :param out_crs: Output CRS.
-        :param densify_pts: Maximum points to be added between image corners to account for nonlinear edges.
+        :param densify_points: Maximum points to be added between image corners to account for nonlinear edges.
             Reduce if time computation is really critical (ms) or increase if extent is not accurate enough.
         """
 
         # Calculate new bounds
-        new_bounds = _get_bounds_projected(self.bounds, in_crs=self.crs, out_crs=out_crs, densify_pts=densify_pts)
+        new_bounds = _get_bounds_projected(self.bounds, in_crs=self.crs, out_crs=out_crs, densify_points=densify_points)
 
         return new_bounds
 
-    def get_footprint_projected(self, out_crs: CRS, densify_pts: int = 5000) -> Vector:
+    def get_footprint_projected(self, out_crs: CRS, densify_points: int = 5000) -> Vector:
         """
         Get vector footprint projected in a specified CRS.
 
@@ -1489,12 +1489,14 @@ class Vector:
         the rectangular square footprint of the original projection into the new one.
 
         :param out_crs: Output CRS.
-        :param densify_pts: Maximum points to be added between image corners to account for non linear edges.
+        :param densify_points: Maximum points to be added between image corners to account for non linear edges.
          Reduce if time computation is really critical (ms) or increase if extent is not accurate enough.
         """
 
         return Vector(
-            _get_footprint_projected(bounds=self.bounds, in_crs=self.crs, out_crs=out_crs, densify_pts=densify_pts)
+            _get_footprint_projected(
+                bounds=self.bounds, in_crs=self.crs, out_crs=out_crs, densify_points=densify_points
+            )
         )
 
     def get_metric_crs(

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -1388,7 +1388,7 @@ class Vector:
     def proximity(
         self,
         raster: gu.Raster | None = None,
-        grid_size: tuple[int, int] = (1000, 1000),
+        size: tuple[int, int] = (1000, 1000),
         geometry_type: str = "boundary",
         in_or_out: Literal["in"] | Literal["out"] | Literal["both"] = "both",
         distance_unit: Literal["pixel"] | Literal["georeferenced"] = "georeferenced",
@@ -1407,7 +1407,7 @@ class Vector:
         See all geometry attributes in the Shapely documentation at https://shapely.readthedocs.io/.
 
         :param raster: Raster to burn the proximity grid on.
-        :param grid_size: If no Raster is provided, grid size to use with this Vector's extent and CRS
+        :param size: If no Raster is provided, grid size to use with this Vector's extent and CRS
             (defaults to 1000 x 1000).
         :param geometry_type: Type of geometry to use for the proximity, defaults to 'boundary'.
         :param in_or_out: Compute proximity only 'in' or 'out'-side the polygon, or 'both'.
@@ -1427,7 +1427,7 @@ class Vector:
             left, bottom, right, top = self.bounds
 
             # Calculate raster transform
-            transform = rio.transform.from_bounds(left, bottom, right, top, grid_size[0], grid_size[1])
+            transform = rio.transform.from_bounds(left, bottom, right, top, size[0], size[1])
 
             raster = gu.Raster.from_array(data=np.zeros((1000, 1000)), transform=transform, crs=self.crs)
 

--- a/tests/test_multiraster.py
+++ b/tests/test_multiraster.py
@@ -47,7 +47,7 @@ class stack_merge_images:
             )
         )
         if different_crs:
-            self.img2 = self.img2.reproject(dst_crs=different_crs)
+            self.img2 = self.img2.reproject(crs=different_crs)
 
         # To check that use_ref_bounds work - create a img that do not cover the whole extent
         self.img3 = img.copy()

--- a/tests/test_projtools.py
+++ b/tests/test_projtools.py
@@ -189,8 +189,8 @@ class TestProjTools:
     )  # type: ignore
     # Try with geographic, a UTM zone and a Robinson
     @pytest.mark.parametrize("out_crs", [pyproj.CRS.from_epsg(4326), pyproj.CRS.from_epsg(32610)])  # type: ignore
-    @pytest.mark.parametrize("densify_pts", [2, 10, 5000])  # type: ignore
-    def test_get_footprint_projected(self, fn_raster_or_vector: str, out_crs: pyproj.CRS, densify_pts: int) -> None:
+    @pytest.mark.parametrize("densify_points", [2, 10, 5000])  # type: ignore
+    def test_get_footprint_projected(self, fn_raster_or_vector: str, out_crs: pyproj.CRS, densify_points: int) -> None:
         """Test the get footprint projected function."""
 
         # Open raster or vector
@@ -200,7 +200,7 @@ class TestProjTools:
             rast_or_vect = gu.Vector(fn_raster_or_vector)
 
         # Get footprint
-        footprint = rast_or_vect.get_footprint_projected(out_crs=out_crs, densify_pts=densify_pts)
+        footprint = rast_or_vect.get_footprint_projected(out_crs=out_crs, densify_points=densify_points)
 
         # Assert it is a vector containing a polygon geometry
         assert isinstance(footprint, gu.Vector)
@@ -216,4 +216,4 @@ class TestProjTools:
 
         # Check that densification yields a logical amount of points
         # (4 initial corner points times the densification factor + the last point)
-        assert len(footprint.geometry[0].exterior.coords[:]) == densify_pts * 4 + 1
+        assert len(footprint.geometry[0].exterior.coords[:]) == densify_points * 4 + 1

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1159,13 +1159,13 @@ class TestRaster:
         r_nodata.set_nodata(None)
 
         # Make sure at least one pixel is masked for test 1
-        rand_indices = gu.raster.subsample_array(r_nodata.data, 10, return_indices=True)
+        rand_indices = gu.raster.sample_array(r_nodata.data, 10, return_indices=True)
         r_nodata.data[rand_indices] = np.ma.masked
         assert np.count_nonzero(r_nodata.data.mask) > 0
 
         # make sure at least one pixel is set at default nodata for test
         default_nodata = _default_nodata(r_nodata.dtypes[0])
-        rand_indices = gu.raster.subsample_array(r_nodata.data, 10, return_indices=True)
+        rand_indices = gu.raster.sample_array(r_nodata.data, 10, return_indices=True)
         r_nodata.data[rand_indices] = default_nodata
         assert np.count_nonzero(r_nodata.data == default_nodata) > 0
 
@@ -1266,7 +1266,7 @@ class TestRaster:
         # Create a raster with (additional) random gaps
         r_gaps = r.copy()
         nsamples = 200
-        rand_indices = gu.raster.subsample_array(r_gaps.data, nsamples, return_indices=True)
+        rand_indices = gu.raster.sample_array(r_gaps.data, nsamples, return_indices=True)
         r_gaps.data[rand_indices] = np.ma.masked
         assert np.sum(r_gaps.data.mask) - np.sum(r.data.mask) == nsamples  # sanity check
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1004,7 +1004,6 @@ class TestRaster:
         r_cropped_reproj = r_cropped.reproject(crs=3857)
         r_cropped3 = r.crop(r_cropped_reproj)
 
-
         # Original CRS bounds can be deformed during transformation, but result should be equivalent to this
         r_cropped4 = r.crop(crop_geom=r_cropped_reproj.get_bounds_projected(out_crs=r.crs))
         assert r_cropped3.raster_equal(r_cropped4)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1724,7 +1724,7 @@ class TestRaster:
         # -- Tests 2: check arguments work as intended --
 
         # 1/ Lat-lon argument check by getting the coordinates of our last test point
-        lat, lon = reproject_to_latlon(pts=[[xtest0], [ytest0]], in_crs=r.crs)
+        lat, lon = reproject_to_latlon(points=[[xtest0], [ytest0]], in_crs=r.crs)
         z_val_2 = r.value_at_coords(lon, lat, latlon=True)
         assert z_val == z_val_2
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -34,41 +34,41 @@ class TestSubsampling:
     assert np.count_nonzero(array3D.mask) > 0
 
     @pytest.mark.parametrize("array", [array1D, array2D, array3D])  # type: ignore
-    def test_subsample(self, array: NDArrayNum) -> None:
+    def test_sample(self, array: NDArrayNum) -> None:
         """
-        Test gu.raster.subsample_array.
+        Test gu.raster.sample_array.
         """
         # Test that subsample > 1 works as expected, i.e. output 1D array, with no masked values, or selected size
         for npts in np.arange(2, np.size(array)):
-            random_values = gu.raster.subsample_array(array, subsample=npts)
+            random_values = gu.raster.sample_array(array, sample=npts)
             assert np.ndim(random_values) == 1
             assert np.size(random_values) == npts
             assert np.count_nonzero(random_values.mask) == 0
 
         # Test if subsample > number of valid values => return all
-        random_values = gu.raster.subsample_array(array, subsample=np.size(array) + 3)
+        random_values = gu.raster.sample_array(array, sample=np.size(array) + 3)
         assert np.all(np.sort(random_values) == array[~array.mask])
 
         # Test if subsample = 1 => return all valid values
-        random_values = gu.raster.subsample_array(array, subsample=1)
+        random_values = gu.raster.sample_array(array, sample=1)
         assert np.all(np.sort(random_values) == array[~array.mask])
 
         # Test if subsample < 1
-        random_values = gu.raster.subsample_array(array, subsample=0.5)
+        random_values = gu.raster.sample_array(array, sample=0.5)
         assert np.size(random_values) == int(np.count_nonzero(~array.mask) * 0.5)
 
         # Test with optional argument return_indices
-        indices = gu.raster.subsample_array(array, subsample=0.3, return_indices=True)
+        indices = gu.raster.sample_array(array, sample=0.3, return_indices=True)
         assert np.ndim(indices) == 2
         assert len(indices) == np.ndim(array)
         assert np.ndim(array[indices]) == 1
         assert np.size(array[indices]) == int(np.count_nonzero(~array.mask) * 0.3)
 
         # Check that we can pass an integer to fix the random state
-        sub42 = gu.raster.subsample_array(array, subsample=10, random_state=42)
+        sub42 = gu.raster.sample_array(array, sample=10, random_state=42)
         # Check by passing a generator directly
         random_gen = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(42)))
-        sub42_gen = gu.raster.subsample_array(array, subsample=10, random_state=random_gen)
+        sub42_gen = gu.raster.sample_array(array, sample=10, random_state=random_gen)
         # Both should be equal
         assert np.array_equal(sub42, sub42_gen)
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -169,23 +169,23 @@ class TestVector:
         assert burned.shape[1] == 1522
 
         # Typically, rasterize returns a raster
-        burned_in2_out1 = vct.rasterize(rst=rst, in_value=2, out_value=1)
+        burned_in2_out1 = vct.rasterize(raster=rst, in_value=2, out_value=1)
         assert isinstance(burned_in2_out1, gu.Raster)
 
         # For an in_value of 1 and out_value of 0 (default), it returns a mask
-        burned_mask = vct.rasterize(rst=rst, in_value=1)
+        burned_mask = vct.rasterize(raster=rst, in_value=1)
         assert isinstance(burned_mask, gu.Mask)
 
         # Check that rasterizing with in_value=1 is the same as creating a mask
-        assert burned_mask.raster_equal(vct.create_mask(rst=rst))
+        assert burned_mask.raster_equal(vct.create_mask(raster=rst))
 
         # The two rasterization should match
         assert np.all(burned_in2_out1[burned_mask] == 2)
         assert np.all(burned_in2_out1[~burned_mask] == 1)
 
         # Check that errors are raised
-        with pytest.raises(ValueError, match="Only one of rst or crs can be provided."):
-            vct.rasterize(rst=rst, crs=3857)
+        with pytest.raises(ValueError, match="Only one of raster or crs can be provided."):
+            vct.rasterize(raster=rst, crs=3857)
 
     test_data = [[landsat_b4_crop_path, everest_outlines_path], [aster_dem_path, aster_outlines_path]]
 
@@ -358,7 +358,7 @@ class TestSynthetic:
         assert isinstance(mask, gu.Mask)
 
         # Check that an error is raised if xres is not passed
-        with pytest.raises(ValueError, match="At least rst or xres must be set."):
+        with pytest.raises(ValueError, match="At least raster or xres must be set."):
             vector.create_mask()
 
         # Check that an error is raised if buffer is the wrong type

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -270,7 +270,7 @@ class TestVector:
         vector.proximity()
 
         # With specific grid size
-        vector.proximity(grid_size=(100, 100))
+        vector.proximity(size=(100, 100))
 
 
 class TestSynthetic:

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -114,7 +114,7 @@ class TestVector:
         v1 = gu.Vector(self.everest_outlines_path)
 
         # First, test with a EPSG integer
-        v1 = v0.reproject(dst_crs=32617)
+        v1 = v0.reproject(crs=32617)
         assert isinstance(v1, gu.Vector)
         assert v1.crs.to_epsg() == 32617
 
@@ -133,20 +133,18 @@ class TestVector:
 
         # Fourth, check that errors are raised when appropriate
         # When no destination CRS is defined, or both dst_crs and dst_ref are passed
-        with pytest.raises(ValueError, match=re.escape("Either of `dst_ref` or `dst_crs` must be set. Not both.")):
+        with pytest.raises(ValueError, match=re.escape("Either of `ref` or `crs` must be set. Not both.")):
             v0.reproject()
-            v0.reproject(dst_ref=r0, dst_crs=32617)
+            v0.reproject(ref=r0, crs=32617)
         # If the path provided does not exist
         with pytest.raises(ValueError, match=re.escape("Reference raster or vector path does not exist.")):
-            v0.reproject(dst_ref="tmp.lol")
+            v0.reproject(ref="tmp.lol")
         # If it exists but cannot be opened by rasterio or fiona
         with pytest.raises(ValueError, match=re.escape("Could not open raster or vector with rasterio or fiona.")):
-            v0.reproject(dst_ref="geoutils/examples.py")
+            v0.reproject(ref="geoutils/examples.py")
         # If input of wrong type
-        with pytest.raises(
-            TypeError, match=re.escape("Type of dst_ref must be string path to file, Raster or Vector.")
-        ):
-            v0.reproject(dst_ref=10)  # type: ignore
+        with pytest.raises(TypeError, match=re.escape("Type of ref must be string path to file, Raster or Vector.")):
+            v0.reproject(ref=10)  # type: ignore
 
     def test_rasterize_proj(self) -> None:
         # Capture the warning on resolution not matching exactly bounds


### PR DESCRIPTION
**This PR causes breaking changes to API**

Resolves the rest of #432. 

- [x] Remove `dst_`
- [x] Replace `rst` with raster
- [x] `grid_size` to `size`
- [x] The various forms of sample (see below)
- [x]  Always use `points`, never `pts`

## Grammar of sampling

This PR proposes to regularise the grammar around the word sample and its derivatives.
- When the intention is to return a (random) sample, the term `sample` is used. Previously, `subset` or `subsample` were both used to denote this purpose.
- `downsample` or `upsample` defines a change in a Raster's resolution.  The more generic term is `resample`, but the use of a specific direction is preferred. Try not to use `resample` as this has connotations of towards `reproject`.
- The terms `subset` and `subsample` refer to an contiguous portion of data (e.g. an `x*y` window of a `Raster`, specific bands of a `Raster`, or `row n...row m` of a `Vector`), without a change in resolution. I am regularising to `subset`.