### PR TITLE
Additional homogenization and fixes of argument names

### DIFF
--- a/bin/geoviewer.py
+++ b/bin/geoviewer.py
@@ -135,7 +135,7 @@ def main(test_args: Sequence[str] = None) -> None:
         dfact = 1
 
     # Read image
-    img = Raster(args.filename, downsample=dfact, indexes=args.band)
+    img = Raster(args.filename, downsample=dfact, bands=args.band)
 
     # Set no data value
     if args.nodata == "default":

--- a/examples/handling/georeferencing/reproj_raster.py
+++ b/examples/handling/georeferencing/reproj_raster.py
@@ -58,5 +58,5 @@ rast2.show(ax="new", cmap="Blues")
 # Ensure the right nodata value is set
 rast2.set_nodata(0)
 # Pass the desired georeferencing parameters
-rast2_warped = rast2.reproject(size=(100, 100), crs=32645)
+rast2_warped = rast2.reproject(grid_size=(100, 100), crs=32645)
 print(rast2_warped.info())

--- a/examples/io/open_save/read_raster.py
+++ b/examples/io/open_save/read_raster.py
@@ -33,7 +33,7 @@ rast.show(cmap="Greys_r")
 # %%
 # Opening can be performed with several parameters, for instance choosing a single band with ``index`` and re-sampling with ``downsample``, to subset a 3-band
 # raster to its second band, and using 1 pixel out of 4.
-rast = gu.Raster(gu.examples.get_path("everest_landsat_rgb"), indexes=2, downsample=4)
+rast = gu.Raster(gu.examples.get_path("everest_landsat_rgb"), bands=2, downsample=4)
 rast
 
 # %%

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2165,7 +2165,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         reproj_kwargs.update({"dst_crs": crs})
 
         # --- Check that reprojection is actually needed --- #
-        # Caution, size is (width, height) while shape is (height, width)
+        # Caution, grid_size is (width, height) while shape is (height, width)
         if all(
             [
                 (transform == self.transform) or (transform is None),

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2083,7 +2083,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             # Warning: this will not work for multiple bands with different dtypes
             dtype = self.dtypes[0]
 
-        # Set source nodata if provided
+        # --- Set source nodata if provided -- #
         if force_source_nodata is None:
             src_nodata = self.nodata
         else:
@@ -2097,16 +2097,6 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                     )
                 )
 
-        # Create a BoundingBox if required
-        if bounds is not None:
-            if not isinstance(bounds, rio.coords.BoundingBox):
-                bounds = rio.coords.BoundingBox(
-                    bounds["left"],
-                    bounds["bottom"],
-                    bounds["right"],
-                    bounds["top"],
-                )
-
         # --- Set destination nodata if provided -- #
         # This is needed in areas not covered by the input data.
         # If None, will use GeoUtils' default, as rasterio's default is unknown, hence cannot be handled properly.
@@ -2114,7 +2104,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             nodata = self.nodata
             if nodata is None:
                 nodata = _default_nodata(dtype)
-                # if nodata is already being used, raise a warning.
+                # If nodata is already being used, raise a warning.
                 # TODO: for uint8, if all values are used, apply rio.warp to mask to identify invalid values
                 if not self.is_loaded:
                     warnings.warn(
@@ -2128,6 +2118,16 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                         f"self.data. This may have unexpected consequences. Consider setting a different nodata with "
                         f"self.set_nodata()."
                     )
+
+        # Create a BoundingBox if required
+        if bounds is not None:
+            if not isinstance(bounds, rio.coords.BoundingBox):
+                bounds = rio.coords.BoundingBox(
+                    bounds["left"],
+                    bounds["bottom"],
+                    bounds["right"],
+                    bounds["top"],
+                )
 
         from geoutils.misc import resampling_method_from_str
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2022,10 +2022,10 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         res: float | abc.Iterable[float] | None = None,
         grid_size: tuple[int, int] | None = None,
         bounds: dict[str, float] | rio.coords.BoundingBox | None = None,
-        nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
+        nodata: int | float | None = None,
         dtype: DTypeLike | None = None,
         resampling: Resampling | str = Resampling.bilinear,
-        force_source_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
+        force_source_nodata: int | float | None = None,
         silent: bool = False,
         n_threads: int = 0,
         memory_limit: int = 64,
@@ -2082,9 +2082,12 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             src_nodata = force_source_nodata
             # Raise warning if a different nodata value exists for this raster than the forced one (not None)
             if self.nodata is not None:
-                warnings.warn("Forcing source nodata value of {} despite an existing nodata value of {} in the raster. "
-                              "To silence this warning, use self.set_nodata() before reprojection instead of forcing.".
-                              format(force_source_nodata, self.nodata))
+                warnings.warn(
+                    "Forcing source nodata value of {} despite an existing nodata value of {} in the raster. "
+                    "To silence this warning, use self.set_nodata() before reprojection instead of forcing.".format(
+                        force_source_nodata, self.nodata
+                    )
+                )
 
         # Create a BoundingBox if required
         if bounds is not None:
@@ -2173,7 +2176,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         ):
             if (nodata == self.nodata) or (nodata is None):
                 if not silent:
-                    warnings.warn("Output projection, bounds and grid size are identical -> returning self (not a copy!)")
+                    warnings.warn(
+                        "Output projection, bounds and grid size are identical -> returning self (not a copy!)"
+                    )
                 return self
 
             elif nodata is not None:
@@ -2199,8 +2204,10 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             # All masked values must be set to a nodata value for rasterio's reproject to work properly
             # TODO: another option is to apply rio.warp.reproject to the mask to identify invalid pixels
             if src_nodata is None and np.sum(self.data.mask) > 0:
-                raise ValueError("No nodata set, set one for the raster with self.set_nodata() or use a temporary one "
-                                 "with `force_source_nodata`.")
+                raise ValueError(
+                    "No nodata set, set one for the raster with self.set_nodata() or use a temporary one "
+                    "with `force_source_nodata`."
+                )
 
             # Mask not taken into account by rasterio, need to fill with src_nodata
             data, transformed = rio.warp.reproject(self.data.filled(src_nodata), **reproj_kwargs)
@@ -2759,7 +2766,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 if self.count == 1:
                     data = self.data[row : row + height, col : col + width]
                 else:
-                    data = self.data[slice(None) if band is None else band - 1, row: row + height, col: col + width]
+                    data = self.data[slice(None) if band is None else band - 1, row : row + height, col : col + width]
                 if not masked:
                     data = data.filled()
                 value = format_value(data)
@@ -3429,10 +3436,10 @@ class Mask(Raster):
         res: float | abc.Iterable[float] | None = None,
         grid_size: tuple[int, int] | None = None,
         bounds: dict[str, float] | rio.coords.BoundingBox | None = None,
-        nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
-        force_source_nodata: int | float | tuple[int, ...] | tuple[float, ...] | None = None,
+        nodata: int | float | None = None,
         dtype: DTypeLike | None = None,
         resampling: Resampling | str = Resampling.nearest,
+        force_source_nodata: int | float | None = None,
         silent: bool = False,
         n_threads: int = 0,
         memory_limit: int = 64,
@@ -3455,9 +3462,9 @@ class Mask(Raster):
             grid_size=grid_size,
             bounds=bounds,
             nodata=nodata,
-            force_source_nodata=force_source_nodata,
             dtype=dtype,
             resampling=resampling,
+            force_source_nodata=force_source_nodata,
             silent=silent,
             n_threads=n_threads,
             memory_limit=memory_limit,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2634,7 +2634,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         x: Number | ArrayLike,
         y: Number | ArrayLike,
         latlon: bool = False,
-        index: int | None = None,
+        band: int | None = None,
         masked: bool = False,
         window: int | None = None,
         reducer_function: Callable[[NDArrayNum], float] = np.ma.mean,
@@ -2650,7 +2650,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :param x: X (or longitude) coordinate(s).
         :param y: Y (or latitude) coordinate(s).
         :param latlon: Whether coordinates are provided as longitude-latitude.
-        :param index: Band number to extract from (from 1 to self.count).
+        :param band: Band number to extract from (from 1 to self.count).
         :param masked: Whether to return a masked array, or classic array.
         :param window: Window size to read around coordinates. Must be odd.
         :param reducer_function: Reducer function to apply to the values in window (defaults to np.mean).
@@ -2759,7 +2759,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 if self.count == 1:
                     data = self.data[row : row + height, col : col + width]
                 else:
-                    data = self.data[slice(None) if index is None else index - 1, row : row + height, col : col + width]
+                    data = self.data[slice(None) if band is None else band - 1, row: row + height, col: col + width]
                 if not masked:
                     data = data.filled()
                 value = format_value(data)
@@ -2774,7 +2774,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                         fill_value=self.nodata,
                         boundless=boundless,
                         masked=masked,
-                        indexes=index,
+                        indexes=band,
                     )
                 value = format_value(data)
                 win = data
@@ -2971,7 +2971,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         points: tuple[list[float], list[float]],
         input_latlon: bool = False,
         mode: str = "linear",
-        index: int = 1,
+        band: int = 1,
         shift_area_or_point: bool = False,
         **kwargs: Any,
     ) -> NDArrayNum:
@@ -2988,7 +2988,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :param mode: One of 'linear', 'cubic', or 'quintic'. Determines what type of spline is used to
             interpolate the raster value at each point. For more information, see scipy.interpolate.interp2d.
             Default is linear.
-        :param index: The band to use (from 1 to self.count).
+        :param band: The band to use (from 1 to self.count).
         :param shift_area_or_point: Shifts index to center pixel coordinates if GDAL's AREA_OR_POINT
             attribute (in self.tags) is "Point", keeps the corner pixel coordinate for "Area".
 
@@ -3019,7 +3019,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if self.count == 1:
             rpoints = map_coordinates(self.data.astype(np.float32), [i, j], **kwargs)
         else:
-            rpoints = map_coordinates(self.data[index - 1, :, :].astype(np.float32), [i, j], **kwargs)
+            rpoints = map_coordinates(self.data[band - 1, :, :].astype(np.float32), [i, j], **kwargs)
 
         rpoints = np.array(rpoints, dtype=np.float32)
         rpoints[np.array(ind_invalid)] = np.nan

--- a/geoutils/raster/satimg.py
+++ b/geoutils/raster/satimg.py
@@ -254,7 +254,7 @@ class SatelliteImage(Raster):  # type: ignore
         self,
         filename_or_dataset: str | RasterType | rio.io.DatasetReader | rio.io.MemoryFile,
         load_data: bool = True,
-        indexes: int | list[int] | None = None,
+        bands: int | list[int] | None = None,
         read_from_fn: bool = True,
         datetime: dt.datetime | None = None,
         tile_name: str | None = None,
@@ -271,7 +271,7 @@ class SatelliteImage(Raster):  # type: ignore
 
         :param filename_or_dataset: The filename of the dataset.
         :param load_data: Load the raster data into the object. Default is True.
-        :param indexes: The band(s) to load into the object. Default is to load all bands.
+        :param bands: The band(s) to load into the object. Default is to load all bands.
         :param read_from_fn: Try to read metadata from the filename
         :param datetime: Provide datetime attribute
         :param tile_name: Provide tile name
@@ -293,7 +293,7 @@ class SatelliteImage(Raster):  # type: ignore
             return
         # Else rely on parent Raster class options (including raised errors)
         else:
-            super().__init__(filename_or_dataset, load_data=load_data, indexes=indexes)
+            super().__init__(filename_or_dataset, load_data=load_data, bands=bands)
 
         # priority to user input
         self._datetime = datetime

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1777,22 +1777,22 @@ class TestRaster:
         itest = int(itest[0])
         jtest = int(jtest[0])
         # Extract the values
-        z_band1 = r_multi.value_at_coords(xtest0, ytest0, index=1)
-        z_band2 = r_multi.value_at_coords(xtest0, ytest0, index=2)
-        z_band3 = r_multi.value_at_coords(xtest0, ytest0, index=3)
+        z_band1 = r_multi.value_at_coords(xtest0, ytest0, band=1)
+        z_band2 = r_multi.value_at_coords(xtest0, ytest0, band=2)
+        z_band3 = r_multi.value_at_coords(xtest0, ytest0, band=3)
         # Compare to the Raster array slice
         assert list(r_multi.data[:, itest, jtest]) == [z_band1, z_band2, z_band3]
 
         # 3/ Masked argument
         r_multi.data[:, itest, jtest] = np.ma.masked
-        z_not_ma = r_multi.value_at_coords(xtest0, ytest0, index=1)
+        z_not_ma = r_multi.value_at_coords(xtest0, ytest0, band=1)
         assert not np.ma.is_masked(z_not_ma)
-        z_ma = r_multi.value_at_coords(xtest0, ytest0, index=1, masked=True)
+        z_ma = r_multi.value_at_coords(xtest0, ytest0, band=1, masked=True)
         assert np.ma.is_masked(z_ma)
 
         # 4/ Window argument
         val_window, z_window = r_multi.value_at_coords(
-            xtest0, ytest0, index=1, window=3, masked=True, return_window=True
+            xtest0, ytest0, band=1, window=3, masked=True, return_window=True
         )
         assert (
             val_window
@@ -1803,7 +1803,7 @@ class TestRaster:
 
         # 5/ Reducer function argument
         val_window2 = r_multi.value_at_coords(
-            xtest0, ytest0, index=1, window=3, masked=True, reducer_function=np.ma.median
+            xtest0, ytest0, band=1, window=3, masked=True, reducer_function=np.ma.median
         )
         assert val_window2 == np.ma.median(r_multi.data[0, itest - 1 : itest + 2, jtest - 1 : jtest + 2])
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -229,8 +229,8 @@ class TestRaster:
         assert r.shape == (r.height, r.width)
         assert r.count == 1
         assert r.count_on_disk == 1
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1,)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1,)
         assert np.array_equal(r.dtypes, ["uint8"])
         assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
         assert np.array_equal(r.res, [30.0, 30.0])
@@ -247,8 +247,8 @@ class TestRaster:
         assert r2.shape == (r2.height, r2.width)
         assert r2.count == 1
         assert r.count_on_disk == 1
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1,)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1,)
         assert np.array_equal(r2.dtypes, ["float32"])
         assert r2.transform == rio.transform.Affine(30.0, 0.0, 627175.0, 0.0, -30.0, 4852085.0)
         assert np.array_equal(r2.res, [30.0, 30.0])
@@ -260,8 +260,8 @@ class TestRaster:
         assert r.is_loaded
         assert r.count == 1
         assert r.count_on_disk == 1
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1,)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1,)
         assert r.data.shape == (r.height, r.width)
 
         # Test 3 - single band, loading data
@@ -269,20 +269,20 @@ class TestRaster:
         assert r.is_loaded
         assert r.count == 1
         assert r.count_on_disk == 1
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1,)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1,)
         assert r.data.shape == (r.height, r.width)
 
         # Test 4 - multiple bands, load all bands
         r = gu.Raster(self.landsat_rgb_path, load_data=True)
         assert r.count == 3
         assert r.count_on_disk == 3
-        assert r.indexes == (
+        assert r.bands == (
             1,
             2,
             3,
         )
-        assert r.indexes_on_disk == (
+        assert r.bands_on_disk == (
             1,
             2,
             3,
@@ -293,16 +293,16 @@ class TestRaster:
         r = gu.Raster(self.landsat_rgb_path, load_data=True, bands=1)
         assert r.count == 1
         assert r.count_on_disk == 3
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1, 2, 3)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1, 2, 3)
         assert r.data.shape == (r.height, r.width)
 
         # Test 6 - multiple bands, load a list of bands
         r = gu.Raster(self.landsat_rgb_path, load_data=True, bands=[2, 3])
         assert r.count == 2
         assert r.count_on_disk == 3
-        assert r.indexes == (1, 2)
-        assert r.indexes_on_disk == (1, 2, 3)
+        assert r.bands == (1, 2)
+        assert r.bands_on_disk == (1, 2, 3)
         assert r.data.shape == (r.count, r.height, r.width)
 
         # Test 7 - load a single band a posteriori calling load()
@@ -310,8 +310,8 @@ class TestRaster:
         r.load(bands=1)
         assert r.count == 1
         assert r.count_on_disk == 3
-        assert r.indexes == (1,)
-        assert r.indexes_on_disk == (1, 2, 3)
+        assert r.bands == (1,)
+        assert r.bands_on_disk == (1, 2, 3)
         assert r.data.shape == (r.height, r.width)
 
         # Test 8 - load a list of band a posteriori calling load()
@@ -319,8 +319,8 @@ class TestRaster:
         r.load(bands=[2, 3])
         assert r.count == 2
         assert r.count_on_disk == 3
-        assert r.indexes == (1, 2)
-        assert r.indexes_on_disk == (1, 2, 3)
+        assert r.bands == (1, 2)
+        assert r.bands_on_disk == (1, 2, 3)
         assert r.data.shape == (r.count, r.height, r.width)
 
         # Check that errors are raised when appropriate
@@ -1776,7 +1776,7 @@ class TestRaster:
         assert z_val == z_val_2
 
         # 2/ Band argument
-        # Get the indexes for the multi-band Raster
+        # Get the band indexes for the multi-band Raster
         r_multi = gu.Raster(self.landsat_rgb_path)
         itest, jtest = r_multi.xy2ij(xtest0, ytest0)
         itest = int(itest[0])

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1170,8 +1170,13 @@ class TestRaster:
         assert np.count_nonzero(r_nodata.data == default_nodata) > 0
 
         # 1 - if no force_source_nodata is set and masked values exist, raises an error
-        with pytest.raises(ValueError, match=re.escape("No nodata set, set one for the raster with self.set_nodata() or use a "
-                                             "temporary one with `force_source_nodata`.")):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "No nodata set, set one for the raster with self.set_nodata() or use a "
+                "temporary one with `force_source_nodata`."
+            ),
+        ):
             _ = r_nodata.reproject(res=r_nodata.res[0] / 2, nodata=0)
 
         # 2 - if no nodata is set and default value conflicts with existing value, a warning is raised


### PR DESCRIPTION
Ongoing

Resolves #441 
Resolves #449 
Resolves #445

Also re-orders some arguments of `reproject` (most used to least used), to make access easier. 

Left to-do:

- [x] Decide if we keep `indexes` and `indexes_on_disk` in the properties, or change those as well?
- [x] Simplify the "checking `nodata`" mess in `reproject`.