### PR TITLE
Fix error checking colormap in geoviewer.py

### DIFF
--- a/bin/geoviewer.py
+++ b/bin/geoviewer.py
@@ -181,12 +181,16 @@ def main(test_args: Sequence[str] = None) -> None:
         vmax = None
 
     # color map
+    # Get the list of existing color maps
+    mpl_cmap_list = list(plt.cm.datad.keys())
+    mpl_cmap_list.extend([cmap + "_r" for cmap in mpl_cmap_list])
+
     if args.cmap == "default":
         cmap = plt.rcParams["image.cmap"]
-    elif args.cmap in plt.cm.datad.keys():
+    elif args.cmap in mpl_cmap_list:
         cmap = args.cmap
     else:
-        raise ValueError("Wrong cmap, must be in: {}".format(",".join(str(elem) for elem in plt.cm.datad.keys())))
+        raise ValueError("Wrong cmap, must be in: {}".format(",".join(str(elem) for elem in mpl_cmap_list)))
 
     # Figsize
     if args.figsize == "default":

--- a/bin/geoviewer.py
+++ b/bin/geoviewer.py
@@ -181,7 +181,7 @@ def main(test_args: Sequence[str] = None) -> None:
         vmax = None
 
     # color map
-    # Get the list of existing color maps
+    # Get the list of existing color maps, including reversed maps
     mpl_cmap_list = list(plt.cm.datad.keys())
     mpl_cmap_list.extend([cmap + "_r" for cmap in mpl_cmap_list])
 

--- a/tests/test_geoviewer.py
+++ b/tests/test_geoviewer.py
@@ -24,6 +24,7 @@ import geoviewer  # noqa
     (
         (),
         ("-cmap", "Reds"),
+        ("-cmap", "Reds_r"),
         ("-vmin", "-10", "-vmax", "10"),
         ("-vmin", "5%", "-vmax", "95%"),
         ("-band", "1"),


### PR DESCRIPTION
In `geoviewer.py`, when setting a colormap with the "_r" suffix, an error was raised. This is fixed by this PR and the tests have been added to check this in the future.
