### PR TITLE
Updates in Raster.reproject: fix bug, simplify code and improve tests

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -294,6 +294,16 @@ def _get_reproject_params(
                 bounds["top"],
             )
 
+    # If all georeferences are the same as input, skip calculating because of issue in
+    # rio.warp.calculate_default_transform (https://github.com/rasterio/rasterio/issues/3010)
+    if (
+        (crs == raster.crs)
+        & ((size is None) | ((height == raster.shape[0]) & (width == raster.shape[1])))
+        & ((res is None) | (res == raster.res))
+        & ((bounds is None) | (bounds == raster.bounds))
+    ):
+        return raster.transform, raster.shape[::-1]
+
     # --- First, calculate default transform ignoring any change in bounds --- #
     tmp_transform, tmp_width, tmp_height = rio.warp.calculate_default_transform(
         raster.crs,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -299,7 +299,7 @@ def _get_reproject_params(
     if (
         (crs == raster.crs)
         & ((size is None) | ((height == raster.shape[0]) & (width == raster.shape[1])))
-        & ((res is None) | (res == raster.res))
+        & ((res is None) | np.all(np.array(res) == raster.res))
         & ((bounds is None) | (bounds == raster.bounds))
     ):
         return raster.transform, raster.shape[::-1]

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2070,10 +2070,6 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         elif ref is None and crs is None:
             crs = self.crs
 
-        # size and res are mutually exclusive
-        if size is not None and res is not None:
-            raise ValueError("size and res both specified. Specify only one.")
-
         # Set output dtype
         if dtype is None:
             # Warning: this will not work for multiple bands with different dtypes

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2779,15 +2779,16 @@ class TestMask:
     def test_reproject(self, mask: gu.Mask) -> None:
         # Test 1: with a classic resampling (bilinear)
 
-        # Reproject mask
-        mask_reproj = mask.reproject()
+        # Reproject mask - resample to 100 x 100 grid
+        # dst_res = tuple(np.array(mask.res)*2)
+        mask_reproj = mask.reproject(size=(100, 100), src_nodata=2)
 
         # Check instance is respected
         assert isinstance(mask_reproj, gu.Mask)
 
         # This should be equivalent to converting the array to uint8, reprojecting, converting back
         mask_uint8 = mask.astype("uint8")
-        mask_uint8_reproj = mask_uint8.reproject()
+        mask_uint8_reproj = mask_uint8.reproject(size=(100, 100), src_nodata=2)
         mask_uint8_reproj.data = mask_uint8_reproj.data.astype("bool")
 
         assert mask_reproj.raster_equal(mask_uint8_reproj)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1381,24 +1381,18 @@ class TestRaster:
             assert (out_img.count, *out_img.shape) == (n, 500, 500)
 
         # Test that the rounding of resolution is correct for large rasters
-        # (we take an example that used to fail, see issue #354)
-        data = np.zeros(shape=(5741, 2959), dtype="uint8")
-        transform = rio.transform.Affine(20.0, 0.0, 238286.29553975424, 0.0, -20.0, 6995453.456051373)
+        # (we take an example that used to fail, see issue #354 and #357)
+        data = np.ones((4759, 2453))
+        transform = rio.transform.Affine(
+            24.12423878332849, 0.0, 238286.29553975424, 0.0, -24.12423878332849, 6995453.456051373
+        )
         crs = rio.CRS.from_epsg(32633)
         nodata = -9999.0
         rst = gu.Raster.from_array(data=data, transform=transform, crs=crs, nodata=nodata)
 
-        # This large grid geotransform is taken from https://cdn.proj.org/us_nga_egm08_25.tif
-        data2 = np.zeros(shape=(4321, 8640), dtype="uint8")
-        transform2 = rio.transform.Affine(
-            0.041666666666666664, 0.0, -180.02083333333334, 0.0, -0.041666666666666664, 90.02083333333333
-        )
-        crs2 = rio.CRS.from_epsg(4979)
-        rst2 = gu.Raster.from_array(data=data2, transform=transform2, crs=crs2, nodata=None)
-
-        rst2_reproj = rst2.reproject(rst)
+        rst_reproj = rst.reproject(bounds=rst.bounds, res=(20.0, 20.0))
         # This used to be 19.999999999999999 due to floating point precision
-        assert rst2_reproj.res == (20.0, 20.0)
+        assert rst_reproj.res == (20.0, 20.0)
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_intersection(self, example: list[str]) -> None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1421,6 +1421,26 @@ class TestRaster:
         r3 = r_nodata.reproject(r2)
         assert r_nodata.nodata == r3.nodata
 
+        # -- Test additional errors raised for argument combinations -- #
+
+        # If both ref and crs are set
+        with pytest.raises(ValueError, match=re.escape("Either of `ref` or `crs` must be set. Not both.")):
+            _ = r.reproject(ref=r2, crs=r.crs)
+
+        # Size and res are mutually exclusive
+        with pytest.raises(ValueError, match=re.escape("size and res both specified. Specify only one.")):
+            _ = r.reproject(size=(10, 10), res=50)
+
+        # If wrong type for `ref`
+        with pytest.raises(
+            TypeError, match=re.escape("Type of ref not understood, must be path to file (str), Raster.")
+        ):
+            _ = r.reproject(ref=3)
+
+        # If input reference is string and file and does not exist
+        with pytest.raises(ValueError, match=re.escape("Reference raster does not exist.")):
+            _ = r.reproject(ref="no_file.tif")
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_intersection(self, example: list[str]) -> None:
         """Check the behaviour of the intersection function"""


### PR DESCRIPTION
Related to #357 and #212.
Re-organized the way `Raster.reproject` works :
- the part that handles the logic of finding the correct output goereferences has been moved to a separate (hidden) function `_get_reproject_params`. It relies now on rasterio functions (`rio.warp.calculate_default_transform` and `rio.transform.from_bounds`) only instead of making our own maths. 
- `reproject` now takes care only of the actual reprojection and handling the data
- re-organized the logic in reproject a bit and improved comments
- improve a test in TestRaster::test_reproject regarding the floating point issue
- updated a test in TestMask::test_reproject that was not actually requiring reprojection to run
- overall, improved logic in test_reproject (testing of match reference should come last instead of first), added some missing tests (coverage increased by 0.2% 🥳) and made minor edits.
- raised an issue in rasterio https://github.com/rasterio/rasterio/issues/3010
