### PR TITLE
Add `config.ini` to package data for `setuptools`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires = file: requirements.txt
 
 [options.package_data]
 geoutils =
+    config.ini
     py.typed
 
 [options.packages.find]


### PR DESCRIPTION
Somehow `config.ini` was copied by `setuptools` for pip but not for conda, trying by declaring it explicitly.