### PR TITLE
Two fixes in Raster.reproject

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -334,9 +334,9 @@ def _get_reproject_params(
             dst_size = grid_size
 
         else:
-            # Otherwise, need to calculate the new output size, rounded up
-            ref_win = rio.windows.from_bounds(*list(bounds), tmp_transform)
-            dst_size = (int(np.ceil(ref_win.width)), int(np.ceil(ref_win.height)))
+            # Otherwise, need to calculate the new output size, rounded to nearest integer
+            ref_win = rio.windows.from_bounds(*list(bounds), tmp_transform).round_lengths()
+            dst_size = (int(ref_win.width), int(ref_win.height))
 
             if res is not None:
                 # In this case, we force output resolution

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1381,6 +1381,13 @@ class TestRaster:
         assert r_test.crs.to_epsg() == 4326
 
         # -- Additional tests --
+        # First, make sure dst_bounds extend beyond current extent to create nodata
+        dst_bounds = rio.coords.BoundingBox(
+            left=bounds[0], bottom=bounds[1] - r.res[0], right=bounds[2] + 2 * r.res[1], top=bounds[3]
+        )
+        r_test = r.reproject(bounds=dst_bounds)
+        assert np.count_nonzero(r_test.data.mask) > 0
+
         # If nodata falls outside the original image range, check range is preserved (with nearest interpolation)
         r_float = r.astype("float32")  # type: ignore
         if r_float.nodata is None:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1390,17 +1390,17 @@ class TestRaster:
 
         # If nodata falls outside the original image range, check range is preserved (with nearest interpolation)
         r_float = r.astype("float32")  # type: ignore
-        if r_float.nodata is None:
+        if (r_float.nodata < np.min(r_float)) or (r_float.nodata > np.max(r_float)):
             r_test = r_float.reproject(bounds=dst_bounds, resampling="nearest")
-            assert r_test.nodata == -99999
-            assert np.min(r_test.data.data) == r_test.nodata
-            assert np.min(r_test.data) == np.min(r_float.data)
+            assert r_test.nodata == r_float.nodata
+            assert np.count_nonzero(r_test.data.data == r_test.nodata) > 0  # Some values should be set to nodata
+            assert np.min(r_test.data) == np.min(r_float.data)  # But min and max should not be affected
             assert np.max(r_test.data) == np.max(r_float.data)
 
         # Check that nodata works as expected
         r_test = r_float.reproject(bounds=dst_bounds, nodata=9999)
         assert r_test.nodata == 9999
-        assert np.max(r_test.data.data) == r_test.nodata
+        assert np.count_nonzero(r_test.data.data == r_test.nodata) > 0
 
         # Test that reproject works the same whether data is already loaded or not
         assert r.is_loaded


### PR DESCRIPTION
- solves #453 
- fixes an issue with reproject not enforcing bounds in some cases due to floating point precision (see [issue](https://github.com/rasterio/rasterio/issues/3016) raised in rasterio). Extracted window need to be rounded to nearest integer rather than up.

Weirdly the second change does not make any difference for tests. I guess in all tested cases, the rounding does not make any difference. This was probably an edge case that I encountered.
Not sure if there is any test to add for this...