### PR TITLE
Add `Raster.from_xarray()` to create raster from a `xr.DataArray`

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -998,15 +998,15 @@ class Raster:
 
         if strict_masked:
             names = ["data.data", "data.mask", "data.fill_value", "dtype", "transform", "crs", "nodata"]
-            equalities =  [
-                    np.array_equal(self.data.data, other.data.data, equal_nan=True),
-                    np.array_equal(self_mask, other_mask),
-                    self.data.fill_value == other.data.fill_value,
-                    self.data.dtype == other.data.dtype,
-                    self.transform == other.transform,
-                    self.crs == other.crs,
-                    self.nodata == other.nodata,
-                ]
+            equalities = [
+                np.array_equal(self.data.data, other.data.data, equal_nan=True),
+                np.array_equal(self_mask, other_mask),
+                self.data.fill_value == other.data.fill_value,
+                self.data.dtype == other.data.dtype,
+                self.transform == other.transform,
+                self.crs == other.crs,
+                self.nodata == other.nodata,
+            ]
         else:
             names = ["data", "data.fill_value", "dtype", "transform", "crs", "nodata"]
             equalities = [
@@ -1015,14 +1015,16 @@ class Raster:
                 self.data.dtype == other.data.dtype,
                 self.transform == other.transform,
                 self.crs == other.crs,
-                self.nodata == other.nodata
-                ]
+                self.nodata == other.nodata,
+            ]
 
         complete_equality = all(equalities)
 
         if not complete_equality and warn_failure_reason:
             where_fail = np.nonzero(~np.array(equalities))[0]
-            warnings.warn(category=UserWarning, message=f"Equality failed for: {', '.join([names[w] for w in where_fail])}.")
+            warnings.warn(
+                category=UserWarning, message=f"Equality failed for: {', '.join([names[w] for w in where_fail])}."
+            )
 
         return complete_equality
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -807,9 +807,9 @@ class Raster:
             driver="GTiff",
         ) as ds:
             if self.count == 1:
-                ds.write(self.data.filled(self.nodata)[np.newaxis, :, :])
+                ds.write(self.data[np.newaxis, :, :])
             else:
-                ds.write(self.data.filled(self.nodata))
+                ds.write(self.data)
 
         # Then open as a DatasetReader
         return mfh.open()

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -978,7 +978,7 @@ class Raster:
         - The raster's transform, crs and nodata values.
 
         :param other: Other raster.
-        :param strict_masked: Whether to check if masked pixels (in .data.mask) have the same value (in .data.data).
+        :param strict_masked: Whether to check if masked cells (in .data.mask) have the same value (in .data.data).
         :param warn_failure_reason: Whether to warn for the reason of failure if the check does not pass.
         """
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1336,18 +1336,24 @@ np.ndarray or number and correct dtype, the compatible nodata value.
         return out_mask
 
     @overload
-    def astype(self, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: Literal[False] = False) -> Raster:
+    def astype(
+        self: RasterType, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: Literal[False] = False
+    ) -> RasterType:
         ...
 
     @overload
-    def astype(self, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: Literal[True]) -> None:
+    def astype(self: RasterType, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: Literal[True]) -> None:
         ...
 
     @overload
-    def astype(self, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: bool = False) -> Raster | None:
+    def astype(
+        self: RasterType, dtype: DTypeLike, convert_nodata: bool = True, *, inplace: bool = False
+    ) -> RasterType | None:
         ...
 
-    def astype(self, dtype: DTypeLike, convert_nodata: bool = True, inplace: bool = False) -> Raster | None:
+    def astype(
+        self: RasterType, dtype: DTypeLike, convert_nodata: bool = True, inplace: bool = False
+    ) -> RasterType | None:
         """
         Convert data type of the raster.
 
@@ -2630,7 +2636,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
                 dst.gcps = (rio_gcps, gcps_crs)
 
     @classmethod
-    def from_xarray(cls, ds: xr.DataArray, dtype: DTypeLike | None = None) -> RasterType:
+    def from_xarray(cls: type[RasterType], ds: xr.DataArray, dtype: DTypeLike | None = None) -> RasterType:
         """
         Create raster from a xarray.DataArray.
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1529,6 +1529,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # Update the nodata value
         self._nodata = new_nodata
+        self.data.fill_value = new_nodata
 
     @property
     def data(self) -> MArrayNum:
@@ -2675,6 +2676,7 @@ np.ndarray or number and correct dtype, the compatible nodata value.
 
         # If type was integer, cast to float to be able to save nodata values in the xarray data array
         if np.issubdtype(self.dtypes[0], np.integer):
+            # Nodata conversion is not needed in this direction (integer towards float), we can maintain the original
             updated_raster = self.astype(np.float32, convert_nodata=False)
         else:
             updated_raster = self

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -397,18 +397,27 @@ class TestRaster:
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path, landsat_rgb_path])  # type: ignore
     def test_from_xarray(self, example: str):
-        """Test the import from a xarray dataset"""
+        """Test raster creation from a xarray dataset, not fully reversible with to_xarray due to float conversion"""
 
         warnings.filterwarnings("ignore")
 
         # Open raster and export to xarray, then import to xarray dataset
         rst = gu.Raster(example)
         ds = rst.to_xarray()
-        rst_2 = gu.Raster.from_xarray(ds=ds)
+        rst2 = gu.Raster.from_xarray(ds=ds)
 
         # Exporting to a Xarray dataset results in loss of information to float32
         # Check that the output equals the input converted to float32 (not fully reversible)
-        assert rst.astype("float32", convert_nodata=False).raster_equal(rst_2)
+        assert rst.astype("float32", convert_nodata=False).raster_equal(rst2)
+
+        # Test with the dtype argument to convert back to original raster even if integer-type
+        if np.issubdtype(rst.dtypes[0], np.integer):
+            # Set an existing nodata value, because all of our integer-type example datasets currently have "None"
+            rst.set_nodata(new_nodata=255)
+            ds = rst.to_xarray()
+            rst3 = gu.Raster.from_xarray(ds=ds, dtype=rst.dtypes[0])
+            assert rst3.raster_equal(rst)
+
 
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
     @pytest.mark.parametrize(

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3466,19 +3466,20 @@ class TestArithmetic:
         assert not r1.raster_equal(r2)
 
         # Change value of a masked cell
-        r1.data[0, 0] = np.ma.masked
-        r1.data.data[0, 0] = 0
         r2 = r1.copy()
-        r2.data.data[0, 0] = 10
-        assert not r1.raster_equal(r2)
-        assert r1.raster_equal(r2, strict_masked=False)
+        r2.data[0, 0] = np.ma.masked
+        r2.data.data[0, 0] = 0
+        r3 = r2.copy()
+        r3.data.data[0, 0] = 10
+        assert not r2.raster_equal(r3)
+        assert r2.raster_equal(r3, strict_masked=False)
 
         # Check that a warning is raised with useful information without equality
         with pytest.warns(UserWarning, match="Equality failed for: data.data."):
-            assert not r1.raster_equal(r2, warn_failure_reason=True)
+            assert not r2.raster_equal(r3, warn_failure_reason=True)
 
         # But no warning is raised for an equality
-        assert r1.raster_equal(r2, strict_masked=False, warn_failure_reason=True)
+        assert r2.raster_equal(r3, strict_masked=False, warn_failure_reason=True)
 
     def test_equal_georeferenced_grid(self) -> None:
         """

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2212,6 +2212,7 @@ class TestRaster:
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
+        assert r.data.fill_value == new_nodata
 
         # By default, the array should have been updated
         if old_nodata is not None:
@@ -2250,6 +2251,7 @@ class TestRaster:
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
+        assert r.data.fill_value == new_nodata
 
         # By default, the array should have been updated similarly for the old nodata
         if old_nodata is not None:
@@ -2292,6 +2294,7 @@ class TestRaster:
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
+        assert r.data.fill_value == new_nodata
 
         # Now, the array should not have been updated, so the entire array should be unchanged except for the pixel
         assert np.array_equal(r.data.data[~mask_pixel_artificially_set], r_copy.data.data[~mask_pixel_artificially_set])
@@ -2320,6 +2323,7 @@ class TestRaster:
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
+        assert r.data.fill_value == new_nodata
 
         # The array should have been updated
         if old_nodata is not None:
@@ -2346,6 +2350,7 @@ class TestRaster:
 
         # The nodata value should have been set in the metadata
         assert r.nodata == new_nodata
+        assert r.data.fill_value == new_nodata
 
         # The array should not have been updated except for the pixel
         assert np.array_equal(r.data.data[~mask_pixel_artificially_set], r_copy.data.data[~mask_pixel_artificially_set])

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3465,6 +3465,21 @@ class TestArithmetic:
         r2.set_nodata(34)
         assert not r1.raster_equal(r2)
 
+        # Change value of a masked cell
+        r1.data[0, 0] = np.ma.masked
+        r1.data.data[0, 0] = 0
+        r2 = r1.copy()
+        r2.data.data[0, 0] = 10
+        assert not r1.raster_equal(r2)
+        assert r1.raster_equal(r2, strict_masked=False)
+
+        # Check that a warning is raised with useful information without equality
+        with pytest.warns(UserWarning, match="Equality failed for: data.data."):
+            assert not r1.raster_equal(r2, warn_failure_reason=True)
+
+        # But no warning is raised for an equality
+        assert r1.raster_equal(r2, strict_masked=False, warn_failure_reason=True)
+
     def test_equal_georeferenced_grid(self) -> None:
         """
         Test that equal for shape, crs and transform work as expected

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -363,7 +363,7 @@ class TestRaster:
     def test_to_xarray(self, example: str):
         """Test the export to a xarray dataset"""
 
-        # Open raster and export to rio dataset
+        # Open raster and export to xarray dataset
         rst = gu.Raster(example)
         ds = rst.to_xarray()
 
@@ -394,6 +394,21 @@ class TestRaster:
             assert np.array_equal(rst.data.data, ds.data)
         else:
             assert np.array_equal(rst.data.data, ds.data.squeeze())
+
+    @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path, landsat_rgb_path])  # type: ignore
+    def test_from_xarray(self, example: str):
+        """Test the import from a xarray dataset"""
+
+        warnings.filterwarnings("ignore")
+
+        # Open raster and export to xarray, then import to xarray dataset
+        rst = gu.Raster(example)
+        ds = rst.to_xarray()
+        rst_2 = gu.Raster.from_xarray(ds=ds)
+
+        # Exporting to a Xarray dataset results in loss of information to float32
+        # Check that the output equals the input converted to float32 (not fully reversible)
+        assert rst.astype("float32", convert_nodata=False).raster_equal(rst_2)
 
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
     @pytest.mark.parametrize(

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -418,7 +418,6 @@ class TestRaster:
             rst3 = gu.Raster.from_xarray(ds=ds, dtype=rst.dtypes[0])
             assert rst3.raster_equal(rst)
 
-
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
     @pytest.mark.parametrize(
         "dtype", ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"]

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3232,7 +3232,7 @@ class TestMask:
             match="Reprojecting a mask with a resampling method other than 'nearest', "
             "the boolean array will be converted to float during interpolation.",
         ):
-            mask.reproject(resampling="bilinear")
+            mask.reproject(res=50, resampling="bilinear", force_source_nodata=2)
 
     @pytest.mark.parametrize("mask", [mask_landsat_b4, mask_aster_dem, mask_everest])  # type: ignore
     def test_crop(self, mask: gu.Mask) -> None:


### PR DESCRIPTION
This PR adds `Raster.from_xarray()` to create a raster from an Xarray dataset (this loads the data, in the future will be able to cast functions directly on the Xarray object through #446).

Correct the behaviour of `to_xarray()` which was not converting the data to floating when converting, and not masking nodata values (as default was `False` for reading mask in `open_rasterio()`), leading to unmasked nodata values for integer raster types. Now converts to floating by defaults to mask properly as NaNs (only way of masking with Xarray).

Additionally, this function adds two new arguments to `Raster.raster_equal()`: `strict_masked` and `warn_failure_reason`. The former allows to check for less strict equality regarding the mask (masked cells can have different underlying values, as those are never used anyway), and the latter is to raise an understandable error when `raster_equal()` assertions fail.
We lose information when converting to an Xarray dataset with NaNs (masked values are transformed to NaNs and cannot be retrieved back when re-creating a raster), so we can only check equality with `strict_masked=False`.

Resolves #519
Resolves #522 