### PR TITLE
Make `Raster.to_pointcloud()` modular and add `Raster.get_mask()` for memory-efficient operations requiring mask

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -107,6 +107,7 @@ documentation.
     Raster.set_mask
     Raster.set_nodata
     Raster.get_nanarray
+    Raster.get_mask
     Raster.subsample
 ```
 

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -118,7 +118,7 @@ documentation.
 
     Raster.load
     Raster.save
-    Raster.to_points
+    Raster.to_pointcloud
     Raster.to_rio_dataset
     Raster.to_xarray
 ```

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -332,7 +332,7 @@ A {class}`~geoutils.Raster` can be exported to different formats, to facilitate 
 Those include exporting to:
 - a {class}`xarray.Dataset` with {class}`~geoutils.Raster.to_xarray`,
 - a {class}`rasterio.io.DatasetReader` with {class}`~geoutils.Raster.to_rio_dataset`,
-- a {class}`numpy.ndarray` or {class}`geoutils.Vector` as a point cloud with {class}`~geoutils.Raster.to_points`.
+- a {class}`numpy.ndarray` or {class}`geoutils.Vector` as a point cloud with {class}`~geoutils.Raster.to_pointcloud`.
 
 ```{code-cell} ipython3
 # Export to rasterio dataset-reader through a memoryfile
@@ -341,7 +341,7 @@ rast_reproj.to_rio_dataset()
 
 ```{code-cell} ipython3
 # Export to geopandas dataframe
-rast_reproj.to_points()
+rast_reproj.to_pointcloud()
 ```
 
 ```{code-cell} ipython3

--- a/examples/handling/interface/topoints.py
+++ b/examples/handling/interface/topoints.py
@@ -19,7 +19,7 @@ rast.crop([rast.bounds.left, rast.bounds.bottom, rast.bounds.left + 500, rast.bo
 rast.plot(cmap="terrain")
 
 # %%
-# We convert the raster to points. By default, this returns a vector with columb geometry burned.
+# We convert the raster to points. By default, this returns a vector with column geometry burned.
 
 pts_rast = rast.to_pointcloud()
 pts_rast
@@ -27,4 +27,4 @@ pts_rast
 # %%
 # We plot the point vector.
 
-pts_rast.ds.plot(column="b1", cmap="terrain", legend=True)
+pts_rast.plot(ax="new", column="b1", cmap="terrain", legend=True)

--- a/examples/handling/interface/topoints.py
+++ b/examples/handling/interface/topoints.py
@@ -27,4 +27,4 @@ pts_rast
 # %%
 # We plot the point vector.
 
-pts_rast.plot(column="b1", cmap="terrain", legend=True)
+pts_rast.ds.plot(column="b1", cmap="terrain", legend=True)

--- a/examples/handling/interface/topoints.py
+++ b/examples/handling/interface/topoints.py
@@ -21,7 +21,7 @@ rast.plot(cmap="terrain")
 # %%
 # We convert the raster to points. By default, this returns a vector with columb geometry burned.
 
-pts_rast = rast.to_points()
+pts_rast = rast.to_pointcloud()
 pts_rast
 
 # %%

--- a/geoutils/raster/array.py
+++ b/geoutils/raster/array.py
@@ -10,7 +10,7 @@ import geoutils as gu
 from geoutils._typing import MArrayNum, NDArrayBool, NDArrayNum
 
 
-def get_mask(array: NDArrayNum | NDArrayBool | MArrayNum) -> NDArrayBool:
+def get_mask_from_array(array: NDArrayNum | NDArrayBool | MArrayNum) -> NDArrayBool:
     """
     Return the mask of invalid values, whether array is a ndarray with NaNs or a np.ma.masked_array.
 
@@ -59,7 +59,7 @@ def get_array_and_mask(
     array_data = np.array(array).squeeze() if copy else np.asarray(array).squeeze()
 
     # Get the mask of invalid pixels and set nans if it is occupied.
-    invalid_mask = get_mask(array)
+    invalid_mask = get_mask_from_array(array)
     if np.any(invalid_mask):
         array_data[invalid_mask] = np.nan
 
@@ -71,7 +71,7 @@ def get_valid_extent(array: NDArrayNum | NDArrayBool | MArrayNum) -> tuple[int, 
     Return (rowmin, rowmax, colmin, colmax), the first/last row/column of array with valid pixels
     """
     if not array.dtype == "bool":
-        valid_mask = ~get_mask(array)
+        valid_mask = ~get_mask_from_array(array)
     else:
         # Not sure why Mypy is not recognizing that the type of the array can only be bool here
         valid_mask = array  # type: ignore

--- a/geoutils/raster/array.py
+++ b/geoutils/raster/array.py
@@ -7,10 +7,10 @@ import warnings
 import numpy as np
 
 import geoutils as gu
-from geoutils._typing import MArrayNum, NDArrayNum
+from geoutils._typing import MArrayNum, NDArrayBool, NDArrayNum
 
 
-def get_mask(array: NDArrayNum | MArrayNum) -> NDArrayNum:
+def get_mask(array: NDArrayNum | NDArrayBool | MArrayNum) -> NDArrayBool:
     """
     Return the mask of invalid values, whether array is a ndarray with NaNs or a np.ma.masked_array.
 
@@ -24,7 +24,7 @@ def get_mask(array: NDArrayNum | MArrayNum) -> NDArrayNum:
 
 def get_array_and_mask(
     array: NDArrayNum | MArrayNum, check_shape: bool = True, copy: bool = True
-) -> tuple[NDArrayNum, NDArrayNum]:
+) -> tuple[NDArrayNum, NDArrayBool]:
     """
     Return array with masked values set to NaN and the associated mask.
     Works whether array is a ndarray with NaNs or a np.ma.masked_array.
@@ -66,14 +66,15 @@ def get_array_and_mask(
     return array_data, invalid_mask
 
 
-def get_valid_extent(array: NDArrayNum | MArrayNum) -> tuple[int, ...]:
+def get_valid_extent(array: NDArrayNum | NDArrayBool | MArrayNum) -> tuple[int, ...]:
     """
     Return (rowmin, rowmax, colmin, colmax), the first/last row/column of array with valid pixels
     """
     if not array.dtype == "bool":
         valid_mask = ~get_mask(array)
     else:
-        valid_mask = array
+        # Not sure why Mypy is not recognizing that the type of the array can only be bool here
+        valid_mask = array  # type: ignore
     cols_nonzero = np.where(np.count_nonzero(valid_mask, axis=0) > 0)[0]
     rows_nonzero = np.where(np.count_nonzero(valid_mask, axis=1) > 0)[0]
     return rows_nonzero[0], rows_nonzero[-1], cols_nonzero[0], cols_nonzero[-1]

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1057,7 +1057,7 @@ class Raster:
             [
                 np.array_equal(self.data.data, other.data.data, equal_nan=True),
                 # Use getmaskarray to avoid comparing boolean with array when mask=False
-                np.array_equal(np.ma.getmaskarray(self.data.mask), np.ma.getmaskarray(other.data.mask)),
+                np.array_equal(np.ma.getmaskarray(self.data), np.ma.getmaskarray(other.data)),
                 self.data.fill_value == other.data.fill_value,
                 self.data.dtype == other.data.dtype,
                 self.transform == other.transform,
@@ -3506,7 +3506,8 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         Optionally, all other bands can also be stored in columns "b1", "b2", etc. For more specific band selection,
         use Raster.split_bands previous to converting to point cloud.
 
-        Optionally, randomly subsample valid pixels of the data band (nodata values are skipped).
+        Optionally, randomly subsample valid pixels for the data band (nodata values are skipped, but only for the band
+        that will be used as data column of the point cloud).
         If 'subsample' is either 1, or is equal to the pixel count, all valid points are returned.
         If 'subsample' is smaller than 1 (for fractions), or smaller than the pixel count, a random subsample
         of valid points is returned.
@@ -3544,7 +3545,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if data_band != 1 and data_column_name == "b1":
             data_column_name = "b" + str(data_band)
 
-        # The valid mask is considered only for the data band
+        # We do 2D subsampling on the data band only, regardless of valid masks on other bands
         if self.is_loaded:
             if self.count == 1:
                 self_mask = get_mask_from_array(self.data)  # This is to avoid the case where the mask is just "False"

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -45,8 +45,8 @@ from geoutils.projtools import (
     _get_footprint_projected,
     _get_utm_ups_crs,
 )
-from geoutils.raster.sampling import subsample_array
 from geoutils.raster.array import get_mask
+from geoutils.raster.sampling import subsample_array
 from geoutils.vector import Vector
 
 # If python38 or above, Literal is builtin. Otherwise, use typing_extensions
@@ -255,6 +255,7 @@ def _load_rio(
         else:
             data = dataset.read(indexes=indexes, masked=masked, window=window, **kwargs)
     return data
+
 
 def _get_reproject_params(
     raster: RasterType,
@@ -3534,7 +3535,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 self_mask = get_mask(self.data)  # This is to avoid the case where the mask is just "False"
                 valid_mask = ~self_mask
             else:
-                self_mask = get_mask(self.data[data_band - 1, :, :])  # This is to avoid the case where the mask is just "False"
+                self_mask = get_mask(
+                    self.data[data_band - 1, :, :]
+                )  # This is to avoid the case where the mask is just "False"
                 valid_mask = ~self_mask
 
         # Load only mask of valid data from disk if array not loaded

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -10,7 +10,7 @@ import warnings
 from collections import abc
 from contextlib import ExitStack
 from math import floor
-from typing import IO, Any, Callable, TypeVar, overload, Iterable
+from typing import IO, Any, Callable, Iterable, TypeVar, overload
 
 import affine
 import geopandas as gpd
@@ -3558,7 +3558,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if not isinstance(data_column_name, str):
             raise ValueError("Data column name must be a string.")
         if not (isinstance(data_band, int) and data_band >= 1 and data_band <= self.count):
-            raise ValueError(f"Data band number must be an integer between 1 and the total number of bands ({self.count}).")
+            raise ValueError(
+                f"Data band number must be an integer between 1 and the total number of bands ({self.count})."
+            )
 
         # Rename data column if a different band is selected but the name is still default
         if data_band != 1 and data_column_name == "b1":
@@ -3568,20 +3570,31 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         if auxiliary_column_names is not None and auxiliary_data_bands is None:
             raise ValueError("Passing auxiliary column names requires passing auxiliary data band numbers as well.")
         if auxiliary_data_bands is not None:
-            if not (isinstance(auxiliary_data_bands, Iterable) and all(isinstance(b, int) for b in auxiliary_data_bands)):
+            if not (
+                isinstance(auxiliary_data_bands, Iterable) and all(isinstance(b, int) for b in auxiliary_data_bands)
+            ):
                 raise ValueError("Auxiliary data band number must be an iterable containing only integers.")
             if any((1 > b or self.count < b) for b in auxiliary_data_bands):
-                raise ValueError(f"Auxiliary data band numbers must be between 1 and the total number of bands ({self.count}).")
+                raise ValueError(
+                    f"Auxiliary data band numbers must be between 1 and the total number of bands ({self.count})."
+                )
             if data_band in auxiliary_data_bands:
-                raise ValueError(f"Main data band {data_band} should not be listed in auxiliary data bands {auxiliary_data_bands}.")
+                raise ValueError(
+                    f"Main data band {data_band} should not be listed in auxiliary data bands {auxiliary_data_bands}."
+                )
 
             # Ensure auxiliary column name is defined if auxiliary data bands is not None
             if auxiliary_column_names is not None:
-                if not (isinstance(auxiliary_column_names, Iterable) and all(isinstance(b, str) for b in auxiliary_column_names)):
+                if not (
+                    isinstance(auxiliary_column_names, Iterable)
+                    and all(isinstance(b, str) for b in auxiliary_column_names)
+                ):
                     raise ValueError("Auxiliary column names must be an iterable containing only strings.")
                 if not len(auxiliary_column_names) == len(auxiliary_data_bands):
-                    raise ValueError(f"Length of auxiliary column name and data band numbers should be the same, "
-                                     f"found {len(auxiliary_column_names)} and {len(auxiliary_data_bands)} respectively.")
+                    raise ValueError(
+                        f"Length of auxiliary column name and data band numbers should be the same, "
+                        f"found {len(auxiliary_column_names)} and {len(auxiliary_data_bands)} respectively."
+                    )
 
             else:
                 auxiliary_column_names = [f"b{i}" for i in auxiliary_data_bands]

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -11,7 +11,6 @@ from collections import abc
 from contextlib import ExitStack
 from math import floor
 from typing import IO, Any, Callable, TypeVar, overload
-from packaging.version import Version
 
 import affine
 import geopandas as gpd
@@ -24,6 +23,7 @@ import rasterio.warp
 import rasterio.windows
 from affine import Affine
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from packaging.version import Version
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.features import shapes
@@ -41,6 +41,7 @@ from geoutils._typing import (
     NDArrayNum,
     Number,
 )
+from geoutils.misc import deprecate
 from geoutils.projtools import (
     _get_bounds_projected,
     _get_footprint_projected,
@@ -49,7 +50,6 @@ from geoutils.projtools import (
 from geoutils.raster.array import get_mask_from_array
 from geoutils.raster.sampling import subsample_array
 from geoutils.vector import Vector
-from geoutils.misc import deprecate
 
 # If python38 or above, Literal is builtin. Otherwise, use typing_extensions
 try:
@@ -3443,8 +3443,10 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         return raster_bands
 
-    @deprecate(Version("0.3.0"), "Raster.to_points() is deprecated in favor of Raster.to_pointcloud() and "
-                                 "will be removed in v0.3.")
+    @deprecate(
+        Version("0.3.0"),
+        "Raster.to_points() is deprecated in favor of Raster.to_pointcloud() and " "will be removed in v0.3.",
+    )
     def to_points(self, **kwargs):  # type: ignore
 
         self.to_pointcloud(**kwargs)  # type: ignore

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3576,9 +3576,9 @@ np.ndarray or number and correct dtype, the compatible nodata value.
             with rio.open(self.filename) as raster:
                 pixel_data = np.array(list(raster.sample(zip(x_coords, y_coords), indexes=bands_to_extract))).T
 
-        # Fill masked array with NaNs before writing to points
+        # At this point there should not be any nodata anymore, so we can transform everything to normal array
         if np.ma.isMaskedArray(pixel_data):
-            pixel_data = pixel_data.filled(np.nan)
+            pixel_data = pixel_data.data
 
         # Now we force the coordinates we define for the point cloud, according to pixel interpretation
         x_coords_2, y_coords_2 = (np.array(a) for a in self.ij2xy(indices[0], indices[1], offset=force_pixel_offset))

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -11,6 +11,7 @@ from collections import abc
 from contextlib import ExitStack
 from math import floor
 from typing import IO, Any, Callable, TypeVar, overload
+from packaging.version import Version
 
 import affine
 import geopandas as gpd
@@ -48,6 +49,7 @@ from geoutils.projtools import (
 from geoutils.raster.array import get_mask_from_array
 from geoutils.raster.sampling import subsample_array
 from geoutils.vector import Vector
+from geoutils.misc import deprecate
 
 # If python38 or above, Literal is builtin. Otherwise, use typing_extensions
 try:
@@ -3440,6 +3442,12 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 )
 
         return raster_bands
+
+    @deprecate(Version("0.3.0"), "Raster.to_points() is deprecated in favor of Raster.to_pointcloud() and "
+                                 "will be removed in v0.3.")
+    def to_points(self, **kwargs):  # type: ignore
+
+        self.to_pointcloud(**kwargs)  # type: ignore
 
     @overload
     def to_pointcloud(

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -72,6 +72,14 @@ def subsample_array(
     valids = np.argwhere(~mask.flatten()).squeeze()
 
     # Get number of points to extract
+    # If subsample is one, we don't perform subsampling any operation, we return the valid array or indices
+    if subsample == 1:
+        unraveled_indices = np.unravel_index(valids, array.shape)
+        if return_indices:
+            return unraveled_indices
+
+        else:
+            return array[unraveled_indices]
     if (subsample <= 1) & (subsample > 0):
         npoints = int(subsample * np.count_nonzero(~mask))
     elif subsample > 1:
@@ -90,7 +98,6 @@ def subsample_array(
 
     if return_indices:
         return unraveled_indices
-
     else:
         return array[unraveled_indices]
 

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -7,7 +7,7 @@ from typing import Literal, overload
 import numpy as np
 
 from geoutils._typing import MArrayNum, NDArrayNum
-from geoutils.raster.array import get_mask
+from geoutils.raster.array import get_mask_from_array
 
 
 @overload
@@ -68,7 +68,7 @@ def subsample_array(
         rnd = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(random_state)))
 
     # Remove invalid values and flatten array
-    mask = get_mask(array)  # -> need to remove .squeeze in get_mask
+    mask = get_mask_from_array(array)  # -> need to remove .squeeze in get_mask
     valids = np.argwhere(~mask.flatten()).squeeze()
 
     # Get number of points to extract

--- a/geoutils/raster/sampling.py
+++ b/geoutils/raster/sampling.py
@@ -72,12 +72,11 @@ def subsample_array(
     valids = np.argwhere(~mask.flatten()).squeeze()
 
     # Get number of points to extract
-    # If subsample is one, we don't perform subsampling any operation, we return the valid array or indices
+    # If subsample is one, we don't perform any subsampling operation, we return the valid array or indices directly
     if subsample == 1:
         unraveled_indices = np.unravel_index(valids, array.shape)
         if return_indices:
             return unraveled_indices
-
         else:
             return array[unraveled_indices]
     if (subsample <= 1) & (subsample > 0):

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -206,12 +206,7 @@ class Vector:
 
         # Create axes, or get current ones by default (like in matplotlib)
         if ax is None:
-            # If no figure exists, get a new axis
-            if len(plt.get_fignums()) == 0:
-                ax0 = plt.gca()
-            # Otherwise, get first axis
-            else:
-                ax0 = plt.gcf().axes[0]
+            ax0 = plt.gca()
         elif isinstance(ax, str) and ax.lower() == "new":
             _, ax0 = plt.subplots()
         elif isinstance(ax, matplotlib.axes.Axes):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2991,7 +2991,7 @@ class TestRaster:
         # Validate that 25 points were sampled (equating to img1.height * img1.width) with x, y, and band0 values.
         assert isinstance(points_arr, np.ndarray)
         assert points_arr.shape == (25, 3)
-        assert points.ds.shape == (25, 2)   # One less column here due to geometry storing X and Y
+        assert points.ds.shape == (25, 2)  # One less column here due to geometry storing X and Y
         # Check that X, Y and Z arrays are equal to raster array input independently of value order
         x_coords, y_coords = img0.ij2xy(i=np.arange(0, 5), j=np.arange(0, 5))
         assert np.array_equal(np.sort(np.asarray(points_arr[:, 0])), np.sort(np.tile(x_coords, 5)))

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -339,6 +339,24 @@ class TestRaster:
             r.filename = None
             r.load()
 
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path, landsat_rgb_path])  # type: ignore
+    def test_load_only_mask(self, example: str) -> None:
+        """
+        Test that loading only mask works properly.
+        """
+
+        # Load raster with and without loading
+        r_loaded = gu.Raster(example, load_data=True)
+        r_notloaded = gu.Raster(example)
+
+        # Get the mask for the two options
+        mask_loaded = np.ma.getmaskarray(r_loaded.data)
+        mask_notloaded = r_notloaded._load_only_mask()
+
+        # Data should not be loaded and masks should be equal
+        assert not r_notloaded.is_loaded
+        assert np.array_equal(mask_notloaded, mask_loaded)
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_to_rio_dataset(self, example: str):
         """Test the export to a rasterio dataset"""

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2966,8 +2966,12 @@ class TestRaster:
         # With only inside proximity
         raster1.proximity(vector=vector, in_or_out="in")
 
-    def test_to_points(self) -> None:
-        """Test the outputs of the to_points method and that it doesn't load if not needed."""
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
+    def test_to_pointcloud(self, example: str) -> None:
+        """Test to_pointcloud with real data."""
+
+    def test_to_pointcloud__synthetic(self) -> None:
+        """Test to_pointcloud method with synthetic data."""
 
         # Create a small raster to test point sampling on
         img0 = gu.Raster.from_array(
@@ -2975,24 +2979,24 @@ class TestRaster:
         )
 
         # Sample the whole raster (fraction==1)
-        points = img0.to_points(1, as_array=True)
+        points = img0.to_pointcloud(subsample=1, as_array=True)
 
         # Validate that 25 points were sampled (equating to img1.height * img1.width) with x, y, and band0 values.
         assert isinstance(points, np.ndarray)
         assert points.shape == (25, 3)
         assert np.array_equal(np.asarray(points[:, 0]), np.tile(np.linspace(0.5, 4.5, 5), 5))
 
-        assert img0.to_points(0.2, as_array=True).shape == (5, 3)
+        assert img0.to_pointcloud(subsample=0.2, as_array=True).shape == (5, 3)
 
         # Try with a single-band raster
         img1 = gu.Raster(self.aster_dem_path)
 
-        points = img1.to_points(10, as_array=True)
+        points = img1.to_pointcloud(subsample=10, as_array=True)
 
         assert points.shape == (10, 3)
         assert not img1.is_loaded
 
-        points_frame = img1.to_points(10)
+        points_frame = img1.to_pointcloud(subsample=10)
 
         assert isinstance(points_frame, gu.Vector)
         assert np.array_equal(points_frame.ds.columns, ["b1", "geometry"])
@@ -3001,12 +3005,12 @@ class TestRaster:
         # Try with a multi-band raster
         img2 = gu.Raster(self.landsat_rgb_path)
 
-        points = img2.to_points(10, as_array=True)
+        points = img2.to_pointcloud(subsample=10, as_array=True)
 
         assert points.shape == (10, 5)
         assert not img2.is_loaded
 
-        points_frame = img2.to_points(10)
+        points_frame = img2.to_pointcloud(subsample=10)
 
         assert isinstance(points_frame, gu.Vector)
         assert np.array_equal(points_frame.ds.columns, ["b1", "b2", "b3", "geometry"])

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3103,22 +3103,37 @@ class TestRaster:
         # 5/ Error raising
         with pytest.raises(ValueError, match="Data column name must be a string.*"):
             img1.to_pointcloud(data_column_name=1)  # type: ignore
-        with pytest.raises(ValueError, match=re.escape("Data band number must be an integer between 1 and the total number of bands (3).")):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Data band number must be an integer between 1 and the total number of bands (3)."),
+        ):
             img2.to_pointcloud(data_band=4)
-        with pytest.raises(ValueError, match="Passing auxiliary column names requires passing auxiliary data band numbers as well."):
+        with pytest.raises(
+            ValueError, match="Passing auxiliary column names requires passing auxiliary data band numbers as well."
+        ):
             img2.to_pointcloud(auxiliary_column_names=["a"])
-        with pytest.raises(ValueError, match="Auxiliary data band number must be an iterable containing only integers."):
+        with pytest.raises(
+            ValueError, match="Auxiliary data band number must be an iterable containing only integers."
+        ):
             img2.to_pointcloud(auxiliary_data_bands=[1, 2.5])  # type: ignore
             img2.to_pointcloud(auxiliary_data_bands="lol")  # type: ignore
-        with pytest.raises(ValueError, match=re.escape("Auxiliary data band numbers must be between 1 and the total number of bands (3).")):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Auxiliary data band numbers must be between 1 and the total number of bands (3)."),
+        ):
             img2.to_pointcloud(auxiliary_data_bands=[0])
             img2.to_pointcloud(auxiliary_data_bands=[4])
-        with pytest.raises(ValueError, match=re.escape("Main data band 1 should not be listed in auxiliary data bands [1, 2].")):
+        with pytest.raises(
+            ValueError, match=re.escape("Main data band 1 should not be listed in auxiliary data bands [1, 2].")
+        ):
             img2.to_pointcloud(auxiliary_data_bands=[1, 2])
         with pytest.raises(ValueError, match="Auxiliary column names must be an iterable containing only strings."):
             img2.to_pointcloud(auxiliary_data_bands=[2, 3], auxiliary_column_names=["lol", 1])
-        with pytest.raises(ValueError, match="Length of auxiliary column name and data band numbers should be the same*"):
+        with pytest.raises(
+            ValueError, match="Length of auxiliary column name and data band numbers should be the same*"
+        ):
             img2.to_pointcloud(auxiliary_data_bands=[2, 3], auxiliary_column_names=["lol", "lol2", "lol3"])
+
 
 class TestMask:
     # Paths to example data

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -53,6 +53,10 @@ class TestSubsampling:
         random_values = gu.raster.subsample_array(array, subsample=1)
         assert np.all(np.sort(random_values) == array[~array.mask])
 
+        # Check that order is preserved for subsample = 1 (no random sampling, simply returns valid mask)
+        random_values_2 = gu.raster.subsample_array(array, subsample=1)
+        assert np.array_equal(random_values, random_values_2)
+
         # Test if subsample < 1
         random_values = gu.raster.subsample_array(array, subsample=0.5)
         assert np.size(random_values) == int(np.count_nonzero(~array.mask) * 0.5)


### PR DESCRIPTION
## Summary
This PR improves `Raster.to_pointcloud()` in terms of argument consistency, modularity, and makes its subsampling functionality only returns valid values (while before it returned any random sample) to also be consistent with other subsampling methods.
Additionally, this PR adds a non-public `Raster._load_only_mask()` function called by a new public function `Raster.get_mask()`, which allows to get the nodata mask without loading the array into memory. This is used in `.to_pointcloud()` to perform sampling of only valid values without loading the array in memory :smile:.

The PR also adds a lot of tests!

## Detailed changes

This PR:
- Renames `Raster.to_points()` into `Raster.to_pointcloud()` for consistent naming in preparation for #492,
- Define a main `data_column_name` argument for `Raster.to_pointcloud()` to associate the point cloud to a certain `data_band` (instead of having a hard-coded "b1", "b2", etc), and proposes to store all columns using the new argument `store_auxiliary_bands` (naming to be made consistent with `PointCloud` class but should be fairly close),
- Adds a `random_state` argument for `subsample`,
- Changes the subsampling done to rely on `subsample_array()`, after calling a new `_load_only_mask` function to get the valid mask from disk without loading the raster array,
- Modifies `_load_rio` to allow to return only the mask by calling `rasterio.read_masks()`,
- Adds a `Raster.get_mask()` function that returns the raster mask consistently as a boolean array (to circumvent the issue of having a single `False` value, see #505) and without loading the raster array.

Resolves #499
Resolves #504
Resolves #505
Resolves #502 

TO-DO:

- [x] Add tests for `subsample=1` in `subsample_array()`,
- [x] Add tests for `_load_only_mask`,
- [x] Define a function `get_mask` that works without the array? See #505.