### PR TITLE
Add pixel interpretation and casting logic based on `AREA_OR_POINT` and package-level config defaults

### DIFF
--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -5,6 +5,7 @@ GeoUtils is a Python package for the analysis of geospatial data.
 from geoutils import examples, projtools, raster, vector  # noqa
 from geoutils.raster import Mask, Raster, SatelliteImage  # noqa
 from geoutils.vector import Vector  # noqa
+from geoutils._config import config  # noqa
 
 try:
     from geoutils._version import __version__ as __version__  # noqa

--- a/geoutils/_config.py
+++ b/geoutils/_config.py
@@ -1,0 +1,58 @@
+"""Setup of runtime-compile configuration of GeoUtils."""
+import configparser
+import os
+from typing import Any
+
+# The setup is inspired by that of Matplotlib and Geowombat
+# https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/rcsetup.py
+# https://github.com/jgrss/geowombat/blob/main/src/geowombat/config.py
+
+_config_ini_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "config.ini"))
+
+# Validators: to check the format of user inputs
+def validate_bool(b):
+    """Convert b to ``bool`` or raise."""
+    if isinstance(b, str):
+        b = b.lower()
+    if b in ('t', 'y', 'yes', 'on', 'true', '1', 1, True):
+        return True
+    elif b in ('f', 'n', 'no', 'off', 'false', '0', 0, False):
+        return False
+    else:
+        raise ValueError(f'Cannot convert {b!r} to bool')
+
+
+# Map the parameter names with a validating function to check user input
+_validators = {
+    "shift_area_or_point": validate_bool,
+    "warn_area_or_point":  validate_bool,
+}
+
+
+class GeoUtilsConfigDict(dict):
+    """Class for a GeoUtils config dictionary"""
+
+    def __setitem__(self, k: str, v: Any):
+        """We override setitem to check user input."""
+
+        validate_func = _validators[k]
+        new_value = validate_func(v)
+        super().__setitem__(k, new_value)
+
+    def _set_defaults(self, path_init_file: str):
+        """A function to set"""
+
+        config_parser = configparser.ConfigParser()
+        config_parser.read(path_init_file)
+
+        for section in config_parser.sections():
+            for k, v in config_parser[section].items():
+                # Select validator function and update dictionary
+                validate_func = _validators[k]
+                self.__setitem__(k, validate_func(v))
+
+
+# Generate default config dictionary
+config = GeoUtilsConfigDict()
+config._set_defaults(path_init_file=_config_ini_file)
+

--- a/geoutils/config.ini
+++ b/geoutils/config.ini
@@ -1,0 +1,9 @@
+# This script sets default global parameters for GeoUtils, which can be customized by the user
+
+# Sections are useless for now, but might become useful later on
+[raster]
+shift_area_or_point = True
+warn_area_or_point = True
+
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+"""Test configuration file."""
+import geoutils as gu
+
+class TestConfig:
+
+    def test_config_defaults(self):
+        """Check defaults compared to file"""
+
+        # Read file
+        default_config = gu._config.GeoUtilsConfigDict()
+        default_config._set_defaults(gu._config._config_ini_file)
+
+        assert default_config == gu.config
+
+    def test_config_set(self):
+        """Check setting a non-default config argument by user"""
+
+        # Default is True
+        assert gu.config["shift_area_or_point"]
+
+        # We set it to False and it should be updated
+        gu.config["shift_area_or_point"] = False
+        assert not gu.config["shift_area_or_point"]
+
+    def test_config_validator(self):
+        """Check setting a config argument with a wrong input type converts it automatically"""
+
+        # We input an "off" value, that should be converted to False
+        gu.config["shift_area_or_point"] = "off"
+        assert not gu.config["shift_area_or_point"]

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -596,6 +596,47 @@ class TestRaster:
             new_raster = raster + 1
         assert new_raster.data.mask[0, 0]
 
+    def test_area_or_point(self):
+        """Check area or point attribute getter, setter and related warnings"""
+
+        # 1/ Getter and instantiation
+        # Check existing file based on a priori knowledge
+        raster_point = gu.Raster(self.landsat_b4_path)
+        assert raster_point.area_or_point == "Point"
+
+        raster_area = gu.Raster(self.aster_dem_path)
+        assert raster_area.area_or_point == "Area"
+
+        # 2/ Setter
+        # For None, it will remove the key from the tags dictionary
+        raster_point.area_or_point = None
+        assert raster_point.area_or_point is None
+        assert "AREA_OR_POINT" not in raster_point.tags
+
+        # For a good value, it will update the tags
+        raster_point.area_or_point = "Point"
+        assert raster_point.area_or_point == "Point"
+        assert "AREA_OR_POINT" in raster_point.tags and raster_point.tags["AREA_OR_POINT"] == "Point"
+
+        # 3/ With function creating a single Raster
+
+        # From array
+        raster_point_fromarray = gu.Raster.from_array(data=raster_point.data, transform=raster_point.transform,
+                                                      area_or_point=raster_point.area_or_point, crs=raster_point.crs)
+        assert raster_point.area_or_point == raster_point_fromarray.area_or_point
+
+        # Copy
+        raster_point_copy = raster_point.copy()
+        assert raster_point.area_or_point == raster_point_copy.area_or_point
+
+        # 4/ With function casting from several Rasters
+
+
+        # with pytest.warns(UserWarning, match='One raster has a pixel interpretation "Area" and the other "Point".*'):
+        #     r
+
+
+
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_b4_path, landsat_rgb_path])  # type: ignore
     def test_get_nanarray(self, example: str) -> None:
         """


### PR DESCRIPTION
Resolves #508
Resolves #500
Resolves #503

## TODO

- [ ] Merge casting functions following #508,
- [ ] Add `shift_area_or_point` transformation to all coordinates function still missing it (`coords` and `ij2xy`),
- [ ] Add warning on `area_or_point` when using a match-reference raster to crop/reproject/proximity another raster?
- [ ] Modify `shift_area_or_point` to be `None` by default and call `config["shift_area_or_point"]`.
- [ ] Add function to convert interpretation? Something like `to_area_or_point()`?