### PR TITLE
Solves #408 (incompatibility between crop and downsampling)

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1654,16 +1654,23 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             self.data[mask_arr > 0] = np.ma.masked
 
-    def info(self, stats: bool = False) -> str:
+    @overload
+    def info(self, stats: bool = False, *, verbose: Literal[True] = ...) -> None:
+        ...
+
+    @overload
+    def info(self, stats: bool = False, *, verbose: Literal[False]) -> str:
+        ...
+
+    def info(self, stats: bool = False, verbose: bool = True) -> None | str:
         """
-        Summarize information about the raster.
+        Print summary information about the raster.
 
         :param stats: Add statistics for each band of the dataset (max, min, median, mean, std. dev.). Default is to
             not calculate statistics.
+        :param verbose: If set to True (default) will directly print to screen and return None
 
-
-        :returns: text information about Raster attributes.
-
+        :returns: summary string or None.
         """
         as_str = [
             f"Driver:               {self.driver} \n",
@@ -1701,7 +1708,11 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                     as_str.append(f"[MEAN]:             {np.nanmean(self.data[b, :, :]):.2f}\n")
                     as_str.append(f"[STD DEV]:          {np.nanstd(self.data[b, :, :]):.2f}\n")
 
-        return "".join(as_str)
+        if verbose:
+            print("".join(as_str))
+            return None
+        else:
+            return "".join(as_str)
 
     def copy(self: RasterType, new_array: NDArrayNum | None = None) -> RasterType:
         """

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1102,6 +1102,39 @@ class TestRaster:
         r_cropped3 = r[outlines]
         assert list(r_cropped3.bounds) == list(new_bounds)
 
+        # -- Test crop works as expected even if transform has been modified, e.g. through downsampling -- #
+        # Test that with downsampling, cropping to same bounds result in same raster
+        r = gu.Raster(raster_path, downsample=5)
+        r_test = r.crop(r.bounds)
+        assert r_test.raster_equal(r)
+
+        # - Test that cropping yields the same results whether data is loaded or not -
+        # With integer cropping (left)
+        rand_int = np.random.randint(1, min(r.shape) - 1)
+        crop_geom2 = [crop_geom[0] + rand_int * r.res[0], crop_geom[1], crop_geom[2], crop_geom[3]]
+        r = gu.Raster(raster_path, downsample=5, load_data=False)
+        assert not r.is_loaded
+        r_crop_unloaded = r.crop(crop_geom2)
+        r.load()
+        r_crop_loaded = r.crop(crop_geom2)
+        # TODO: the following condition should be met once issue #447 is solved
+        # assert r_crop_unloaded.raster_equal(r_crop_loaded)
+        assert r_crop_unloaded.shape == r_crop_loaded.shape
+        assert r_crop_unloaded.transform == r_crop_loaded.transform
+
+        # With a float number of pixels added to the right, mode 'match_pixel'
+        rand_float = np.random.randint(1, min(r.shape) - 1) + 0.25
+        crop_geom2 = [crop_geom[0], crop_geom[1], crop_geom[2] + rand_float * r.res[0], crop_geom[3]]
+        r = gu.Raster(raster_path, downsample=5, load_data=False)
+        assert not r.is_loaded
+        r_crop_unloaded = r.crop(crop_geom2, mode="match_pixel")
+        r.load()
+        r_crop_loaded = r.crop(crop_geom2, mode="match_pixel")
+        # TODO: the following condition should be met once issue #447 is solved
+        # assert r_crop_unloaded.raster_equal(r_crop_loaded)
+        assert r_crop_unloaded.shape == r_crop_loaded.shape
+        assert r_crop_unloaded.transform == r_crop_loaded.transform
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path, landsat_rgb_path])  # type: ignore
     def test_shift(self, example: str) -> None:
         """Tests shift works as intended"""

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -172,6 +172,10 @@ class TestRaster:
 
         r = gu.Raster(example)
 
+        # Check default runs without error (prints to screen)
+        output = r.info()
+        assert output is None
+
         # Check all is good with passing attributes
         with rio.open(example) as dataset:
             for attr in _default_rio_attrs:
@@ -180,7 +184,7 @@ class TestRaster:
         # Check that the stats=True flag doesn't trigger a warning
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="New nodata.*", category=UserWarning)
-            stats = r.info(stats=True)
+            stats = r.info(stats=True, verbose=False)
 
         # Check the stats adapt to nodata values
         if r.dtypes[0] == "uint8":
@@ -196,7 +200,7 @@ class TestRaster:
             with pytest.warns(UserWarning):
                 r.set_nodata(-99999)
 
-        new_stats = r.info(stats=True)
+        new_stats = r.info(stats=True, verbose=False)
         for i, line in enumerate(stats.splitlines()):
             if "MINIMUM" not in line:
                 continue


### PR DESCRIPTION
Resolves #408.

Phew, this was a tough one! It turns out that `Raster.crop()` was not very thoroughly implemented in the case when data is not loaded. A few things to pay attention to:
- one needs to create a Window using the on-disk transform, not the in-memory one, otherwise we're just reading the wrong bits!
- calling `rio.DatasetReader.read` is actually more complex than it seems when either of cropping or downsampling need to be executed. One needs to make sure that Window and out_shape really match. The window shape can actually be misleading because with option `boundless=False` (default), the window will be cropped if it extends beyond the raster extent. It makes sense after all...

Doing so, I noticed that our downsampling functionality is actually slightly wrong, see issue #447. Basically, the sampling interval is not exactly constant.
Because of that, one does not get exactly the same result if cropping a downsampled raster with or without data loaded (see commented test). This should be fixed together with #447.

Decided to also modify `Raster.info()` to print to screen by default, as mentioned in #361.
