### PR TITLE
Make `interp_points` robust to non-equal grids and impractical default SciPy arguments

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -188,6 +188,11 @@ html_theme_options = {
         "binderhub_url": "https://mybinder.org/",
         "notebook_interface": "jupyterlab",  # For launching Binder in Jupyterlab to open MD files as notebook (downloads them otherwise)
     },
+    "announcement": (
+        "⚠️ Our 0.1 release refactored several early-development functions for long-term stability, "
+        'to update your code see <a href="https://github.com/GlacioHack/geoutils/releases/tag/v0.1.0">here</a>. ⚠️'
+        "<br>Future changes will come with deprecation warnings! 🙂"
+    )
     # "logo_only": True,
     # "icon_links": [
     #         {

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -317,7 +317,7 @@ rast_reproj.value_at_coords(x=0.5, y=0.5, window=3, reducer_function=np.ma.media
 
 ```{code-cell} ipython3
 # Interpolate coordinate value with quintic algorithm
-rast_reproj.interp_points([(0.5, 0.5)], mode="quintic")
+rast_reproj.interp_points([(0.5, 0.5)], method="quintic")
 ```
 
 ```{note}

--- a/examples/analysis/point_extraction/interpolation.py
+++ b/examples/analysis/point_extraction/interpolation.py
@@ -50,7 +50,7 @@ rast.tags["AREA_OR_POINT"] = "Point"
 # %%
 # We can interpolate again by shifting according to our interpretation, and changing the resampling algorithm (default to "linear").
 
-vals_shifted = rast.interp_points(points=list(zip(x_coords, y_coords)), shift_area_or_point=True, mode="quintic")
+vals_shifted = rast.interp_points(points=list(zip(x_coords, y_coords)), shift_area_or_point=True, method="quintic")
 np.nanmean(vals - vals_shifted)
 
 # %%

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3282,7 +3282,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # If the raster is on an equal grid, use scipy.ndimage.map_coordinates
         force_map_coords = force_scipy_function is not None and force_scipy_function == "map_coordinates"
-        if self.res[0] == self.res[1] or force_map_coords:
+        force_interpn = force_scipy_function is not None and force_scipy_function == "interpn"
+
+        if (self.res[0] == self.res[1] or force_map_coords) and not force_interpn:
 
             # Convert method name into order
             method_to_order = {"nearest": 0, "linear": 1, "cubic": 3, "quintic": 5}
@@ -3300,7 +3302,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         # Otherwise, use scipy.interpolate.interpn
         else:
 
-            xycoords = self.coords(offset="center", grid=False)
+            xycoords = self.coords(offset="corner", grid=False)
 
             # Let interpolation outside the bounds not raise any error by default
             if "bounds_error" not in kwargs.keys():
@@ -3309,7 +3311,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             if "fill_value" not in kwargs.keys():
                 kwargs.update({"fill_value": np.nan})
 
-            rpoints = interpn(xycoords, self.get_nanarray(), np.array([i, j]), method=method, **kwargs)
+            rpoints = interpn(xycoords, self.get_nanarray(), np.array([i, j]).T, method=method, **kwargs)
 
         rpoints = np.array(rpoints, dtype=np.float32)
         rpoints[np.array(ind_invalid)] = np.nan

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3251,8 +3251,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         :param points: Point(s) at which to interpolate raster value. If points fall outside of image, value
             returned is nan. Shape should be (N,2).
         :param method: Interpolation method, one of 'nearest', 'linear', 'cubic', or 'quintic'. For more information,
-        see scipy.ndimage.map_coordinates and scipy.interpolate.interpn.
-            Default is linear.
+            see scipy.ndimage.map_coordinates and scipy.interpolate.interpn. Default is linear.
         :param band: Band to use (from 1 to self.count).
         :param input_latlon: Whether the input is in latlon, unregarding of Raster CRS
         :param shift_area_or_point: Shifts index to center pixel coordinates if GDAL's AREA_OR_POINT

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -27,8 +27,8 @@ from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.features import shapes
 from rasterio.plot import show as rshow
-from scipy.ndimage import distance_transform_edt, map_coordinates
 from scipy.interpolate import interpn
+from scipy.ndimage import distance_transform_edt, map_coordinates
 
 import geoutils.vector as gv
 from geoutils._typing import (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 author = The GlacioHack Team
 name = geoutils
-version = 0.0.17
+version = 0.1.0
 description = Analysis and handling of georeferenced rasters and vectors
 keywords = raster, vector, geospatial, gis, xarray
 long_description = file: README.md

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1924,12 +1924,17 @@ class TestRaster:
 
         # Warnings should be raised when AREA_OR_POINT is None similarly, we ignore them from now on
         if tag_aop is None and shift_aop:
-            warnings.filterwarnings("ignore", category=UserWarning,
-                                    message="Attribute AREA_OR_POINT undefined in self.tags*")
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="Attribute AREA_OR_POINT undefined in self.tags*"
+            )
 
         raster_points_lin = raster.interp_points(points, method="linear", shift_area_or_point=shift_aop)
-        raster_points_interpn = raster.interp_points(points, method="nearest", force_scipy_function="interpn", shift_area_or_point=shift_aop)
-        raster_points_interpn_lin = raster.interp_points(points, method="linear", force_scipy_function="interpn", shift_area_or_point=shift_aop)
+        raster_points_interpn = raster.interp_points(
+            points, method="nearest", force_scipy_function="interpn", shift_area_or_point=shift_aop
+        )
+        raster_points_interpn_lin = raster.interp_points(
+            points, method="linear", force_scipy_function="interpn", shift_area_or_point=shift_aop
+        )
 
         assert np.array_equal(raster_points, raster_points_lin)
         assert np.array_equal(raster_points, raster_points_interpn)
@@ -1956,7 +1961,9 @@ class TestRaster:
 
         # Here again compare methods
         raster_points_in = raster.interp_points(points_in, method="linear", shift_area_or_point=shift_aop)
-        raster_points_in_interpn = raster.interp_points(points_in, method="linear", force_scipy_function="interpn", shift_area_or_point=shift_aop)
+        raster_points_in_interpn = raster.interp_points(
+            points_in, method="linear", force_scipy_function="interpn", shift_area_or_point=shift_aop
+        )
 
         assert np.array_equal(raster_points_in, raster_points_in_interpn)
 
@@ -1997,7 +2004,9 @@ class TestRaster:
             raster_points_mapcoords = raster.interp_points(
                 points_in_rand, method=method, force_scipy_function="map_coordinates", shift_area_or_point=shift_aop
             )
-            raster_points_interpn = raster.interp_points(points_in_rand, method=method, force_scipy_function="interpn", shift_area_or_point=shift_aop)
+            raster_points_interpn = raster.interp_points(
+                points_in_rand, method=method, force_scipy_function="interpn", shift_area_or_point=shift_aop
+            )
 
             assert np.array_equal(raster_points_mapcoords, raster_points_interpn)
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1940,14 +1940,13 @@ class TestRaster:
 
         # Check bilinear extrapolation for points at 1 spacing outside from the input grid
         points_out = (
-                [(-1, i) for i in np.arange(1, 4)]
-                + [(i, -1) for i in np.arange(1, 4)]
-                + [(4, i) for i in np.arange(1, 4)]
-                + [(i, 4) for i in np.arange(4, 1)]
+            [(-1, i) for i in np.arange(1, 4)]
+            + [(i, -1) for i in np.arange(1, 4)]
+            + [(4, i) for i in np.arange(1, 4)]
+            + [(i, 4) for i in np.arange(4, 1)]
         )
         raster_points_out = raster.interp_points(points_out)
         assert all(~np.isfinite(raster_points_out))
-
 
     def test_value_at_coords(self) -> None:
         """

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1892,6 +1892,8 @@ class TestRaster:
         arr = np.flipud(np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((3, 3)))
         transform = rio.transform.from_bounds(0, 0, 3, 3, 3, 3)
         raster = gu.Raster.from_array(data=arr, transform=transform, crs=None, nodata=-9999)
+
+        # Define the AREA_OR_POINT attribute
         raster.tags = {"AREA_OR_POINT": tag_aop}
 
         # Check interpolation falls right on values for points (1, 1), (1, 2) etc...
@@ -1922,7 +1924,7 @@ class TestRaster:
         else:
             raster_points = raster.interp_points(points, method="nearest", shift_area_or_point=shift_aop)
 
-        # Warnings should be raised when AREA_OR_POINT is None similarly, we ignore them from now on
+        # Warnings should be raised when AREA_OR_POINT is None everywhere, so we ignore them from now on
         if tag_aop is None and shift_aop:
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="Attribute AREA_OR_POINT undefined in self.tags*"

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1961,12 +1961,10 @@ class TestRaster:
         points_in_rand = np.array((points_x_rand, points_y_rand)).T
 
         for method in ["nearest", "linear", "cubic", "quintic"]:
-            raster_points_mapcoords = raster.interp_points(points_in_rand,
-                                                           method=method,
-                                                           force_scipy_function="map_coordinates")
-            raster_points_interpn = raster.interp_points(points_in_rand,
-                                                         method=method,
-                                                         force_scipy_function="interpn")
+            raster_points_mapcoords = raster.interp_points(
+                points_in_rand, method=method, force_scipy_function="map_coordinates"
+            )
+            raster_points_interpn = raster.interp_points(points_in_rand, method=method, force_scipy_function="interpn")
 
             assert np.array_equal(raster_points_mapcoords, raster_points_interpn)
 
@@ -1979,12 +1977,12 @@ class TestRaster:
 
         # Nearest doesn't apply, just linear and above
         for method in ["cubic", "quintic"]:
-            raster_points_mapcoords_edge = raster.interp_points(points_edge_rand,
-                                                                method=method,
-                                                                force_scipy_function="map_coordinates")
-            raster_points_interpn_edge = raster.interp_points(points_edge_rand,
-                                                              method=method,
-                                                              force_scipy_function="interpn")
+            raster_points_mapcoords_edge = raster.interp_points(
+                points_edge_rand, method=method, force_scipy_function="map_coordinates"
+            )
+            raster_points_interpn_edge = raster.interp_points(
+                points_edge_rand, method=method, force_scipy_function="interpn"
+            )
 
             assert all(~np.isfinite(raster_points_mapcoords_edge))
             assert all(~np.isfinite(raster_points_interpn_edge))

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1834,7 +1834,7 @@ class TestRaster:
             list_z_ind.append(z_ind)
 
         # First order interpolation
-        rpts = r.interp_points(pts, order=1)
+        rpts = r.interp_points(pts, method="linear")
         # The values interpolated should be equal
         assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
@@ -1866,7 +1866,7 @@ class TestRaster:
             z_ind = img[int(i[k]), int(j[k])]
             list_z_ind.append(z_ind)
 
-        rpts = r.interp_points(pts, order=1)
+        rpts = r.interp_points(pts, method="linear")
 
         assert np.array_equal(np.array(list_z_ind, dtype=np.float32), rpts, equal_nan=True)
 
@@ -1874,13 +1874,13 @@ class TestRaster:
         x = 493120.0
         y = 3101000.0
         i, j = r.xy2ij(x, y)
-        val = r.interp_points([(x, y)], order=1)[0]
+        val = r.interp_points([(x, y)], method="linear")[0]
         val_img = img[int(i[0]), int(j[0])]
         assert val_img == val
 
         # Finally, check that interp convert to latlon
         lat, lon = gu.projtools.reproject_to_latlon([x, y], in_crs=r.crs)
-        val_latlon = r.interp_points([(lat, lon)], order=1, input_latlon=True)[0]
+        val_latlon = r.interp_points([(lat, lon)], method="linear", input_latlon=True)[0]
         assert val == pytest.approx(val_latlon, abs=0.0001)
 
     def test_value_at_coords(self) -> None:


### PR DESCRIPTION
This PR:
- Makes the behaviour of `interp_points` consistent between equal and regular grid by using both `map_coordinates` and `interpn` from SciPy depending on the grid,
- Removes the default `prefilter` argument of `map_coordinates` that created large data gaps,
- Corrects the `method` argument for `map_coordinates` by mapping it into an `order` argument,
- Adds detailed tests with synthetic data to ensure all results are consistent, in addition to the ones existing in `test_xy2ij`.

Resolves #483 

TO-DO:

- [x] Test the consistency of the `AREA_OR_POINT` argument between the methods.
