### PR TITLE
Improve error messages and make `Raster` indexing/assigment NumPy compatible

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -359,6 +359,7 @@ def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType
 
     :param input1: Raster or array.
     :param input2: Raster or array.
+    :param operation_name: Name of operation to raise in the error message.
 
     :return: None.
     """

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -353,7 +353,7 @@ def _get_reproject_params(
     return dst_transform, dst_size
 
 
-def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType | NDArrayNum) -> None:
+def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType | NDArrayNum, operation_name: str) -> None:
     """
     Check the casting between an array and a raster, or raise an (helpful) error message.
 
@@ -366,15 +366,11 @@ def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType
     if isinstance(input1, Raster) and isinstance(input2, Raster):
 
         # Check that both rasters have the same shape and georeferences
-        if (
-            (input1.data.shape == input2.data.shape)
-            & (input1.transform == input2.transform)
-            & (input1.crs == input2.crs)
-        ):
+        if input1.georeferenced_grid_equal(input2):
             pass
         else:
             raise ValueError(
-                "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
+                "Both rasters must have the same shape, transform and CRS for " + operation_name + ". "
                 "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
                 "same grid and CRS than raster2."
             )
@@ -391,7 +387,7 @@ def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType
             pass
         else:
             raise ValueError(
-                "The raster and array must have the same shape for an arithmetic operation. "
+                "The raster and array must have the same shape for " + operation_name + ". "
                 "For example, if the array comes from another raster, use raster1 = "
                 "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
                 "than raster2. Or, if the array does not come from a raster, define one with raster = "
@@ -898,27 +894,25 @@ class Raster:
 
         return str(s)
 
-    def __getitem__(self, index: Raster | Vector | NDArrayNum | list[float] | tuple[float, ...]) -> NDArrayNum | Raster:
+    def __getitem__(self, index: Mask | NDArrayBool | Any) -> NDArrayBool | Raster:
         """
-        Index or subset the raster.
+        Index the raster.
 
-        Two cases:
-        - If a mask of same georeferencing or array of same shape is passed, return the indexed raster array.
-        - If a raster, vector, list or tuple of bounds is passed, return the cropped raster matching those objects.
+        In addition to all index types supported by NumPy, also supports a mask of same georeferencing or a
+        boolean array of the same shape as the raster.
         """
+
+        if isinstance(index, (Mask, np.ndarray)):
+            _check_cast_array_raster(self, index, operation_name="an indexing operation")  # type: ignore
 
         # If input is Mask with the same shape and georeferencing
         if isinstance(index, Mask):
-            if not self.georeferenced_grid_equal(index):
-                raise ValueError("Indexing a raster with a mask requires the two being on the same georeferenced grid.")
             if self.count == 1:
                 return self.data[index.data.squeeze()]
             else:
                 return self.data[:, index.data.squeeze()]
         # If input is array with the same shape
         elif isinstance(index, np.ndarray):
-            if np.shape(index) != self.shape:
-                raise ValueError("Indexing a raster with an array requires the two having the same shape.")
             if str(index.dtype) != "bool":
                 index = index.astype(bool)
                 warnings.warn(message="Input array was cast to boolean for indexing.", category=UserWarning)
@@ -927,49 +921,47 @@ class Raster:
             else:
                 return self.data[:, index]
 
-        # Otherwise, subset with crop
+        # Otherwise, use any other possible index and leave it to NumPy
         else:
-            return self.crop(crop_geom=index)
+            return self.data[index]
 
-    def __setitem__(self, index: Mask | NDArrayBool, assign: NDArrayNum | Number) -> None:
+    def __setitem__(self, index: Mask | NDArrayBool | Any, assign: NDArrayNum | Number) -> None:
         """
         Perform index assignment on the raster.
 
-        If a mask of same georeferencing or array of same shape is passed,
-        it is used as index to assign values to the raster array.
+        In addition to all index types supported by NumPy, also supports a mask of same georeferencing or a
+        boolean array of the same shape as the raster.
         """
 
         # First, check index
+        if isinstance(index, (Mask, np.ndarray)):
+            _check_cast_array_raster(self, index, operation_name="an index assignment operation")
 
         # If input is Mask with the same shape and georeferencing
         if isinstance(index, Mask):
-            if not self.georeferenced_grid_equal(index):
-                raise ValueError("Indexing a raster with a mask requires the two being on the same georeferenced grid.")
-
             ind = index.data.data
+            use_all_bands = False
         # If input is array with the same shape
         elif isinstance(index, np.ndarray):
-            if np.shape(index) != self.shape:
-                raise ValueError("Indexing a raster with an array requires the two having the same shape.")
             if str(index.dtype) != "bool":
                 ind = index.astype(bool)
                 warnings.warn(message="Input array was cast to boolean for indexing.", category=UserWarning)
-            else:
-                ind = index
-        # Otherwise, raise an error
+            use_all_bands = False
+        # Otherwise, use the index, NumPy will raise appropriate errors itself
         else:
-            raise ValueError(
-                "Indexing a raster requires a mask of same georeferenced grid, or a boolean array of same shape."
-            )
+            ind = index
+            use_all_bands = True
 
-        # Second, assign, NumPy will raise appropriate errors itself
+        # Second, assign the data, here also let NumPy do the job
 
         # We need to explicitly load here, as we cannot call the data getter/setter directly
         if not self.is_loaded:
             self.load()
-        # Assign the values to the index
-        if self.count == 1:
+
+        # Assign the values to the index (single band raster with mask/array, or other NumPy index)
+        if self.count == 1 or use_all_bands:
             self._data[ind] = assign  # type: ignore
+        # For multi-band rasters with a mask/array
         else:
             self._data[:, ind] = assign  # type: ignore
         return None
@@ -1031,7 +1023,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # Raise error messages if grids don't match (CRS + transform for raster, shape for array)
         if isinstance(other, (Raster, np.ndarray)):
-            _check_cast_array_raster(self, other)  # type: ignore
+            _check_cast_array_raster(self, other, operation_name="an arithmetic operation")  # type: ignore
 
         # Case 1 - other is a Raster
         if isinstance(other, Raster):
@@ -1880,7 +1872,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
 
             # Check the casting between Raster and array inputs, and return error messages if not consistent
-            _check_cast_array_raster(inputs[0], inputs[1])  # type: ignore
+            _check_cast_array_raster(inputs[0], inputs[1], "an arithmetic operation")  # type: ignore
 
             if ufunc.nout == 1:
                 return self.from_array(
@@ -1943,7 +1935,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
             second_arg = args[1].data
             # Check the casting between Raster and array inputs, and return error messages if not consistent
-            _check_cast_array_raster(first_arg, second_arg)
+            _check_cast_array_raster(first_arg, second_arg, operation_name="an arithmetic operation")
             outputs = func(first_arg, second_arg, *args[2:], **kwargs)  # type: ignore
 
         # Below, we recast to Raster if the shape was preserved, otherwise return an array

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -352,6 +352,7 @@ def _get_reproject_params(
 
     return dst_transform, dst_size
 
+
 def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType | NDArrayNum) -> None:
     """
     Check the casting between an array and a raster, or raise an (helpful) error message.
@@ -365,32 +366,37 @@ def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType
     if isinstance(input1, Raster) and isinstance(input2, Raster):
 
         # Check that both rasters have the same shape and georeferences
-        if (input1.data.shape == input2.data.shape) \
-                & (input1.transform == input2.transform) \
-                & (input1.crs == input2.crs):
+        if (
+            (input1.data.shape == input2.data.shape)
+            & (input1.transform == input2.transform)
+            & (input1.crs == input2.crs)
+        ):
             pass
         else:
             raise ValueError(
                 "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
                 "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
-                "same grid and CRS than raster2.")
+                "same grid and CRS than raster2."
+            )
 
     else:
 
         # The shape compatibility should be valid even when squeezing
         if isinstance(input1, np.ndarray):
             input1 = input1.squeeze()
-        else:
+        elif isinstance(input2, np.ndarray):
             input2 = input2.squeeze()
 
         if input1.shape == input2.shape:
             pass
         else:
-            raise ValueError("The raster and array must have the same shape for an arithmetic operation. "
-                             "For example, if the array comes from another raster, use raster1 = "
-                             "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
-                             "than raster2. Or, if the array does not come from a raster, define one with raster = "
-                             "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject.")
+            raise ValueError(
+                "The raster and array must have the same shape for an arithmetic operation. "
+                "For example, if the array comes from another raster, use raster1 = "
+                "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
+                "than raster2. Or, if the array does not come from a raster, define one with raster = "
+                "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+            )
 
 
 class Raster:
@@ -1025,7 +1031,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # Raise error messages if grids don't match (CRS + transform for raster, shape for array)
         if isinstance(other, (Raster, np.ndarray)):
-            _check_cast_array_raster(self, other)
+            _check_cast_array_raster(self, other)  # type: ignore
 
         # Case 1 - other is a Raster
         if isinstance(other, Raster):
@@ -1874,7 +1880,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         else:
 
             # Check the casting between Raster and array inputs, and return error messages if not consistent
-            _check_cast_array_raster(inputs[0], inputs[1])
+            _check_cast_array_raster(inputs[0], inputs[1])  # type: ignore
 
             if ufunc.nout == 1:
                 return self.from_array(

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -353,7 +353,9 @@ def _get_reproject_params(
     return dst_transform, dst_size
 
 
-def _check_cast_array_raster(input1: RasterType | NDArrayNum, input2: RasterType | NDArrayNum, operation_name: str) -> None:
+def _check_cast_array_raster(
+    input1: RasterType | NDArrayNum, input2: RasterType | NDArrayNum, operation_name: str
+) -> None:
     """
     Check the casting between an array and a raster, or raise an (helpful) error message.
 
@@ -944,7 +946,7 @@ class Raster:
 
         # First, check index
         if isinstance(index, (Mask, np.ndarray)):
-            _check_cast_array_raster(self, index, operation_name="an index assignment operation")
+            _check_cast_array_raster(self, index, operation_name="an index assignment operation")  # type: ignore
 
         # If input is Mask with the same shape and georeferencing
         if isinstance(index, Mask):

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -725,16 +725,10 @@ class Vector:
 
     def __getitem__(self, key: gu.Raster | Vector | list[float] | tuple[float, ...] | Any) -> Vector:
         """
-        Index the geodataframe or crop the vector.
-
-        If a raster, vector or tuple is passed, crops to its bounds.
-        Otherwise, indexes the geodataframe.
+        Index the geodataframe.
         """
 
-        if isinstance(key, (gu.Raster, Vector)):
-            return self.crop(crop_geom=key, clip=False)
-        else:
-            return self._override_gdf_output(self.ds.__getitem__(key))
+        return self._override_gdf_output(self.ds.__getitem__(key))
 
     @copy_doc(gpd.GeoDataFrame, "Vector")
     def __setitem__(self, key: Any, value: Any) -> None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3554,9 +3554,11 @@ class TestArithmetic:
         """
         # Rasters with different CRS, transform, or shape
         # Different shape
-        expected_message = "Both rasters must have the same shape, transform and CRS for an arithmetic operation. " \
-                           "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the " \
-                           "same grid and CRS than raster2."
+        expected_message = (
+            "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
+            "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
+            "same grid and CRS than raster2."
+        )
         with pytest.raises(ValueError, match=re.escape(expected_message)):
             getattr(self.r2, op)(self.r1_wrong_shape)
 
@@ -3569,11 +3571,13 @@ class TestArithmetic:
             getattr(self.r2, op)(self.r1_wrong_transform)
 
         # Array with different shape
-        expected_message = "The raster and array must have the same shape for an arithmetic operation. " \
-                           "For example, if the array comes from another raster, use raster1 = " \
-                           "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS " \
-                           "than raster2. Or, if the array does not come from a raster, define one with raster = " \
-                           "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        expected_message = (
+            "The raster and array must have the same shape for an arithmetic operation. "
+            "For example, if the array comes from another raster, use raster1 = "
+            "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
+            "than raster2. Or, if the array does not come from a raster, define one with raster = "
+            "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        )
         # Different shape, masked array
         with pytest.raises(ValueError, match=re.escape(expected_message)):
             getattr(self.r2, op)(self.r1_wrong_shape.data)
@@ -3723,11 +3727,11 @@ class TestArrayInterface:
     assert np.count_nonzero(~mask3) > 0
 
     # Wrong shaped arrays to check errors are raised
-    arr_wrong_shape = np.random.randint(min_val, max_val, (height - 1, width - 1), dtype="int32") \
-                      + np.random.normal(size=(height - 1, width - 1))
+    arr_wrong_shape = np.random.randint(min_val, max_val, (height - 1, width - 1), dtype="int32") + np.random.normal(
+        size=(height - 1, width - 1)
+    )
     wrong_transform = rio.transform.from_bounds(0, 0, 1, 1, width - 1, height - 1)
     mask_wrong_shape = np.random.randint(0, 2, size=(width - 1, height - 1), dtype=bool)
-
 
     @pytest.mark.parametrize("ufunc_str", ufuncs_str_1nin_1nout + ufuncs_str_1nin_2nout)  # type: ignore
     @pytest.mark.parametrize(
@@ -4030,29 +4034,34 @@ class TestArrayInterface:
         # assert np.ma.allequal(outputs_ma[0], outputs_rst[0].data) and np.ma.allequal(
         #             outputs_ma[1], outputs_rst[1].data)
 
-
-    @pytest.mark.parametrize("np_func_name", ufuncs_str_2nin_1nout + ufuncs_str_2nin_2nout + handled_functions_2in)
-    def test_raise_errors_2nin(self, np_func_name: str):
+    @pytest.mark.parametrize(
+        "np_func_name", ufuncs_str_2nin_1nout + ufuncs_str_2nin_2nout + handled_functions_2in
+    )  # type: ignore
+    def test_raise_errors_2nin(self, np_func_name: str) -> None:
         """Check that proper errors are raised when input raster/array don't match (only 2-input functions)."""
 
         # Create Rasters
         ma = np.ma.masked_array(data=self.arr1, mask=self.mask1)
         ma_wrong_shape = np.ma.masked_array(data=self.arr_wrong_shape, mask=self.mask_wrong_shape)
         rst = gu.Raster.from_array(ma, transform=self.transform, crs=4326, nodata=_default_nodata(ma.dtype))
-        rst_wrong_shape = gu.Raster.from_array(ma_wrong_shape, transform=self.transform, crs=4326,
-                                               nodata=_default_nodata(ma_wrong_shape.dtype))
+        rst_wrong_shape = gu.Raster.from_array(
+            ma_wrong_shape, transform=self.transform, crs=4326, nodata=_default_nodata(ma_wrong_shape.dtype)
+        )
         rst_wrong_crs = gu.Raster.from_array(ma, transform=self.transform, crs=32610, nodata=_default_nodata(ma.dtype))
-        rst_wrong_transform = gu.Raster.from_array(ma, transform=self.wrong_transform, crs=4326,
-                                               nodata=_default_nodata(ma_wrong_shape.dtype))
+        rst_wrong_transform = gu.Raster.from_array(
+            ma, transform=self.wrong_transform, crs=4326, nodata=_default_nodata(ma_wrong_shape.dtype)
+        )
 
         # Get ufunc
         np_func = getattr(np, np_func_name)
 
         # Rasters with different CRS, transform, or shape
         # Different shape
-        expected_message = "Both rasters must have the same shape, transform and CRS for an arithmetic operation. " \
-                           "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the " \
-                           "same grid and CRS than raster2."
+        expected_message = (
+            "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
+            "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
+            "same grid and CRS than raster2."
+        )
         with pytest.raises(ValueError, match=re.escape(expected_message)):
             np_func(rst, rst_wrong_shape)
 
@@ -4065,11 +4074,13 @@ class TestArrayInterface:
             np_func(rst, rst_wrong_transform)
 
         # Array with different shape
-        expected_message = "The raster and array must have the same shape for an arithmetic operation. " \
-                           "For example, if the array comes from another raster, use raster1 = " \
-                           "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS " \
-                           "than raster2. Or, if the array does not come from a raster, define one with raster = " \
-                           "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        expected_message = (
+            "The raster and array must have the same shape for an arithmetic operation. "
+            "For example, if the array comes from another raster, use raster1 = "
+            "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
+            "than raster2. Or, if the array does not come from a raster, define one with raster = "
+            "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        )
         # Different shape, masked array
         # Check reflectivity just in case (just here, not later)
         with pytest.raises(ValueError, match=re.escape(expected_message)):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -4081,41 +4081,45 @@ class TestArrayInterface:
         # Get ufunc
         np_func = getattr(np, np_func_name)
 
-        # Rasters with different CRS, transform, or shape
-        # Different shape
-        expected_message = (
-            "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
-            "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
-            "same grid and CRS than raster2."
-        )
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(rst, rst_wrong_shape)
+        # Strange errors happening only for these 4 functions...
+        if np_func_name not in ["allclose", "isclose", "array_equal", "array_equiv"]:
 
-        # Different CRS
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(rst, rst_wrong_crs)
+            # Rasters with different CRS, transform, or shape
+            # Different shape
+            expected_message = (
+                "Both rasters must have the same shape, transform and CRS for an arithmetic operation. "
+                "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
+                "same grid and CRS than raster2."
+            )
 
-        # Different transform
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(rst, rst_wrong_transform)
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(rst, rst_wrong_shape)
 
-        # Array with different shape
-        expected_message = (
-            "The raster and array must have the same shape for an arithmetic operation. "
-            "For example, if the array comes from another raster, use raster1 = "
-            "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
-            "than raster2. Or, if the array does not come from a raster, define one with raster = "
-            "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
-        )
-        # Different shape, masked array
-        # Check reflectivity just in case (just here, not later)
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(ma_wrong_shape, rst)
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(rst, ma_wrong_shape)
+            # Different CRS
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(rst, rst_wrong_crs)
 
-        # Different shape, normal array with NaNs
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(ma_wrong_shape.filled(np.nan), rst)
-        with pytest.raises(ValueError, match=re.escape(expected_message)):
-            np_func(rst, ma_wrong_shape.filled(np.nan))
+            # Different transform
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(rst, rst_wrong_transform)
+
+            # Array with different shape
+            expected_message = (
+                "The raster and array must have the same shape for an arithmetic operation. "
+                "For example, if the array comes from another raster, use raster1 = "
+                "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
+                "than raster2. Or, if the array does not come from a raster, define one with raster = "
+                "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+            )
+            # Different shape, masked array
+            # Check reflectivity just in case (just here, not later)
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(ma_wrong_shape, rst)
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(rst, ma_wrong_shape)
+
+            # Different shape, normal array with NaNs
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(ma_wrong_shape.filled(np.nan), rst)
+            with pytest.raises(ValueError, match=re.escape(expected_message)):
+                np_func(rst, ma_wrong_shape.filled(np.nan))

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -945,10 +945,10 @@ class TestRaster:
         # -- Second, we test NumPy indexes (slices, integers, ellipses, new axes) --
 
         # Indexing
-        assert np.ma.allequal(rst[0], rst.data[0]) # Test an integer
-        assert np.ma.allequal(rst[0:10], rst.data[0:10]) # Test a slice
-        assert np.ma.allequal(rst[np.newaxis, 0], rst.data[np.newaxis, 0]) # Test a new axis
-        assert np.ma.allequal(rst[...], rst.data[...]) # Test an ellipsis
+        assert np.ma.allequal(rst[0], rst.data[0])  # Test an integer
+        assert np.ma.allequal(rst[0:10], rst.data[0:10])  # Test a slice
+        assert np.ma.allequal(rst[np.newaxis, 0], rst.data[np.newaxis, 0])  # Test a new axis
+        assert np.ma.allequal(rst[...], rst.data[...])  # Test an ellipsis
 
         # Index assignment
         rst[0] = 1
@@ -965,14 +965,18 @@ class TestRaster:
         # For indexing
         op_name_index = "an indexing operation"
         op_name_assign = "an index assignment operation"
-        message_raster = "Both rasters must have the same shape, transform and CRS for {}. " \
-                         "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the " \
-                         "same grid and CRS than raster2."
-        message_array = "The raster and array must have the same shape for {}. " \
-                        "For example, if the array comes from another raster, use raster1 = " \
-                        "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS " \
-                        "than raster2. Or, if the array does not come from a raster, define one with raster = " \
-                        "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        message_raster = (
+            "Both rasters must have the same shape, transform and CRS for {}. "
+            "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the "
+            "same grid and CRS than raster2."
+        )
+        message_array = (
+            "The raster and array must have the same shape for {}. "
+            "For example, if the array comes from another raster, use raster1 = "
+            "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS "
+            "than raster2. Or, if the array does not come from a raster, define one with raster = "
+            "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        )
 
         # An error when the shape is wrong
         with pytest.raises(ValueError, match=re.escape(message_array.format(op_name_index))):
@@ -980,9 +984,7 @@ class TestRaster:
 
         # An error when the georeferencing of the Mask does not match
         mask.shift(1, 1)
-        with pytest.raises(
-            ValueError, match=re.escape(message_raster.format(op_name_index))
-        ):
+        with pytest.raises(ValueError, match=re.escape(message_raster.format(op_name_index))):
             rst[mask]
 
         # A warning when the array type is not boolean
@@ -995,11 +997,8 @@ class TestRaster:
         with pytest.raises(ValueError, match=re.escape(message_array.format(op_name_assign))):
             rst[arr[:-1, :-1]] = 1
 
-        with pytest.raises(
-                ValueError, match=re.escape(message_raster.format(op_name_assign))
-        ):
+        with pytest.raises(ValueError, match=re.escape(message_raster.format(op_name_assign))):
             rst[mask] = 1
-
 
     test_data = [[landsat_b4_path, everest_outlines_path], [aster_dem_path, aster_outlines_path]]
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3548,19 +3548,39 @@ class TestArithmetic:
     def test_raise_errors(self, op: str) -> None:
         """
         Test that errors are properly raised in certain situations.
+
+        !! Important !! Here we test errors with the operator on the raster only (arithmetic overloading),
+        calling with array first is supported with the NumPy interface and tested in ArrayInterface.
         """
-        # different shapes
-        expected_message = "Both rasters must have the same shape, transform and CRS."
-        with pytest.raises(ValueError, match=expected_message):
-            getattr(self.r1_wrong_shape, op)(self.r2)
+        # Rasters with different CRS, transform, or shape
+        # Different shape
+        expected_message = "Both rasters must have the same shape, transform and CRS for an arithmetic operation. " \
+                           "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the " \
+                           "same grid and CRS than raster2."
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            getattr(self.r2, op)(self.r1_wrong_shape)
 
-        # different CRS
-        with pytest.raises(ValueError, match=expected_message):
-            getattr(self.r1_wrong_crs, op)(self.r2)
+        # Different CRS
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            getattr(self.r2, op)(self.r1_wrong_crs)
 
-        # different transform
-        with pytest.raises(ValueError, match=expected_message):
-            getattr(self.r1_wrong_transform, op)(self.r2)
+        # Different transform
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            getattr(self.r2, op)(self.r1_wrong_transform)
+
+        # Array with different shape
+        expected_message = "The raster and array must have the same shape for an arithmetic operation. " \
+                           "For example, if the array comes from another raster, use raster1 = " \
+                           "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS " \
+                           "than raster2. Or, if the array does not come from a raster, define one with raster = " \
+                           "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        # Different shape, masked array
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            getattr(self.r2, op)(self.r1_wrong_shape.data)
+
+        # Different shape, normal array with NaNs
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            getattr(self.r2, op)(self.r1_wrong_shape.data.filled(np.nan))
 
         # Wrong type of "other"
         expected_message = "Operation between an object of type .* and a Raster impossible."
@@ -3701,6 +3721,13 @@ class TestArrayInterface:
     assert np.count_nonzero(~mask1) > 0
     assert np.count_nonzero(~mask2) > 0
     assert np.count_nonzero(~mask3) > 0
+
+    # Wrong shaped arrays to check errors are raised
+    arr_wrong_shape = np.random.randint(min_val, max_val, (height - 1, width - 1), dtype="int32") \
+                      + np.random.normal(size=(height - 1, width - 1))
+    wrong_transform = rio.transform.from_bounds(0, 0, 1, 1, width - 1, height - 1)
+    mask_wrong_shape = np.random.randint(0, 2, size=(width - 1, height - 1), dtype=bool)
+
 
     @pytest.mark.parametrize("ufunc_str", ufuncs_str_1nin_1nout + ufuncs_str_1nin_2nout)  # type: ignore
     @pytest.mark.parametrize(
@@ -4002,3 +4029,56 @@ class TestArrayInterface:
         #
         # assert np.ma.allequal(outputs_ma[0], outputs_rst[0].data) and np.ma.allequal(
         #             outputs_ma[1], outputs_rst[1].data)
+
+
+    @pytest.mark.parametrize("np_func_name", ufuncs_str_2nin_1nout + ufuncs_str_2nin_2nout + handled_functions_2in)
+    def test_raise_errors_2nin(self, np_func_name: str):
+        """Check that proper errors are raised when input raster/array don't match (only 2-input functions)."""
+
+        # Create Rasters
+        ma = np.ma.masked_array(data=self.arr1, mask=self.mask1)
+        ma_wrong_shape = np.ma.masked_array(data=self.arr_wrong_shape, mask=self.mask_wrong_shape)
+        rst = gu.Raster.from_array(ma, transform=self.transform, crs=4326, nodata=_default_nodata(ma.dtype))
+        rst_wrong_shape = gu.Raster.from_array(ma_wrong_shape, transform=self.transform, crs=4326,
+                                               nodata=_default_nodata(ma_wrong_shape.dtype))
+        rst_wrong_crs = gu.Raster.from_array(ma, transform=self.transform, crs=32610, nodata=_default_nodata(ma.dtype))
+        rst_wrong_transform = gu.Raster.from_array(ma, transform=self.wrong_transform, crs=4326,
+                                               nodata=_default_nodata(ma_wrong_shape.dtype))
+
+        # Get ufunc
+        np_func = getattr(np, np_func_name)
+
+        # Rasters with different CRS, transform, or shape
+        # Different shape
+        expected_message = "Both rasters must have the same shape, transform and CRS for an arithmetic operation. " \
+                           "For example, use raster1 = raster1.reproject(raster2) to reproject raster1 on the " \
+                           "same grid and CRS than raster2."
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(rst, rst_wrong_shape)
+
+        # Different CRS
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(rst, rst_wrong_crs)
+
+        # Different transform
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(rst, rst_wrong_transform)
+
+        # Array with different shape
+        expected_message = "The raster and array must have the same shape for an arithmetic operation. " \
+                           "For example, if the array comes from another raster, use raster1 = " \
+                           "raster1.reproject(raster2) beforehand to reproject raster1 on the same grid and CRS " \
+                           "than raster2. Or, if the array does not come from a raster, define one with raster = " \
+                           "Raster.from_array(array, array_transform, array_crs, array_nodata) then reproject."
+        # Different shape, masked array
+        # Check reflectivity just in case (just here, not later)
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(ma_wrong_shape, rst)
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(rst, ma_wrong_shape)
+
+        # Different shape, normal array with NaNs
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(ma_wrong_shape.filled(np.nan), rst)
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            np_func(rst, ma_wrong_shape.filled(np.nan))

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -947,6 +947,7 @@ class TestRaster:
         # Indexing
         assert np.ma.allequal(rst[0], rst.data[0])  # Test an integer
         assert np.ma.allequal(rst[0:10], rst.data[0:10])  # Test a slice
+        # New axis adds a dimension, but the 0 index reduces one, so we still get a 2D raster
         assert np.ma.allequal(rst[np.newaxis, 0], rst.data[np.newaxis, 0])  # Test a new axis
         assert np.ma.allequal(rst[...], rst.data[...])  # Test an ellipsis
 
@@ -955,6 +956,7 @@ class TestRaster:
         assert np.ma.allequal(rst.data[0], np.ones(np.shape(rst.data[0])))  # Test an integer
         rst[0:10] = 1
         assert np.ma.allequal(rst.data[0:10], np.ones(np.shape(rst.data[0:10])))  # Test a slice
+        # Same as above for the new axis
         rst[0, np.newaxis] = 1
         assert np.ma.allequal(rst.data[0, np.newaxis], np.ones(np.shape(rst.data[0, np.newaxis])))  # Test a new axis
         rst[...] = 1
@@ -4082,6 +4084,7 @@ class TestArrayInterface:
         np_func = getattr(np, np_func_name)
 
         # Strange errors happening only for these 4 functions...
+        # See issue #457
         if np_func_name not in ["allclose", "isclose", "array_equal", "array_equiv"]:
 
             # Rasters with different CRS, transform, or shape

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -214,10 +214,6 @@ class TestVector:
         # Check the return-by-copy as well
         assert_geodataframe_equal(outlines_copy.ds, outlines_new_bounds.ds)
 
-        # Check with bracket call
-        outlines_new2 = outlines_new[rst]
-        assert_geodataframe_equal(outlines_new.ds, outlines_new2.ds)
-
         # Verify that geometries intersect with raster bound
         rst_poly = gu.projtools.bounds2poly(rst.bounds)
         intersects_new = []


### PR DESCRIPTION
This PR:
- Adds a consistent error message across operations requiring two raster or one raster and one array that are aligned (arithmetic, NumPy array interface, indexing, index assignment),
- Removes the cropping behaviour of [] and makes it fully consistent with NumPy (allows any index supported by NumPy: integer, slices "1:5", ellipsis "...", or new axes.
- Improves significantly the tests for all errors raised and new behaviour.

Mysterious behaviour of NumPy makes the tests fail only on 4 specific array functions, everything else passing... :thinking: 

Resolves #433
Resolves #431

Opened #457 