### PR TITLE
Update documentation for `v0.1`: Index, Quick start and Feature overview

### DIFF
--- a/doc/source/about_geoutils.md
+++ b/doc/source/about_geoutils.md
@@ -114,11 +114,11 @@ header-rows: 1
         :language: python
         :lines: 10-25
     ```
-    
+
   - ```{eval-rst}
     .. literalinclude:: code/about_geoutils_sidebyside_vector_geopandas.py
         :language: python
         :lines: 10-40
     ```
-    
+
 `````

--- a/doc/source/about_geoutils.md
+++ b/doc/source/about_geoutils.md
@@ -87,78 +87,16 @@ header-rows: 1
 ---
 * - GeoUtils
   - Rasterio
-* - ```python
-    import geoutils as gu
-
-    # Opening of two rasters
-    rast1 = gu.Raster("myraster1.tif")
-    rast2 = gu.Raster("myraster2.tif")
-
-    # Reproject 1 to match 2
-    # (raster 2 not loaded, only metadata)
-    rast1_reproj = rast1.reproject(
-        dst_ref = rast2
-        )
-
-    # Array interfacing and implicit loading
-    # (raster 2 loads implicitly)
-    rast_result = (1 + rast2) / rast1_reproj
-
-    # Saving
-    rast_result.save("myresult.tif")
+* - ```{eval-rst}
+    .. literalinclude:: code/about_geoutils_sidebyside_raster_geoutils.py
+        :language: python
+        :lines: 12-29
     ```
 
-  - ```python
-    import rasterio as rio
-    import numpy as np
-
-    # Opening of two rasters
-    rast1 = rio.io.DatasetReader("myraster1.tif")
-    rast2 = rio.io.DatasetReader("myraster2.tif")
-
-    # Equivalent of a match-reference reprojection
-    # (returns an array, not a raster-type object)
-    arr1_reproj, _ = rio.warp.reproject(
-        source = rast1.read(),
-        destination = np.ones(rast2.shape),
-        src_transform = rast1.transform,
-        src_crs = rast1.crs,
-        src_nodata = rast1.nodata,
-        dst_transform = rast2.transform,
-        dst_crs = rast2.crs,
-        dst_nodata = rast2.nodata,
-        )
-
-    # Equivalent of array interfacing
-    # (ensuring nodata and dtypes are rightly
-    # propagated through masked arrays)
-    ma1_reproj = np.ma.MaskedArray(
-        data = arr1_reproj,
-        mask = (arr1_reproj == rast2.nodata)
-        )
-    ma2 = rast2.read(masked = True)
-    ma_result = (1 + ma2) / (ma1_reproj)
-
-    # Equivalent of saving
-    # (requires to define a logical
-    # nodata for the data type)
-    out_nodata = custom_func(
-        dtype = ma_result.dtype,
-        nodata1 = rast1.nodata,
-        nodata2 = rast2.nodata
-        )
-    with rio.open(
-        "myresult.tif",
-        mode = "w",
-        height = rast2.height,
-        width = rast2.width,
-        count = rast1.count,
-        dtype = ma_result.dtype,
-        crs = rast2.crs,
-        transform = rast2.transform,
-        nodata = rast2.nodata,
-    ) as dst:
-        dst.write(ma_result.filled(out_nodata))
+  - ```{eval-rst}
+    .. literalinclude:: code/about_geoutils_sidebyside_raster_rasterio.py
+        :language: python
+        :lines: 10-62
     ```
 `````
 
@@ -171,57 +109,16 @@ header-rows: 1
 ---
 * - GeoUtils
   - GeoPandas (and Rasterio)
-* - ```python
-    import geoutils as gu
-
-    # Opening a vector and a raster
-    vect = gu.Vector("myvector.shp")
-    rast = gu.Raster("myraster.tif")
-
-    # Metric buffering
-    vect_buff = vect.buffer(distance = 100)
-
-    # Create a mask on the raster grid
-    # (raster not loaded, only metadata)
-    mask = vect_buff.create_mask(
-        dst_ref = rast
-        )
-
-    # Index raster values on mask
-    # (raster loads implicitly)
-    values = rast[mask]
+* - ```{eval-rst}
+    .. literalinclude:: code/about_geoutils_sidebyside_vector_geoutils.py
+        :language: python
+        :lines: 10-25
     ```
-
-  - ```python
-    import geopandas as gpd
-    import rasterio as rio
-
-    # Opening a vector and a raster
-    df = gpd.read_file("myvector.tif")
-    rast2 = rio.io.DatasetReader("myraster.tif")
-
-    # Equivalent of a metric buffering
-    # (while keeping a frame object)
-    gs_m_crs = df.to_crs(df.estimate_utm_crs())
-    gs_m_crs_buff = gs_m_crs.buffer(distance = 100)
-    gs_buff = gs_m_crs_buff.to_crs(df.crs)
-    df_buff = gpd.GeoDataFrame(
-        geometry = gs_buff
-        )
-
-    # Equivalent of creating a rasterized mask
-    # (ensuring CRS are similar)
-    df_buff = df_buff.to_crs(rast2.crs)
-    mask = features.rasterize(
-        shapes = gdf.geometry,
-        fill = 0,
-        out_shape = rast2.shape,
-        transform = rast2.transform,
-        default_value = 1,
-        dtype = "uint8"
-        )
-    mask = mask.astype("bool")
-
-    # Equivalent of indexing with mask
-    values = rast2.read(1, masked = True)[mask]
+    
+  - ```{eval-rst}
+    .. literalinclude:: code/about_geoutils_sidebyside_vector_geopandas.py
+        :language: python
+        :lines: 10-40
+    ```
+    
 `````

--- a/doc/source/about_geoutils.md
+++ b/doc/source/about_geoutils.md
@@ -42,7 +42,7 @@ In particular, GeoUtils:
 
 
 ```{note}
-More on these core features of GeoUtils in the {ref}`quick-start`, or {ref}`core-index` for details.
+More on these core features of GeoUtils in the {ref}`feature-overview`, or {ref}`core-index` for details.
 ```
 
 ## Why the need for GeoUtils?

--- a/doc/source/cli.md
+++ b/doc/source/cli.md
@@ -1,7 +1,7 @@
 (cli)=
-# Command Line Interface
+# Command line interface
 
-This page lists all CLI functionalities of GeoUtils.
+This page lists all command line interface (CLI) functionalities of GeoUtils.
 These commands can be run directly from a terminal, without having to launch a Python console.
 
 ## geoviewer.py

--- a/doc/source/code/about_geoutils_sidebyside_raster_geoutils.py
+++ b/doc/source/code/about_geoutils_sidebyside_raster_geoutils.py
@@ -1,0 +1,36 @@
+####
+# Part not shown in the doc, to get data files ready
+import geoutils
+landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
+landsat_b4_crop_path = geoutils.examples.get_path("everest_landsat_b4_cropped")
+geoutils.Raster(landsat_b4_path).save("myraster1.tif")
+geoutils.Raster(landsat_b4_crop_path).save("myraster2.tif")
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, nodata must be set.*")
+####
+
+import geoutils as gu
+
+# Opening of two rasters
+rast1 = gu.Raster("myraster1.tif")
+rast2 = gu.Raster("myraster2.tif")
+
+# Reproject 1 to match 2
+# (raster 2 not loaded, only metadata)
+rast1_reproj = rast1.reproject(
+    ref=rast2
+)
+
+# Array interfacing and implicit loading
+# (raster 2 loads implicitly)
+rast_result = (1 + rast2) / rast1_reproj
+
+# Saving
+rast_result.save("myresult.tif")
+
+####
+# Part not shown in the docs, to clean up
+import os
+for file in ["myraster1.tif", "myraster2.tif", "myresult.tif"]:
+    os.remove(file)
+####

--- a/doc/source/code/about_geoutils_sidebyside_raster_geoutils.py
+++ b/doc/source/code/about_geoutils_sidebyside_raster_geoutils.py
@@ -1,11 +1,13 @@
 ####
 # Part not shown in the doc, to get data files ready
 import geoutils
+
 landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
 landsat_b4_crop_path = geoutils.examples.get_path("everest_landsat_b4_cropped")
 geoutils.Raster(landsat_b4_path).save("myraster1.tif")
 geoutils.Raster(landsat_b4_crop_path).save("myraster2.tif")
 import warnings
+
 warnings.filterwarnings("ignore", category=UserWarning, message="For reprojection, nodata must be set.*")
 ####
 
@@ -17,9 +19,7 @@ rast2 = gu.Raster("myraster2.tif")
 
 # Reproject 1 to match 2
 # (raster 2 not loaded, only metadata)
-rast1_reproj = rast1.reproject(
-    ref=rast2
-)
+rast1_reproj = rast1.reproject(ref=rast2)
 
 # Array interfacing and implicit loading
 # (raster 2 loads implicitly)
@@ -31,6 +31,7 @@ rast_result.save("myresult.tif")
 ####
 # Part not shown in the docs, to clean up
 import os
+
 for file in ["myraster1.tif", "myraster2.tif", "myresult.tif"]:
     os.remove(file)
 ####

--- a/doc/source/code/about_geoutils_sidebyside_raster_rasterio.py
+++ b/doc/source/code/about_geoutils_sidebyside_raster_rasterio.py
@@ -1,14 +1,15 @@
 ####
 # Part not shown in the doc, to get data files ready
 import geoutils
+
 landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
 landsat_b4_crop_path = geoutils.examples.get_path("everest_landsat_b4_cropped")
 geoutils.Raster(landsat_b4_path).save("myraster1.tif")
 geoutils.Raster(landsat_b4_crop_path).save("myraster2.tif")
 ####
 
-import rasterio as rio
 import numpy as np
+import rasterio as rio
 
 # Opening of two rasters
 rast1 = rio.io.DatasetReader("myraster1.tif")
@@ -25,15 +26,12 @@ arr1_reproj, _ = rio.warp.reproject(
     dst_transform=rast2.transform,
     dst_crs=rast2.crs,
     dst_nodata=rast2.nodata,
-    )
+)
 
 # Equivalent of array interfacing
 # (ensuring nodata and dtypes are rightly
 # propagated through masked arrays)
-ma1_reproj = np.ma.MaskedArray(
-    data=arr1_reproj,
-    mask=(arr1_reproj == rast2.nodata)
-    )
+ma1_reproj = np.ma.MaskedArray(data=arr1_reproj, mask=(arr1_reproj == rast2.nodata))
 ma2 = rast2.read(masked=True)
 ma_result = (1 + ma2) / (ma1_reproj)
 
@@ -43,11 +41,8 @@ ma_result = (1 + ma2) / (ma1_reproj)
 def custom_func(dtype, nodata1, nodata2):
     return -9999
 
-out_nodata = custom_func(
-    dtype=ma_result.dtype,
-    nodata1=rast1.nodata,
-    nodata2=rast2.nodata
-    )
+
+out_nodata = custom_func(dtype=ma_result.dtype, nodata1=rast1.nodata, nodata2=rast2.nodata)
 with rio.open(
     "myresult.tif",
     mode="w",
@@ -64,6 +59,7 @@ with rio.open(
 ####
 # Part not shown in the docs, to clean up
 import os
+
 for file in ["myraster1.tif", "myraster2.tif", "myresult.tif"]:
     os.remove(file)
 ####

--- a/doc/source/code/about_geoutils_sidebyside_raster_rasterio.py
+++ b/doc/source/code/about_geoutils_sidebyside_raster_rasterio.py
@@ -1,0 +1,69 @@
+####
+# Part not shown in the doc, to get data files ready
+import geoutils
+landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
+landsat_b4_crop_path = geoutils.examples.get_path("everest_landsat_b4_cropped")
+geoutils.Raster(landsat_b4_path).save("myraster1.tif")
+geoutils.Raster(landsat_b4_crop_path).save("myraster2.tif")
+####
+
+import rasterio as rio
+import numpy as np
+
+# Opening of two rasters
+rast1 = rio.io.DatasetReader("myraster1.tif")
+rast2 = rio.io.DatasetReader("myraster2.tif")
+
+# Equivalent of a match-reference reprojection
+# (returns an array, not a raster-type object)
+arr1_reproj, _ = rio.warp.reproject(
+    source=rast1.read(),
+    destination=np.ones(rast2.shape),
+    src_transform=rast1.transform,
+    src_crs=rast1.crs,
+    src_nodata=rast1.nodata,
+    dst_transform=rast2.transform,
+    dst_crs=rast2.crs,
+    dst_nodata=rast2.nodata,
+    )
+
+# Equivalent of array interfacing
+# (ensuring nodata and dtypes are rightly
+# propagated through masked arrays)
+ma1_reproj = np.ma.MaskedArray(
+    data=arr1_reproj,
+    mask=(arr1_reproj == rast2.nodata)
+    )
+ma2 = rast2.read(masked=True)
+ma_result = (1 + ma2) / (ma1_reproj)
+
+# Equivalent of saving
+# (requires to define a logical
+# nodata for the data type)
+def custom_func(dtype, nodata1, nodata2):
+    return -9999
+
+out_nodata = custom_func(
+    dtype=ma_result.dtype,
+    nodata1=rast1.nodata,
+    nodata2=rast2.nodata
+    )
+with rio.open(
+    "myresult.tif",
+    mode="w",
+    height=rast2.height,
+    width=rast2.width,
+    count=rast1.count,
+    dtype=ma_result.dtype,
+    crs=rast2.crs,
+    transform=rast2.transform,
+    nodata=rast2.nodata,
+) as dst:
+    dst.write(ma_result.filled(out_nodata))
+
+####
+# Part not shown in the docs, to clean up
+import os
+for file in ["myraster1.tif", "myraster2.tif", "myresult.tif"]:
+    os.remove(file)
+####

--- a/doc/source/code/about_geoutils_sidebyside_vector_geopandas.py
+++ b/doc/source/code/about_geoutils_sidebyside_vector_geopandas.py
@@ -1,0 +1,47 @@
+####
+# Part not shown in the doc, to get data files ready
+import geoutils
+landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
+everest_outlines_path = geoutils.examples.get_path("everest_rgi_outlines")
+geoutils.Raster(landsat_b4_path).save("myraster.tif")
+geoutils.Vector(everest_outlines_path).save("myvector.gpkg")
+####
+
+import geopandas as gpd
+import rasterio as rio
+
+# Opening a vector and a raster
+df = gpd.read_file("myvector.gpkg")
+rast2 = rio.io.DatasetReader("myraster.tif")
+
+# Equivalent of a metric buffering
+# (while keeping a frame object)
+gs_m_crs = df.to_crs(df.estimate_utm_crs())
+gs_m_crs_buff = gs_m_crs.buffer(distance=100)
+gs_buff = gs_m_crs_buff.to_crs(df.crs)
+df_buff = gpd.GeoDataFrame(
+    geometry=gs_buff
+    )
+
+# Equivalent of creating a rasterized mask
+# (ensuring CRS are similar)
+df_buff = df_buff.to_crs(rast2.crs)
+mask = rio.features.rasterize(
+    shapes=df.geometry,
+    fill=0,
+    out_shape=rast2.shape,
+    transform=rast2.transform,
+    default_value=1,
+    dtype="uint8"
+    )
+mask = mask.astype("bool")
+
+# Equivalent of indexing with mask
+values = rast2.read(1, masked=True)[mask]
+
+####
+# Part not shown in the doc, to get data files ready
+import os
+for file in ["myraster.tif", "myvector.gpkg"]:
+    os.remove(file)
+####

--- a/doc/source/code/about_geoutils_sidebyside_vector_geopandas.py
+++ b/doc/source/code/about_geoutils_sidebyside_vector_geopandas.py
@@ -1,6 +1,7 @@
 ####
 # Part not shown in the doc, to get data files ready
 import geoutils
+
 landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
 everest_outlines_path = geoutils.examples.get_path("everest_rgi_outlines")
 geoutils.Raster(landsat_b4_path).save("myraster.tif")
@@ -19,21 +20,14 @@ rast2 = rio.io.DatasetReader("myraster.tif")
 gs_m_crs = df.to_crs(df.estimate_utm_crs())
 gs_m_crs_buff = gs_m_crs.buffer(distance=100)
 gs_buff = gs_m_crs_buff.to_crs(df.crs)
-df_buff = gpd.GeoDataFrame(
-    geometry=gs_buff
-    )
+df_buff = gpd.GeoDataFrame(geometry=gs_buff)
 
 # Equivalent of creating a rasterized mask
 # (ensuring CRS are similar)
 df_buff = df_buff.to_crs(rast2.crs)
 mask = rio.features.rasterize(
-    shapes=df.geometry,
-    fill=0,
-    out_shape=rast2.shape,
-    transform=rast2.transform,
-    default_value=1,
-    dtype="uint8"
-    )
+    shapes=df.geometry, fill=0, out_shape=rast2.shape, transform=rast2.transform, default_value=1, dtype="uint8"
+)
 mask = mask.astype("bool")
 
 # Equivalent of indexing with mask
@@ -42,6 +36,7 @@ values = rast2.read(1, masked=True)[mask]
 ####
 # Part not shown in the doc, to get data files ready
 import os
+
 for file in ["myraster.tif", "myvector.gpkg"]:
     os.remove(file)
 ####

--- a/doc/source/code/about_geoutils_sidebyside_vector_geoutils.py
+++ b/doc/source/code/about_geoutils_sidebyside_vector_geoutils.py
@@ -1,6 +1,7 @@
 ####
 # Part not shown in the doc, to get data files ready
 import geoutils
+
 landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
 everest_outlines_path = geoutils.examples.get_path("everest_rgi_outlines")
 geoutils.Raster(landsat_b4_path).save("myraster.tif")
@@ -27,6 +28,7 @@ values = rast[mask]
 ####
 # Part not shown in the doc, to get data files ready
 import os
+
 for file in ["myraster.tif", "myvector.gpkg"]:
     os.remove(file)
 ####

--- a/doc/source/code/about_geoutils_sidebyside_vector_geoutils.py
+++ b/doc/source/code/about_geoutils_sidebyside_vector_geoutils.py
@@ -1,0 +1,32 @@
+####
+# Part not shown in the doc, to get data files ready
+import geoutils
+landsat_b4_path = geoutils.examples.get_path("everest_landsat_b4")
+everest_outlines_path = geoutils.examples.get_path("everest_rgi_outlines")
+geoutils.Raster(landsat_b4_path).save("myraster.tif")
+geoutils.Vector(everest_outlines_path).save("myvector.gpkg")
+####
+
+import geoutils as gu
+
+# Opening a vector and a raster
+vect = gu.Vector("myvector.gpkg")
+rast = gu.Raster("myraster.tif")
+
+# Metric buffering
+vect_buff = vect.buffer_metric(buffer_size=100)
+
+# Create a mask on the raster grid
+# (raster not loaded, only metadata)
+mask = vect_buff.create_mask(rast)
+
+# Index raster values on mask
+# (raster loads implicitly)
+values = rast[mask]
+
+####
+# Part not shown in the doc, to get data files ready
+import os
+for file in ["myraster.tif", "myvector.gpkg"]:
+    os.remove(file)
+####

--- a/doc/source/core_composition.md
+++ b/doc/source/core_composition.md
@@ -51,7 +51,7 @@ By default, {attr}`~geoutils.Raster.data` is not loaded during instantiation. Se
 ```{code-cell} ipython3
 :tags: [hide-output]
 # Show summarized information
-print(rast.info())
+rast.info()
 ```
 
 ```{important}
@@ -93,7 +93,7 @@ vect
 ```{code-cell} ipython3
 :tags: [hide-output]
 # Show summarized information
-print(vect.info())
+vect.info()
 ```
 
 All geospatial methods of {class}`~geopandas.GeoDataFrame` are directly available into {class}`~geoutils.Vector`, and cast the output logically depending on

--- a/doc/source/core_match_ref.md
+++ b/doc/source/core_match_ref.md
@@ -47,9 +47,6 @@ or {class}`~geoutils.Vector`:
    * - {func}`~geoutils.Raster.crop`
      - {attr}`~geoutils.Vector.bounds`
      - {attr}`~geoutils.Raster.bounds`
-   * - {func}`~geoutils.Raster.resample`
-     - {attr}`~geoutils.Raster.res`
-     - N/A
 
 ```
 

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -81,12 +81,12 @@ For convenience and consistency, nearly all of these methods can be passed solel
 
 
 ```{code-cell} ipython3
-# Print initial bounds of the raster
-print(rast.bounds)
-# Crop raster to vector's extent
-rast = rast.crop(vect)
-# Print bounds of cropped raster
-print(rast.bounds)
+# Print initial bounds of the vector
+print(vect.bounds)
+# Crop vector to raster's extent, and add clipping option (otherwise keeps all intersecting features)
+vect_cropped = vect.crop(rast, clip=True)
+# Print bounds of cropped + clipped vector
+print(vect_cropped.bounds)
 ```
 
 ```{margin}
@@ -193,8 +193,8 @@ All {class}`~geoutils.Raster` classes also support Python logical comparison ope
 {func}`<<operator.lt>`), or more complex NumPy logical functions. Those operations automatically casts them into a {class}`~geoutils.Mask`, a subclass of {class}`~geoutils.Raster`.
 
 ```{code-cell} ipython3
-# Get mask of an AOI: infrared index above 0.7, at least 200 m from glaciers
-mask_aoi = np.logical_and(rast > 0.7, rast_proximity_to_vec > 200)
+# Get mask of an AOI: infrared index above 0.6, at least 200 m from glaciers
+mask_aoi = np.logical_and(rast > 0.6, rast_proximity_to_vec > 200)
 ```
 
 Masks can then be used for indexing a {class}`~geoutils.Raster`, which returns a {class}`~numpy.ma.MaskedArray` of indexed values.
@@ -215,7 +215,7 @@ vect_aoi = mask_aoi.polygonize()
 ```{code-cell} ipython3
 # Plot result
 rast.show(cmap='Reds', cbar_title='Normalized infrared')
-vect_aoi.show(fc='none', ec='k', lw=0.5)
+vect_aoi.show(fc='none', ec='k', lw=0.75)
 ```
 
 ## Saving to file
@@ -253,8 +253,8 @@ rast = gu.SatelliteImage(filename_rast, silent=False)
 In a few lines, we:
  - **easily handled georeferencing** operations on rasters and vectors,
  - performed numerical calculations **inherently respecting invalid data**,
- - **naturally casted to a mask** from a logical operation on raster, and
- - **straightforwardly vectorized a mask** by harnessing overloaded subclass methods.
+ - **casted to a mask** implicitly from a logical operation on raster, and
+ - **vectorized a mask** by harnessing overloaded subclass methods.
 
 **Our result:** a vector of high infrared absorption indexes at least 200 meters away from glaciers
 near Everest, which likely corresponds to **perennial snowfields**.

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -19,7 +19,7 @@ The following presents a descriptive example show-casing all core features of Ge
 For more details, refer to the {ref}`core-index`, {ref}`rasters-index` or {ref}`vectors-index` pages.
 
 ```{tip}
-All pages of this documentation containing code cells can be **run interactively online without the need of setting up your own environment**. Simply click the top launch button! 
+All pages of this documentation containing code cells can be **run interactively online without the need of setting up your own environment**. Simply click the top launch button!
 (MyBinder can be a bit capricious: you might have to be patient, or restart it after the build is done the first time 😅)
 
 Alternatively, start your own notebook to test GeoUtils at [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GlacioHack/geoutils/main).

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -1,0 +1,263 @@
+---
+file_format: mystnb
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: geoutils-env
+  language: python
+  name: geoutils
+---
+(feature-overview)=
+
+# Feature overview
+
+The following presents a descriptive example show-casing all core features of GeoUtils.
+
+For more details, refer to the {ref}`core-index`, {ref}`rasters-index` or {ref}`vectors-index` pages.
+
+```{tip}
+All pages of this documentation containing code cells can be **run interactively online without the need of setting up your own environment**. Simply click the top launch button! 
+(MyBinder can be a bit capricious: you might have to be patient, or restart it after the build is done the first time 😅)
+
+Alternatively, start your own notebook to test GeoUtils at [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GlacioHack/geoutils/main).
+```
+
+## The core {class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes
+
+In GeoUtils, geospatial handling is object-based and revolves around {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
+These link to either **on-disk** or **in-memory** datasets, opened by instantiating the class.
+
+```{code-cell} ipython3
+import geoutils as gu
+
+# Examples files: infrared band of Landsat and glacier outlines
+filename_rast = gu.examples.get_path("everest_landsat_b4")
+filename_vect = gu.examples.get_path("everest_rgi_outlines")
+
+# Open files by instantiating Raster and Vector
+rast = gu.Raster(filename_rast)
+vect = gu.Vector(filename_vect)
+```
+
+A {class}`~geoutils.Raster` is a composition class with four main attributes: a {class}`numpy.ma.MaskedArray` as {attr}`~geoutils.Raster.data`, a
+{class}`pyproj.crs.CRS` as {attr}`~geoutils.Raster.crs`, an [{class}`affine.Affine`](https://rasterio.readthedocs.io/en/stable/topics/migrating-to-v1.html#affine-affine-vs-gdal-style-geotransforms)
+as {attr}`~geoutils.Raster.transform`, and a {class}`float` or {class}`int` as {attr}`~geoutils.Raster.nodata`.
+
+
+```{code-cell} ipython3
+# The opened raster
+rast
+```
+
+```{important}
+When a file exists on disk, {class}`~geoutils.Raster` is linked to a {class}`rasterio.io.DatasetReader` object for loading the metadata. The array will be
+**loaded in-memory implicitly** when {attr}`~geoutils.Raster.data` is required by an operation.
+
+See {ref}`core-lazy-load` for more details.
+```
+
+A {class}`~geoutils.Vector` is a composition class with a single main attribute: a {class}`~geopandas.GeoDataFrame` as {attr}`~geoutils.Vector.ds`, for which
+most methods are wrapped directly into {class}`~geoutils.Vector`.
+
+```{code-cell} ipython3
+# The opened vector
+vect
+```
+
+All other attributes are derivatives of those main attributes, or of the filename on disk. Attributes of {class}`~geoutils.Raster` and
+{class}`~geoutils.Vector` update with geospatial operations on themselves.
+
+
+## Handling and match-reference
+
+In GeoUtils, geospatial handling operations are based on class methods, such as {func}`~geoutils.Raster.crop` or {func}`~geoutils.Raster.reproject`.
+
+For convenience and consistency, nearly all of these methods can be passed solely another {class}`~geoutils.Raster` or {class}`~geoutils.Vector` as a
+**reference to match** during the operation. A **reference {class}`~geoutils.Vector`** enforces a matching of {attr}`~geoutils.Vector.bounds` and/or
+{attr}`~geoutils.Vector.crs`, while a **reference {class}`~geoutils.Raster`** can also enforce a matching of {attr}`~geoutils.Raster.res`, depending on the nature of the operation.
+
+
+```{code-cell} ipython3
+# Print initial bounds of the raster
+print(rast.bounds)
+# Crop raster to vector's extent
+rast = rast.crop(vect)
+# Print bounds of cropped raster
+print(rast.bounds)
+```
+
+```{margin}
+<sup>1</sup>The names of geospatial handling methods is largely based on [GDAL and OGR](https://gdal.org/)'s, with the notable exception of {func}`~geoutils.Vector.reproject` that better applies to vectors than `warp`.
+```
+
+Additionally, in GeoUtils, **methods that apply to the same georeferencing attributes have consistent naming**<sup>1</sup> across {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
+
+A {func}`~geoutils.Raster.reproject` involves a change in {attr}`~geoutils.Raster.crs` or {attr}`~geoutils.Raster.transform`, while a {func}`~geoutils.Raster.crop` only involves a change
+in {attr}`~geoutils.Raster.bounds`. Using {func}`~geoutils.Raster.polygonize` allows to generate a {class}`~geoutils.Vector` from a {class}`~geoutils.Raster`,
+and the other way around for {func}`~geoutils.Vector.rasterize`.
+
+```{list-table}
+   :widths: 30 30 30
+   :header-rows: 1
+
+   * - **Class**
+     - {class}`~geoutils.Raster`
+     - {class}`~geoutils.Vector`
+   * - Warping/Reprojection
+     - {func}`~geoutils.Raster.reproject`
+     - {func}`~geoutils.Vector.reproject`
+   * - Cropping/Clipping
+     - {func}`~geoutils.Raster.crop`
+     - {func}`~geoutils.Vector.crop`
+   * - Rasterize/Polygonize
+     - {func}`~geoutils.Raster.polygonize`
+     - {func}`~geoutils.Vector.rasterize`
+```
+
+All methods can also be passed any number of georeferencing arguments such as {attr}`~geoutils.Raster.shape` or {attr}`~geoutils.Raster.res`, and will
+naturally deduce others from the input {class}`~geoutils.Raster` or {class}`~geoutils.Vector`, much as in [GDAL](https://gdal.org/)'s command line.
+
+
+## Higher-level analysis tools
+
+GeoUtils also implements higher-level geospatial analysis tools for both {class}`Rasters<geoutils.Raster>` and {class}`Vectors<geoutils.Vector>`. For
+example, one can compute the distance to a {class}`~geoutils.Vector` geometry, or to target pixels of a {class}`~geoutils.Raster`, using
+{func}`~geoutils.Vector.proximity`.
+
+As with the geospatial handling functions previously listed, many analysis functions can take a {class}`~geoutils.Raster` or {class}`~geoutils.Vector` as a
+**reference to utilize** during the operation. In the case of {func}`~geoutils.Vector.proximity`, passing a {class}`~geoutils.Raster` serves as a reference
+for the georeferenced grid on which to compute the distances.
+
+```{code-cell} ipython3
+# Compute proximity to vector on raster's grid
+rast_proximity_to_vec = vect.proximity(rast)
+```
+
+```{note}
+Right now, the array {attr}`~geoutils.Raster.data` of `rast` is still not loaded. Applying {func}`~geoutils.Raster.crop` does not yet require loading,
+and `rast`'s metadata is sufficient to provide a georeferenced grid for {func}`~geoutils.Vector.proximity`. The array will only be loaded when necessary.
+```
+
+## Quick plotting
+
+To facilitate the analysis process, GeoUtils includes quick plotting tools that support multiple colorbars and implicitly add layers to the current axis.
+Those are build on top of {func}`rasterio.plot.show` and {func}`geopandas.GeoDataFrame.plot`, and relay any argument passed.
+
+```{seealso}
+GeoUtils' plotting tools only aim to smooth out the most common hassles when quickly plotting raster and vectors.
+
+For advanced plotting tools to create "publication-quality" figures, see [Cartopy](https://scitools.org.uk/cartopy/docs/latest/) or
+[GeoPlot](https://residentmario.github.io/geoplot/index.html).
+```
+
+The plotting functionality is named {func}`~geoutils.Raster.show` everywhere, for consistency. Here again, a {class}`~geoutils.Raster` or
+{class}`~geoutils.Vector` can be passed as a **reference to match** to ensure all data is displayed on the same grid and projection.
+
+```{code-cell} ipython3
+# Plot proximity to vector
+rast_proximity_to_vec = vect.proximity(rast)
+rast_proximity_to_vec.show(cbar_title="Distance to glacier outline")
+vect.show(rast_proximity_to_vec, fc="none")
+```
+
+```{tip}
+To quickly visualize a raster directly from a terminal, without opening a Python console/notebook, check out our tool `geoviewer.py` in the {ref}`cli` documentation.
+```
+
+## Pythonic arithmetic and NumPy interface
+
+All {class}`~geoutils.Raster` objects support Python arithmetic ({func}`+<operator.add>`, {func}`-<operator.sub>`, {func}`/<operator.truediv>`, {func}`//<operator.floordiv>`, {func}`*<operator.mul>`,
+{func}`**<operator.pow>`, {func}`%<operator.mod>`) with any other {class}`~geoutils.Raster`, {class}`~numpy.ndarray` or
+number. With another {class}`~geoutils.Raster`, the georeferencing must match, while only the shape with a {class}`~numpy.ndarray`.
+
+```{code-cell} ipython3
+# Add 1 to the raster array
+rast += 1
+```
+
+Additionally, the class {class}`~geoutils.Raster` possesses a NumPy masked-array interface that allows to apply to it any [NumPy universal function](https://numpy.org/doc/stable/reference/ufuncs.html) and
+most other NumPy array functions, while logically casting {class}`dtypes<numpy.dtype>` and respecting {attr}`~geoutils.Raster.nodata` values.
+
+```{code-cell} ipython3
+# Apply a normalization to the raster
+import numpy as np
+rast = (rast - np.min(rast)) / (np.max(rast) - np.min(rast))
+```
+
+## Casting to {class}`~geoutils.Mask`, indexing and overload
+
+All {class}`~geoutils.Raster` classes also support Python logical comparison operators ({func}`==<operator.eq>`, {func}` != <operator.ne>`, {func}`>=<operator.ge>`, {func}`><operator.gt>`, {func}`<=<operator.le>`,
+{func}`<<operator.lt>`), or more complex NumPy logical functions. Those operations automatically casts them into a {class}`~geoutils.Mask`, a subclass of {class}`~geoutils.Raster`.
+
+```{code-cell} ipython3
+# Get mask of an AOI: infrared index above 0.7, at least 200 m from glaciers
+mask_aoi = np.logical_and(rast > 0.7, rast_proximity_to_vec > 200)
+```
+
+Masks can then be used for indexing a {class}`~geoutils.Raster`, which returns a {class}`~numpy.ma.MaskedArray` of indexed values.
+
+```{code-cell} ipython3
+# Index raster with mask to extract a 1-D array
+values_aoi = rast[mask_aoi]
+```
+
+Masks also have simplified, overloaded {class}`~geoutils.Raster` methods due to their boolean {class}`dtypes<numpy.dtype>`. Using {func}`~geoutils.Raster.polygonize` with a
+{class}`~geoutils.Mask` is straightforward, for instance, to retrieve a {class}`~geoutils.Vector` of the area-of-interest:
+
+```{code-cell} ipython3
+# Polygonize areas where mask is True
+vect_aoi = mask_aoi.polygonize()
+```
+
+```{code-cell} ipython3
+# Plot result
+rast.show(cmap='Reds', cbar_title='Normalized infrared')
+vect_aoi.show(fc='none', ec='k', lw=0.5)
+```
+
+## Saving to file
+
+Finally, for saving a {class}`~geoutils.Raster` or {class}`~geoutils.Vector` to file, simply call the {func}`~geoutils.Raster.save` function.
+
+```{code-cell} ipython3
+# Save our AOI vector
+vect_aoi.save("myaoi.gpkg")
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+import os
+os.remove("myaoi.gpkg")
+```
+
+## Parsing metadata with {class}`~geoutils.SatelliteImage`
+
+In our case, `rast` would be better opened using the {class}`~geoutils.Raster` subclass {class}`~geoutils.SatelliteImage` instead, which tentatively parses
+metadata recognized from the filename or auxiliary files.
+
+```{code-cell} ipython3
+# Name of the image we used
+import os
+print(os.path.basename(filename_rast))
+```
+
+```{code-cell} ipython3
+# Open while parsing metadata
+rast = gu.SatelliteImage(filename_rast, silent=False)
+```
+
+```{admonition} Wrap-up
+In a few lines, we:
+ - **easily handled georeferencing** operations on rasters and vectors,
+ - performed numerical calculations **inherently respecting invalid data**,
+ - **naturally casted to a mask** from a logical operation on raster, and
+ - **straightforwardly vectorized a mask** by harnessing overloaded subclass methods.
+
+**Our result:** a vector of high infrared absorption indexes at least 200 meters away from glaciers
+near Everest, which likely corresponds to **perennial snowfields**.
+
+Otherwise, for more **hands-on** examples, explore GeoUtils' gallery of examples!
+```

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -28,7 +28,7 @@ Alternatively, start your own notebook to test GeoUtils at [![Binder](https://my
 ## The core {class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes
 
 In GeoUtils, geospatial handling is object-based and revolves around {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
-These link to either **on-disk** or **in-memory** datasets, opened by instantiating the class.
+These link to either **on-disk** or **in-memory** datasets, opened by instantiating the class with a file path.
 
 ```{code-cell} ipython3
 import geoutils as gu

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -28,7 +28,7 @@ Alternatively, start your own notebook to test GeoUtils at [![Binder](https://my
 ## The core {class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes
 
 In GeoUtils, geospatial handling is object-based and revolves around {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
-These link to either **on-disk** or **in-memory** datasets, opened by instantiating the class with a file path.
+These link to either **on-disk** or **in-memory** datasets, opened by calling the object with a file path.
 
 ```{code-cell} ipython3
 import geoutils as gu
@@ -37,12 +37,12 @@ import geoutils as gu
 filename_rast = gu.examples.get_path("everest_landsat_b4")
 filename_vect = gu.examples.get_path("everest_rgi_outlines")
 
-# Open files by instantiating Raster and Vector
+# Open files by calling Raster and Vector
 rast = gu.Raster(filename_rast)
 vect = gu.Vector(filename_vect)
 ```
 
-A {class}`~geoutils.Raster` is a composition class with four main attributes: a {class}`numpy.ma.MaskedArray` as {attr}`~geoutils.Raster.data`, a
+A {class}`~geoutils.Raster` is an object with four main attributes: a {class}`numpy.ma.MaskedArray` as {attr}`~geoutils.Raster.data`, a
 {class}`pyproj.crs.CRS` as {attr}`~geoutils.Raster.crs`, an [{class}`affine.Affine`](https://rasterio.readthedocs.io/en/stable/topics/migrating-to-v1.html#affine-affine-vs-gdal-style-geotransforms)
 as {attr}`~geoutils.Raster.transform`, and a {class}`float` or {class}`int` as {attr}`~geoutils.Raster.nodata`.
 
@@ -59,7 +59,7 @@ When a file exists on disk, {class}`~geoutils.Raster` is linked to a {class}`ras
 See {ref}`core-lazy-load` for more details.
 ```
 
-A {class}`~geoutils.Vector` is a composition class with a single main attribute: a {class}`~geopandas.GeoDataFrame` as {attr}`~geoutils.Vector.ds`, for which
+A {class}`~geoutils.Vector` is an object with a single main attribute: a {class}`~geopandas.GeoDataFrame` as {attr}`~geoutils.Vector.ds`, for which
 most methods are wrapped directly into {class}`~geoutils.Vector`.
 
 ```{code-cell} ipython3
@@ -178,7 +178,7 @@ number. With another {class}`~geoutils.Raster`, the georeferencing must match, w
 rast += 1
 ```
 
-Additionally, the class {class}`~geoutils.Raster` possesses a NumPy masked-array interface that allows to apply to it any [NumPy universal function](https://numpy.org/doc/stable/reference/ufuncs.html) and
+Additionally, the {class}`~geoutils.Raster` object possesses a NumPy masked-array interface that allows to apply to it any [NumPy universal function](https://numpy.org/doc/stable/reference/ufuncs.html) and
 most other NumPy array functions, while logically casting {class}`dtypes<numpy.dtype>` and respecting {attr}`~geoutils.Raster.nodata` values.
 
 ```{code-cell} ipython3
@@ -189,8 +189,8 @@ rast = (rast - np.min(rast)) / (np.max(rast) - np.min(rast))
 
 ## Casting to {class}`~geoutils.Mask`, indexing and overload
 
-All {class}`~geoutils.Raster` classes also support Python logical comparison operators ({func}`==<operator.eq>`, {func}` != <operator.ne>`, {func}`>=<operator.ge>`, {func}`><operator.gt>`, {func}`<=<operator.le>`,
-{func}`<<operator.lt>`), or more complex NumPy logical functions. Those operations automatically casts them into a {class}`~geoutils.Mask`, a subclass of {class}`~geoutils.Raster`.
+All {class}`~geoutils.Raster` objects also support Python logical comparison operators ({func}`==<operator.eq>`, {func}` != <operator.ne>`, {func}`>=<operator.ge>`, {func}`><operator.gt>`, {func}`<=<operator.le>`,
+{func}`<<operator.lt>`), or more complex NumPy logical functions. Those operations automatically casts them into a {class}`~geoutils.Mask`, a boolean raster that inherits all methods from {class}`~geoutils.Raster`.
 
 ```{code-cell} ipython3
 # Get mask of an AOI: infrared index above 0.6, at least 200 m from glaciers
@@ -235,7 +235,7 @@ os.remove("myaoi.gpkg")
 
 ## Parsing metadata with {class}`~geoutils.SatelliteImage`
 
-In our case, `rast` would be better opened using the {class}`~geoutils.Raster` subclass {class}`~geoutils.SatelliteImage` instead, which tentatively parses
+In our case, `rast` would be better opened using the {class}`~geoutils.Raster` object {class}`~geoutils.SatelliteImage` instead, which tentatively parses
 metadata recognized from the filename or auxiliary files.
 
 ```{code-cell} ipython3
@@ -254,7 +254,7 @@ In a few lines, we:
  - **easily handled georeferencing** operations on rasters and vectors,
  - performed numerical calculations **inherently respecting invalid data**,
  - **casted to a mask** implicitly from a logical operation on raster, and
- - **vectorized a mask** by harnessing overloaded subclass methods.
+ - **vectorized a mask** without need for any additional metadata, simply using the nature of the mask object!
 
 **Our result:** a vector of high infrared absorption indexes at least 200 meters away from glaciers
 near Everest, which likely corresponds to **perennial snowfields**.

--- a/doc/source/how_to_install.md
+++ b/doc/source/how_to_install.md
@@ -8,7 +8,7 @@
 mamba install -c conda-forge geoutils
 ```
 
-```{important}
+```{tip}
 Solving dependencies can take a long time with `conda`, `mamba` significantly speeds up the process. Install it with:
 
     conda install mamba -n base -c conda-forge

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -26,7 +26,7 @@ GeoUtils is a Python package for **accessible**, **efficient** and **reliable** 
 
 ```{important}
 :class: margin
-GeoUtils ``v0.1`` is released, with most features drafted 3 years ago finalized 🎉! We are working on an **Xarray accessor** and a few other features for 2024 towards a `v1.0`.
+GeoUtils ``v0.1`` is released, with most features drafted 3 years ago now finalized 🎉! We are working on an **Xarray accessor** and a few other features for 2024.
 ```
 
 ----------------

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -24,33 +24,14 @@ title: GeoUtils
 GeoUtils is a Python package for **accessible**, **efficient** and **reliable** geospatial analysis.
 ::::
 
-```{tip}
+```{important}
 :class: margin
-**Run any page of this documentation interactively** by clicking the top launch button!
-
-Or **start your own test notebook**: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GlacioHack/geoutils/main).
+GeoUtils ``v0.1`` is released, with most stable features drafted 3 years ago 🎉! We are working on an **Xarray accessor** and a few other features for 2024.
 ```
-
-**Accessible** owing to its convenient object-based structure, intuitive match-reference operations and familiar geospatial dependencies
-([Rasterio](https://rasterio.readthedocs.io/en/latest/), [Rioxarray](https://corteva.github.io/rioxarray/stable/),
-[GeoPandas](https://geopandas.org/en/stable/docs.html), [PyProj](https://pyproj4.github.io/pyproj/stable/index.html)).
-
-**Efficient** owing to its implicit lazy loading functionalities, logical integration with pythonic operators and array interfacing
-([NumPy](https://numpy.org/doc/stable/), [SciPy](https://docs.scipy.org/doc/scipy/) and [Xarray](https://docs.xarray.dev/en/stable/)).
-
-**Reliable** owing to its consistent higher-level operations respecting geospatial intricacies such as nodata values and pixel interpretation, ensured by
-its testing suite and type checking ([Pytest](https://docs.pytest.org/en/7.2.x/), [Mypy](https://mypy-lang.org/)).
 
 ----------------
 
 # Where to start?
-
-```{important}
-:class: margin
-GeoUtils is in early stages of development and its features might evolve rapidly. Note the version you are working on for
-**reproducibility**!
-We are working on making features fully consistent for the first long-term release ``v0.1`` (likely sometime in 2023).
-```
 
 ::::{grid} 1 2 2 3
 :gutter: 1 1 1 2
@@ -106,6 +87,7 @@ If you are DEM-enthusiastic, **[check-out our sister package xDEM](https://xdem.
 about_geoutils
 how_to_install
 quick_start
+feature_overview
 ```
 
 ```{toctree}

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -26,7 +26,7 @@ GeoUtils is a Python package for **accessible**, **efficient** and **reliable** 
 
 ```{important}
 :class: margin
-GeoUtils ``v0.1`` is released, with most stable features drafted 3 years ago 🎉! We are working on an **Xarray accessor** and a few other features for 2024.
+GeoUtils ``v0.1`` is released, with most features drafted 3 years ago finalized 🎉! We are working on an **Xarray accessor** and a few other features for 2024 towards a `v1.0`.
 ```
 
 ----------------

--- a/doc/source/proj_tools.md
+++ b/doc/source/proj_tools.md
@@ -30,7 +30,7 @@ import geoutils as gu
 
 # Initiate a raster from disk
 rast = gu.Raster(gu.examples.get_path("exploradores_aster_dem"))
-print(rast.info())
+rast.info()
 
 # Estimate a universal metric CRS for the raster
 rast.get_metric_crs()

--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -75,8 +75,8 @@ import numpy as np
 calc_rast = np.log(rast / 2) + 3.5
 
 # Plot raster and vector, using raster as projection-reference for vector
-calc_rast.show(cmap='Spectral', cbar_title='My calculation')
-vect_buff.show(calc_rast, fc='none', ec='k', lw=0.5)
+calc_rast.plot(cmap='Spectral', cbar_title='My calculation')
+vect_buff.plot(calc_rast, fc='none', ec='k', lw=0.5)
 
 # Save to file
 calc_rast.save("mycalc.tif")

--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -14,253 +14,81 @@ kernelspec:
 
 # Quick start
 
-The following presents a descriptive example show-casing all core aspects of GeoUtils.
+A short code example using several end-user functionalities of GeoUtils. For a more detailed example of all features, 
+have a look at the {ref}`feature-overview` page! Or, to find an example about 
+a specific functionality, jump to {ref}`quick-gallery` right below.
 
-For more details, refer to the {ref}`core-index`, {ref}`rasters-index` or {ref}`vectors-index` pages.
+## Short example
 
-To find an example about a specific functionality, jump to {ref}`quick-gallery`.
+```{note}
+:class: margin
 
-```{tip}
-All pages of this documentation containing code cells can be **run interactively online without the need of setting up your own environment**. Simply click the top launch button!
+Most functions examplified here normally require many lines of code using several independent packages with inconsistent 
+geospatial syntax and volatile passing of metadata that can lead to errors!
 
-Alternatively, start your own notebook to test GeoUtils at [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/GlacioHack/geoutils/main).
+In GeoUtils, **these higher-level operations are tested to ensure robustness and consistency**. 🙂
 ```
 
-## The core {class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes
+The package functionalities revolve around the 
+{class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes, from which most methods can be called.
+Below, in a few lines, we load a raster and a vector, crop them to a common extent, re-assign raster values around 
+a buffer of the vector, perform calculations on the modified raster, and finally plot and save it!
 
-In GeoUtils, geospatial handling is object-based and revolves around {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
-These link to either **on-disk** or **in-memory** datasets, opened by instantiating the class.
+<!--- An empty margin to add some vertical padding --->
+```{margin}
+&nbsp;              
+```
+
+
+```{note}
+:class: margin
+
+**We notice a ``Userwarning``:** No nodata value was defined in the GeoTIFF file, so GeoUtils automatically defined 
+one compatible with the data type to use during operations.
+```
 
 ```{code-cell} ipython3
 import geoutils as gu
 
-# Examples files: infrared band of Landsat and glacier outlines
+# Examples files: paths to a GeoTIFF file and an ESRI shapefile
 filename_rast = gu.examples.get_path("everest_landsat_b4")
 filename_vect = gu.examples.get_path("everest_rgi_outlines")
 
 # Open files by instantiating Raster and Vector
+# (Rasters are loaded lazily = only metadata but not array unless required)
 rast = gu.Raster(filename_rast)
 vect = gu.Vector(filename_vect)
-```
 
-A {class}`~geoutils.Raster` is a composition class with four main attributes: a {class}`numpy.ma.MaskedArray` as {attr}`~geoutils.Raster.data`, a
-{class}`pyproj.crs.CRS` as {attr}`~geoutils.Raster.crs`, an [{class}`affine.Affine`](https://rasterio.readthedocs.io/en/stable/topics/migrating-to-v1.html#affine-affine-vs-gdal-style-geotransforms)
-as {attr}`~geoutils.Raster.transform`, and a {class}`float` or {class}`int` as {attr}`~geoutils.Raster.nodata`.
-
-
-```{code-cell} ipython3
-# The opened raster
-rast
-```
-
-```{important}
-When a file exists on disk, {class}`~geoutils.Raster` is linked to a {class}`rasterio.io.DatasetReader` object for loading the metadata. The array will be
-**loaded in-memory implicitly** when {attr}`~geoutils.Raster.data` is required by an operation.
-
-See {ref}`core-lazy-load` for more details.
-```
-
-A {class}`~geoutils.Vector` is a composition class with a single main attribute: a {class}`~geopandas.GeoDataFrame` as {attr}`~geoutils.Vector.ds`, for which
-most methods are wrapped directly into {class}`~geoutils.Vector`.
-
-```{code-cell} ipython3
-# The opened vector
-vect
-```
-
-All other attributes are derivatives of those main attributes, or of the filename on disk. Attributes of {class}`~geoutils.Raster` and
-{class}`~geoutils.Vector` update with geospatial operations on themselves.
-
-
-## Handling and match-reference
-
-In GeoUtils, geospatial handling operations are based on class methods, such as {func}`~geoutils.Raster.crop` or {func}`~geoutils.Raster.reproject`.
-
-For convenience and consistency, nearly all of these methods can be passed solely another {class}`~geoutils.Raster` or {class}`~geoutils.Vector` as a
-**reference to match** during the operation. A **reference {class}`~geoutils.Vector`** enforces a matching of {attr}`~geoutils.Vector.bounds` and/or
-{attr}`~geoutils.Vector.crs`, while a **reference {class}`~geoutils.Raster`** can also enforce a matching of {attr}`~geoutils.Raster.res`, depending on the nature of the operation.
-
-
-```{code-cell} ipython3
-# Print initial bounds of the raster
-print(rast.bounds)
-# Crop raster to vector's extent
+# Crop raster to vector's extent by simply passing vector as "match-reference"
 rast = rast.crop(vect)
-# Print bounds of cropped raster
-print(rast.bounds)
-```
 
-```{margin}
-<sup>1</sup>The names of geospatial handling methods is largely based on [GDAL and OGR](https://gdal.org/)'s, with the notable exception of {func}`~geoutils.Vector.reproject` that better applies to vectors than `warp`.
-```
+# Buffer the vector by 500 meters no matter its current projection system
+vect_buff = vect.buffer_metric(500)
 
-Additionally, in GeoUtils, **methods that apply to the same georeferencing attributes have consistent naming**<sup>1</sup> across {class}`~geoutils.Raster` and {class}`~geoutils.Vector`.
+# Create boolean mask of vector on same grid/CRS as raster using it as "match-reference"
+mask_buff = vect_buff.create_mask(rast)
 
-A {func}`~geoutils.Raster.reproject` involves a change in {attr}`~geoutils.Raster.crs` or {attr}`~geoutils.Raster.transform`, while a {func}`~geoutils.Raster.crop` only involves a change
-in {attr}`~geoutils.Raster.bounds`. Using {func}`~geoutils.Raster.polygonize` allows to generate a {class}`~geoutils.Vector` from a {class}`~geoutils.Raster`,
-and the other way around for {func}`~geoutils.Vector.rasterize`.
+# Re-assign values of pixels in the mask while performing a sum
+# (Now the raster loads implicitly)
+rast[mask_buff] += 50
 
-```{list-table}
-   :widths: 30 30 30
-   :header-rows: 1
-
-   * - **Class**
-     - {class}`~geoutils.Raster`
-     - {class}`~geoutils.Vector`
-   * - Warping/Reprojection
-     - {func}`~geoutils.Raster.reproject`
-     - {func}`~geoutils.Vector.reproject`
-   * - Cropping/Clipping
-     - {func}`~geoutils.Raster.crop`
-     - {func}`~geoutils.Vector.crop`
-   * - Rasterize/Polygonize
-     - {func}`~geoutils.Raster.polygonize`
-     - {func}`~geoutils.Vector.rasterize`
-```
-
-All methods can also be passed any number of georeferencing arguments such as {attr}`~geoutils.Raster.shape` or {attr}`~geoutils.Raster.res`, and will
-naturally deduce others from the input {class}`~geoutils.Raster` or {class}`~geoutils.Vector`, much as in [GDAL](https://gdal.org/)'s command line.
-
-
-## Higher-level analysis tools
-
-GeoUtils also implements higher-level geospatial analysis tools for both {class}`Rasters<geoutils.Raster>` and {class}`Vectors<geoutils.Vector>`. For
-example, one can compute the distance to a {class}`~geoutils.Vector` geometry, or to target pixels of a {class}`~geoutils.Raster`, using
-{func}`~geoutils.Vector.proximity`.
-
-As with the geospatial handling functions previously listed, many analysis functions can take a {class}`~geoutils.Raster` or {class}`~geoutils.Vector` as a
-**reference to utilize** during the operation. In the case of {func}`~geoutils.Vector.proximity`, passing a {class}`~geoutils.Raster` serves as a reference
-for the georeferenced grid on which to compute the distances.
-
-```{code-cell} ipython3
-# Compute proximity to vector on raster's grid
-rast_proximity_to_vec = vect.proximity(rast)
-```
-
-```{note}
-Right now, the array {attr}`~geoutils.Raster.data` of `rast` is still not loaded. Applying {func}`~geoutils.Raster.crop` does not yet require loading,
-and `rast`'s metadata is sufficient to provide a georeferenced grid for {func}`~geoutils.Vector.proximity`. The array will only be loaded when necessary.
-```
-
-## Quick plotting
-
-To facilitate the analysis process, GeoUtils includes quick plotting tools that support multiple colorbars and implicitly add layers to the current axis.
-Those are build on top of {func}`rasterio.plot.show` and {func}`geopandas.GeoDataFrame.plot`, and relay any argument passed.
-
-```{seealso}
-GeoUtils' plotting tools only aim to smooth out the most common hassles when quickly plotting raster and vectors.
-
-For advanced plotting tools to create "publication-quality" figures, see [Cartopy](https://scitools.org.uk/cartopy/docs/latest/) or
-[GeoPlot](https://residentmario.github.io/geoplot/index.html).
-```
-
-The plotting functionality is named {func}`~geoutils.Raster.show` everywhere, for consistency. Here again, a {class}`~geoutils.Raster` or
-{class}`~geoutils.Vector` can be passed as a **reference to match** to ensure all data is displayed on the same grid and projection.
-
-```{code-cell} ipython3
-# Plot proximity to vector
-rast_proximity_to_vec = vect.proximity(rast)
-rast_proximity_to_vec.show(cbar_title="Distance to glacier outline")
-vect.show(rast_proximity_to_vec, fc="none")
-```
-
-```{tip}
-To quickly visualize a raster directly from a terminal, without opening a Python console/notebook, check out our tool `geoviewer.py` in the {ref}`cli` documentation.
-```
-
-## Pythonic arithmetic and NumPy interface
-
-All {class}`~geoutils.Raster` objects support Python arithmetic ({func}`+<operator.add>`, {func}`-<operator.sub>`, {func}`/<operator.truediv>`, {func}`//<operator.floordiv>`, {func}`*<operator.mul>`,
-{func}`**<operator.pow>`, {func}`%<operator.mod>`) with any other {class}`~geoutils.Raster`, {class}`~numpy.ndarray` or
-number. With another {class}`~geoutils.Raster`, the georeferencing must match, while only the shape with a {class}`~numpy.ndarray`.
-
-```{code-cell} ipython3
-# Add 1 to the raster array
-rast += 1
-```
-
-Additionally, the class {class}`~geoutils.Raster` possesses a NumPy masked-array interface that allows to apply to it any [NumPy universal function](https://numpy.org/doc/stable/reference/ufuncs.html) and
-most other NumPy array functions, while logically casting {class}`dtypes<numpy.dtype>` and respecting {attr}`~geoutils.Raster.nodata` values.
-
-```{code-cell} ipython3
-# Apply a normalization to the raster
+# Use other arithmetic operations and NumPy functions directly on the raster
+# (Data types automatically cast, and operations respect nodata values)
 import numpy as np
-rast = (rast - np.min(rast)) / (np.max(rast) - np.min(rast))
-```
+calc_rast = np.log(rast / 2) + 3.5
 
-## Casting to {class}`~geoutils.Mask`, indexing and overload
+# Plot raster and vector, using raster as projection-reference for vector
+calc_rast.show(cmap='Spectral', cbar_title='My calculation')
+vect_buff.show(calc_rast, fc='none', ec='k', lw=0.5)
 
-All {class}`~geoutils.Raster` classes also support Python logical comparison operators ({func}`==<operator.eq>`, {func}` != <operator.ne>`, {func}`>=<operator.ge>`, {func}`><operator.gt>`, {func}`<=<operator.le>`,
-{func}`<<operator.lt>`), or more complex NumPy logical functions. Those operations automatically casts them into a {class}`~geoutils.Mask`, a subclass of {class}`~geoutils.Raster`.
-
-```{code-cell} ipython3
-# Get mask of an AOI: infrared index above 0.7, at least 200 m from glaciers
-mask_aoi = np.logical_and(rast > 0.7, rast_proximity_to_vec > 200)
-```
-
-Masks can then be used for indexing a {class}`~geoutils.Raster`, which returns a {class}`~numpy.ma.MaskedArray` of indexed values.
-
-```{code-cell} ipython3
-# Index raster with mask to extract a 1-D array
-values_aoi = rast[mask_aoi]
-```
-
-Masks also have simplified, overloaded {class}`~geoutils.Raster` methods due to their boolean {class}`dtypes<numpy.dtype>`. Using {func}`~geoutils.Raster.polygonize` with a
-{class}`~geoutils.Mask` is straightforward, for instance, to retrieve a {class}`~geoutils.Vector` of the area-of-interest:
-
-```{code-cell} ipython3
-# Polygonize areas where mask is True
-vect_aoi = mask_aoi.polygonize()
-```
-
-```{code-cell} ipython3
-# Plot result
-rast.show(cmap='Reds', cbar_title='Normalized infrared')
-vect_aoi.show(fc='none', ec='k', lw=0.5)
-```
-
-## Saving to file
-
-Finally, for saving a {class}`~geoutils.Raster` or {class}`~geoutils.Vector` to file, simply call the {func}`~geoutils.Raster.save` function.
-
-```{code-cell} ipython3
-# Save our AOI vector
-vect_aoi.save("myaoi.gpkg")
+# Save to file
+calc_rast.save("mycalc.tif")
 ```
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
 import os
-os.remove("myaoi.gpkg")
-```
-
-## Parsing metadata with {class}`~geoutils.SatelliteImage`
-
-In our case, `rast` would be better opened using the {class}`~geoutils.Raster` subclass {class}`~geoutils.SatelliteImage` instead, which tentatively parses
-metadata recognized from the filename or auxiliary files.
-
-```{code-cell} ipython3
-# Name of the image we used
-import os
-print(os.path.basename(filename_rast))
-```
-
-```{code-cell} ipython3
-# Open while parsing metadata
-rast = gu.SatelliteImage(filename_rast, silent=False)
-```
-
-```{admonition} Wrap-up
-In a few lines, we:
- - **easily handled georeferencing** operations on rasters and vectors,
- - performed numerical calculations **inherently respecting invalid data**,
- - **naturally casted to a mask** from a logical operation on raster, and
- - **straightforwardly vectorized a mask** by harnessing overloaded subclass methods.
-
-**Our result:** a vector of high infrared absorption indexes at least 200 meters away from glaciers
-near Everest, which likely corresponds to **perennial snowfields**.
-
-Otherwise, for more **hands-on** examples, explore GeoUtils' gallery of examples!
+os.remove("mycalc.tif")
 ```
 
 (quick-gallery)=

--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -65,7 +65,7 @@ rast = rast.crop(vect)
 # Buffer the vector by 500 meters no matter its current projection system
 vect_buff = vect.buffer_metric(500)
 
-# Create boolean mask of vector on same grid/CRS as raster using it as "match-reference"
+# Create mask of vector on same grid/CRS as raster using it as "match-reference"
 mask_buff = vect_buff.create_mask(rast)
 
 # Re-assign values of pixels in the mask while performing a sum

--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -14,8 +14,8 @@ kernelspec:
 
 # Quick start
 
-A short code example using several end-user functionalities of GeoUtils. For a more detailed example of all features, 
-have a look at the {ref}`feature-overview` page! Or, to find an example about 
+A short code example using several end-user functionalities of GeoUtils. For a more detailed example of all features,
+have a look at the {ref}`feature-overview` page! Or, to find an example about
 a specific functionality, jump to {ref}`quick-gallery` right below.
 
 ## Short example
@@ -23,27 +23,27 @@ a specific functionality, jump to {ref}`quick-gallery` right below.
 ```{note}
 :class: margin
 
-Most functions examplified here normally require many lines of code using several independent packages with inconsistent 
+Most functions examplified here normally require many lines of code using several independent packages with inconsistent
 geospatial syntax and volatile passing of metadata that can lead to errors!
 
 In GeoUtils, **these higher-level operations are tested to ensure robustness and consistency**. 🙂
 ```
 
-The package functionalities revolve around the 
+The package functionalities revolve around the
 {class}`~geoutils.Raster` and {class}`~geoutils.Vector` classes, from which most methods can be called.
-Below, in a few lines, we load a raster and a vector, crop them to a common extent, re-assign raster values around 
+Below, in a few lines, we load a raster and a vector, crop them to a common extent, re-assign raster values around
 a buffer of the vector, perform calculations on the modified raster, and finally plot and save it!
 
 <!--- An empty margin to add some vertical padding --->
 ```{margin}
-&nbsp;              
+&nbsp;
 ```
 
 
 ```{note}
 :class: margin
 
-**We notice a ``Userwarning``:** No nodata value was defined in the GeoTIFF file, so GeoUtils automatically defined 
+**We notice a ``Userwarning``:** No nodata value was defined in the GeoTIFF file, so GeoUtils automatically defined
 one compatible with the data type to use during operations.
 ```
 

--- a/doc/source/vector_class.md
+++ b/doc/source/vector_class.md
@@ -56,7 +56,7 @@ Detailed information on the {class}`~geoutils.Vector` is printed using {func}`~g
 
 ```{code-cell} ipython3
 # Print details of vector
-print(vect.info())
+vect.info()
 ```
 
 A {class}`~geoutils.Vector` is saved to file by calling {func}`~geoutils.Raster.save` with a {class}`str` or a {class}`pathlib.Path`.
@@ -171,7 +171,7 @@ intersecting geometries to the extent.
 ```{code-cell} ipython3
 # Crop vector to smaller bounds
 vect_crop = vect.crop(crop_geom=(-73.5, -46.6, -73.4, -46.5), clip=True)
-print(vect_crop.info())
+vect_crop.info()
 ```
 
 ## Rasterize

--- a/examples/handling/georeferencing/crop_raster.py
+++ b/examples/handling/georeferencing/crop_raster.py
@@ -18,7 +18,7 @@ vect = vect[vect["RGIId"] == "RGI60-15.10055"]
 
 # %%
 # The first raster has larger extent and higher resolution than the vector.
-print(rast.info())
+rast.info()
 print(vect.bounds)
 
 # %%

--- a/examples/handling/georeferencing/reproj_raster.py
+++ b/examples/handling/georeferencing/reproj_raster.py
@@ -16,8 +16,8 @@ rast2 = gu.Raster(filename_rast2)
 
 # %%
 # The first raster has larger extent and higher resolution than the second one.
-print(rast1.info())
-print(rast2.info())
+rast1.info()
+rast2.info()
 
 # %%
 # Let's plot the first raster, with the warped extent of the second one.
@@ -43,7 +43,7 @@ rast1_warped
 #
 # Now the shape and georeferencing should be the same as that of the second raster, shown above.
 
-print(rast1_warped.info())
+rast1_warped.info()
 
 # %%
 # We can plot the two rasters next to one another
@@ -59,4 +59,4 @@ rast2.show(ax="new", cmap="Blues")
 rast2.set_nodata(0)
 # Pass the desired georeferencing parameters
 rast2_warped = rast2.reproject(grid_size=(100, 100), crs=32645)
-print(rast2_warped.info())
+rast2_warped.info()

--- a/examples/handling/georeferencing/reproj_vector.py
+++ b/examples/handling/georeferencing/reproj_vector.py
@@ -17,8 +17,8 @@ vect = gu.Vector(filename_vect)
 
 # %%
 # The two objects are in different projections.
-print(rast.info())
-print(vect.info())
+rast.info()
+vect.info()
 
 # %%
 # Let's plot the two in their original projection.

--- a/examples/io/import_export/from_array.py
+++ b/examples/io/import_export/from_array.py
@@ -29,7 +29,7 @@ rast
 
 # %%
 # We can print info on the raster.
-print(rast.info())
+rast.info()
 
 # %%
 # The array has been automatically cast into a :class:`~numpy.ma.MaskedArray`, to respect :class:`~geoutils.Raster.nodata` values.

--- a/examples/io/open_save/read_raster.py
+++ b/examples/io/open_save/read_raster.py
@@ -24,7 +24,7 @@ rast
 #        A raster can also be instantiated with a :class:`rasterio.io.DatasetReader` or a :class:`rasterio.io.MemoryFile`, see :ref:`sphx_glr_io_examples_import_export_import_raster.py`.
 #
 # We can print more info on the raster.
-print(rast.info())
+rast.info()
 
 # %%
 # The data will be loaded explicitly by any function requiring its :attr:`~geoutils.Raster.data`, such as :func:`~geoutils.Raster.show`.

--- a/examples/io/open_save/read_vector.py
+++ b/examples/io/open_save/read_vector.py
@@ -23,7 +23,7 @@ vect
 #        A vector can also be instantiated with a :class:`geopandas.GeoDataFrame`, see :ref:`sphx_glr_io_examples_import_export_import_vector.py`.
 #
 # We can print more info on the vector.
-print(vect.info())
+vect.info()
 
 # %%
 # Let's plot by vector area

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -54,7 +54,8 @@ class TestDocs:
                 list(executor.map(run_code, filenames))
             """
 
-            os.chdir(current_dir)
+        os.chdir(current_dir)
+        
 
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -14,6 +14,7 @@ class TestDocs:
     def test_example_code(self) -> None:
         """Try running each python script in the doc/source/code\
                 directory and check that it doesn't raise an error."""
+        current_dir = os.getcwd()
         os.chdir(os.path.join(self.docs_dir, "source"))
 
         def run_code(filename: str) -> None:
@@ -44,7 +45,6 @@ class TestDocs:
         # Some of the doc scripts in code/ fails on Windows due to permission errors
         if (platform.system() == "Linux") or (platform.system() == "Darwin"):
 
-            current_dir = os.getcwd()
             for filename in filenames:
                 run_code(filename)
             """

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -55,7 +55,6 @@ class TestDocs:
             """
 
         os.chdir(current_dir)
-        
 
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -11,6 +11,48 @@ class TestDocs:
     docs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../", "doc/")
     n_threads = os.getenv("N_CPUS")
 
+    def test_example_code(self) -> None:
+        """Try running each python script in the doc/source/code\
+                directory and check that it doesn't raise an error."""
+        current_dir = os.getcwd()
+        os.chdir(os.path.join(self.docs_dir, "source"))
+
+        def run_code(filename: str) -> None:
+            """Run a python script in one thread."""
+            with open(filename) as infile:
+                # Run everything except plt.show() calls.
+                with warnings.catch_warnings():
+                    # When running the code asynchronously, matplotlib complains a bit
+                    ignored_warnings = [
+                        "Starting a Matplotlib GUI outside of the main thread",
+                        ".*fetching the attribute.*Polygon.*",
+                    ]
+                    # This is a GeoPandas issue
+                    warnings.simplefilter("error")
+
+                    for warning_text in ignored_warnings:
+                        warnings.filterwarnings("ignore", warning_text)
+                    try:
+                        exec(infile.read().replace("plt.show()", "plt.close()"))
+                    except Exception as exception:
+                        if isinstance(exception, DeprecationWarning):
+                            print(exception)
+                        else:
+                            raise RuntimeError(f"Failed on {filename}") from exception
+
+        filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
+
+        for filename in filenames:
+            run_code(filename)
+        """
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=int(self.n_threads) if self.n_threads is not None else None
+        ) as executor:
+            list(executor.map(run_code, filenames))
+        """
+
+        os.chdir(current_dir)
+
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -14,7 +14,6 @@ class TestDocs:
     def test_example_code(self) -> None:
         """Try running each python script in the doc/source/code\
                 directory and check that it doesn't raise an error."""
-        current_dir = os.getcwd()
         os.chdir(os.path.join(self.docs_dir, "source"))
 
         def run_code(filename: str) -> None:
@@ -42,16 +41,20 @@ class TestDocs:
 
         filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
 
-        for filename in filenames:
-            run_code(filename)
-        """
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=int(self.n_threads) if self.n_threads is not None else None
-        ) as executor:
-            list(executor.map(run_code, filenames))
-        """
+        # Some of the doc scripts in code/ fails on Windows due to permission errors
+        if (platform.system() == "Linux") or (platform.system() == "Darwin"):
 
-        os.chdir(current_dir)
+            current_dir = os.getcwd()
+            for filename in filenames:
+                run_code(filename)
+            """
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=int(self.n_threads) if self.n_threads is not None else None
+            ) as executor:
+                list(executor.map(run_code, filenames))
+            """
+
+            os.chdir(current_dir)
 
     def test_build(self) -> None:
         """Try building the documentation and see if it works."""


### PR DESCRIPTION
We're nearly at `v0.1`!! The final touches on the documentation :slightly_smiling_face: 
(There isn't actually many changes, it's just that one doc page was renamed)

Here's the new doc: https://geoutils-rhugonnet.readthedocs.io/en/update_quickstart/

This PR:
- Turns the old "Quick start" (that was far too long, but valuable) into a new page "Feature overview" (with almost no change), for users that want more details on all features centralized in a starting page,
- Adds a new "Quick start" that consists of a single code cell show-casing a short example with a couple core functionalities, and the links to Gallery examples at the bottom,
- Updates some statements at the landing page + simplifies the page (removes the long description that came first, felt a bit too much), and removes the "Tip" to use Binder: I checked, it still works but is capricious, and doesn't seem so popular anyway; people are starting to know the "rocket" at the top can be used for this).

After review, also:
- Refactor all the `print(rast_or_vect.info())` into just `.info()`,
- Updates the API with some missing functions,
- And other minor things.