### PR TITLE
Refactor `Raster.dtypes` tuple to a `Raster.dtype` string

### DIFF
--- a/doc/source/about_geoutils.md
+++ b/doc/source/about_geoutils.md
@@ -38,7 +38,7 @@ In particular, GeoUtils:
 - Strives to rely on **lazy operations** under-the-hood to avoid unnecessary data loading,
 - Allows for **match-reference operations** to facilitate geospatial handling,
 - Re-implements **several of [GDAL](https://gdal.org/)'s features** missing in other packages (e.g., proximity, gdalDEM),
-- Naturally handles **different `dtypes` and `nodata`** values through its NumPy masked-array interface.
+- Naturally handles **different `dtype` and `nodata`** values through its NumPy masked-array interface.
 
 
 ```{note}

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -64,7 +64,7 @@ documentation.
     Raster.bands_on_disk
     Raster.res
     Raster.bounds
-    Raster.dtypes
+    Raster.dtype
     Raster.is_loaded
     Raster.is_modified
     Raster.name

--- a/doc/source/core_array_funcs.md
+++ b/doc/source/core_array_funcs.md
@@ -30,7 +30,7 @@ Universal functions can take one or two inputs, and return one or two outputs. T
 the output will be a {class}`~geoutils.Raster`. If there is a second input, it can be a {class}`~geoutils.Raster` or {class}`~numpy.ndarray` with
 matching georeferencing or shape, respectively.
 
-These functions inherently support the casting of different {attr}`~geoutils.Raster.dtypes` and values masked by {attr}`~geoutils.Raster.nodata` in the
+These functions inherently support the casting of different {attr}`~geoutils.Raster.dtype` and values masked by {attr}`~geoutils.Raster.nodata` in the
 {class}`~numpy.ma.MaskedArray`.
 
 Below, we re-use the same example created in {ref}`core-py-ops`.

--- a/doc/source/core_py_ops.md
+++ b/doc/source/core_py_ops.md
@@ -66,7 +66,7 @@ rast - (rast**0.5)
 ```
 
 If an unmasked {class}`~numpy.ndarray` is passed, it will internally be cast into a {class}`~numpy.ma.MaskedArray` to respect the propagation of
-{class}`~geoutils.Raster.nodata` values. Additionally, the {attr}`~geoutils.Raster.dtypes` are also reconciled as they would for {class}`~numpy.ndarray`,
+{class}`~geoutils.Raster.nodata` values. Additionally, the {attr}`~geoutils.Raster.dtype` are also reconciled as they would for {class}`~numpy.ndarray`,
 following [standard NumPy coercion rules](https://numpy.org/doc/stable/reference/generated/numpy.find_common_type.html).
 
 ## Logical comparisons cast to {class}`~geoutils.Mask`

--- a/doc/source/feature_overview.md
+++ b/doc/source/feature_overview.md
@@ -179,7 +179,7 @@ rast += 1
 ```
 
 Additionally, the {class}`~geoutils.Raster` object possesses a NumPy masked-array interface that allows to apply to it any [NumPy universal function](https://numpy.org/doc/stable/reference/ufuncs.html) and
-most other NumPy array functions, while logically casting {class}`dtypes<numpy.dtype>` and respecting {attr}`~geoutils.Raster.nodata` values.
+most other NumPy array functions, while logically casting {class}`dtype<numpy.dtype>` and respecting {attr}`~geoutils.Raster.nodata` values.
 
 ```{code-cell} ipython3
 # Apply a normalization to the raster
@@ -204,7 +204,7 @@ Masks can then be used for indexing a {class}`~geoutils.Raster`, which returns a
 values_aoi = rast[mask_aoi]
 ```
 
-Masks also have simplified, overloaded {class}`~geoutils.Raster` methods due to their boolean {class}`dtypes<numpy.dtype>`. Using {func}`~geoutils.Raster.polygonize` with a
+Masks also have simplified, overloaded {class}`~geoutils.Raster` methods due to their boolean {class}`dtype<numpy.dtype>`. Using {func}`~geoutils.Raster.polygonize` with a
 {class}`~geoutils.Mask` is straightforward, for instance, to retrieve a {class}`~geoutils.Vector` of the area-of-interest:
 
 ```{code-cell} ipython3

--- a/doc/source/mask_class.md
+++ b/doc/source/mask_class.md
@@ -37,8 +37,8 @@ There is no {class}`~geoutils.Raster.nodata` value defined in a {class}`~geoutil
 method from {class}`~geoutils.Raster`.
 
 ```{important}
-Most raster file formats such a [GeoTIFFs](https://gdal.org/drivers/raster/gtiff.html) **do not support {class}`bool` array {class}`dtypes<numpy.dtype>`
-on-disk**, and **most of Rasterio functionalities also do not support {class}`bool` {class}`dtypes<numpy.dtype>`**.
+Most raster file formats such a [GeoTIFFs](https://gdal.org/drivers/raster/gtiff.html) **do not support {class}`bool` array {class}`dtype<numpy.dtype>`
+on-disk**, and **most of Rasterio functionalities also do not support {class}`bool` {class}`dtype<numpy.dtype>`**.
 
 To address this, during opening, saving and geospatial handling operations, {class}`Masks<geoutils.Mask>` are automatically converted to and from {class}`numpy.uint8`.
 The {class}`~geoutils.Raster.nodata` of a {class}`~geoutils.Mask` can now be defined to save to a file, and defaults to `255`.

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -35,7 +35,7 @@ A first category includes georeferencing attributes directly derived from {attr}
 {attr}`~geoutils.Raster.height`, {attr}`~geoutils.Raster.width`, {attr}`~geoutils.Raster.res`, {attr}`~geoutils.Raster.bounds`.
 
 A second category concerns the attributes derived from the raster array shape and type: {attr}`~geoutils.Raster.count`, {attr}`~geoutils.Raster.bands` and
-{attr}`~geoutils.Raster.dtypes`. The two former refer to the number of bands loaded in a {class}`~geoutils.Raster`, and the band indexes.
+{attr}`~geoutils.Raster.dtype`. The two former refer to the number of bands loaded in a {class}`~geoutils.Raster`, and the band indexes.
 
 ```{important}
 The {attr}`~geoutils.Raster.bands` of {class}`rasterio.io.DatasetReader` start from 1 and not 0, be careful when instantiating or loading from a
@@ -150,14 +150,14 @@ might result in larger memory usage than in the original {class}`~geoutils.Raste
 Thanks to the {ref}`core-array-funcs`, **NumPy functions applied directly to a {class}`~geoutils.Raster` will respect {class}`~geoutils.Raster.nodata`
 values** as well as if computing with the {class}`~numpy.ma.MaskedArray` or an unmasked {class}`~numpy.ndarray` filled with {class}`~numpy.nan`.
 
-Additionally, the {class}`~geoutils.Raster` will automatically cast between different {class}`dtypes<numpy.dtype>`, and possibly re-define missing
+Additionally, the {class}`~geoutils.Raster` will automatically cast between different {class}`dtype<numpy.dtype>`, and possibly re-define missing
 {class}`nodatas<geoutils.Raster.nodata>`.
 ```
 
 ## Arithmetic
 
 A {class}`~geoutils.Raster` can be applied any pythonic arithmetic operation ({func}`+<operator.add>`, {func}`-<operator.sub>`, {func}`/<operator.truediv>`, {func}`//<operator.floordiv>`, {func}`*<operator.mul>`,
-{func}`**<operator.pow>`, {func}`%<operator.mod>`) with another {class}`~geoutils.Raster`, {class}`~numpy.ndarray` or number. It will output one or two {class}`Rasters<geoutils.Raster>`. NumPy coercion rules apply for {class}`dtypes<numpy.dtype>`.
+{func}`**<operator.pow>`, {func}`%<operator.mod>`) with another {class}`~geoutils.Raster`, {class}`~numpy.ndarray` or number. It will output one or two {class}`Rasters<geoutils.Raster>`. NumPy coercion rules apply for {class}`dtype<numpy.dtype>`.
 
 ```{code-cell} ipython3
 # Add 1 and divide raster by 2

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -746,7 +746,7 @@ class Raster:
 
     @property
     def dtype(self) -> str:
-        """Data type for each raster band (string representation)."""
+        """Data type of the raster (string representation)."""
         if not self.is_loaded and self._disk_dtype is not None:
             return self._disk_dtype
         return str(self.data.dtype)

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -556,7 +556,7 @@ class Raster:
         self._is_modified = True
         self._disk_shape: tuple[int, int, int] | None = None
         self._disk_bands: tuple[int] | None = None
-        self._disk_dtype: tuple[str] | None = None
+        self._disk_dtype: str | None = None
         self._disk_transform: affine.Affine | None = None
         self._downsample: int | float = 1
         self._area_or_point: Literal["Area", "Point"] | None = None

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -175,7 +175,6 @@ _default_rio_attrs = [
     "count",
     "crs",
     "driver",
-    "dtypes",
     "height",
     "indexes",
     "name",

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -556,7 +556,7 @@ class Raster:
         self._is_modified = True
         self._disk_shape: tuple[int, int, int] | None = None
         self._disk_bands: tuple[int] | None = None
-        self._disk_dtypes: tuple[str] | None = None
+        self._disk_dtype: tuple[str] | None = None
         self._disk_transform: affine.Affine | None = None
         self._downsample: int | float = 1
         self._area_or_point: Literal["Area", "Point"] | None = None
@@ -614,7 +614,7 @@ class Raster:
 
                 self._disk_shape = (ds.count, ds.height, ds.width)
                 self._disk_bands = ds.indexes
-                self._disk_dtypes = ds.dtypes
+                self._disk_dtype = ds.dtypes[0]
                 self._disk_transform = ds.transform
 
             # Check number of bands to be loaded
@@ -746,11 +746,11 @@ class Raster:
         return self._data is not None
 
     @property
-    def dtypes(self) -> tuple[str, ...]:
+    def dtype(self) -> str:
         """Data type for each raster band (string representation)."""
-        if not self.is_loaded and self._disk_dtypes is not None:
-            return self._disk_dtypes
-        return (str(self.data.dtype),) * self.count
+        if not self.is_loaded and self._disk_dtype is not None:
+            return self._disk_dtype
+        return str(self.data.dtype)
 
     @property
     def bands_on_disk(self) -> None | tuple[int, ...]:
@@ -1092,7 +1092,7 @@ class Raster:
             height=self.height,
             width=self.width,
             count=self.count,
-            dtype=self.dtypes[0],
+            dtype=self.dtype,
             crs=self.crs,
             transform=self.transform,
             nodata=self.nodata,
@@ -1729,8 +1729,8 @@ class Raster:
             raise ValueError("Type of nodata not understood, must be float or int.")
 
         if new_nodata is not None:
-            if not rio.dtypes.can_cast_dtype(new_nodata, self.dtypes[0]):
-                raise ValueError(f"nodata value {new_nodata} incompatible with self.dtype {self.dtypes[0]}")
+            if not rio.dtypes.can_cast_dtype(new_nodata, self.dtype):
+                raise ValueError(f"nodata value {new_nodata} incompatible with self.dtype {self.dtype}")
 
         # If we update mask or array, get the masked array
         if update_array or update_mask:
@@ -1838,8 +1838,8 @@ class Raster:
             dtype = str(self._data.dtype)
             orig_shape = self._data.shape
         # If filename exists
-        elif self._disk_dtypes is not None:
-            dtype = self._disk_dtypes[0]
+        elif self._disk_dtype is not None:
+            dtype = self._disk_dtype
             if self._out_count == 1:
                 orig_shape = self._out_shape
             else:
@@ -2027,7 +2027,7 @@ class Raster:
             f"Modified since load?  {self.is_modified} \n",
             f"Grid size:                 {self.width}, {self.height}\n",
             f"Number of bands:      {self.count:d}\n",
-            f"Data types:           {self.dtypes}\n",
+            f"Data types:           {self.dtype}\n",
             f"Coordinate system:    {[self.crs.to_string() if self.crs is not None else None]}\n",
             f"Nodata value:         {self.nodata}\n",
             f"Pixel interpretation: {self.area_or_point}\n",
@@ -2596,7 +2596,7 @@ class Raster:
         # Set output dtype
         if dtype is None:
             # Warning: this will not work for multiple bands with different dtypes
-            dtype = self.dtypes[0]
+            dtype = self.dtype
 
         # --- Set source nodata if provided -- #
         if force_source_nodata is None:
@@ -3000,7 +3000,7 @@ class Raster:
         """
 
         # If type was integer, cast to float to be able to save nodata values in the xarray data array
-        if np.issubdtype(self.dtypes[0], np.integer):
+        if np.issubdtype(self.dtype, np.integer):
             # Nodata conversion is not needed in this direction (integer towards float), we can maintain the original
             updated_raster = self.astype(np.float32, convert_nodata=False)
         else:
@@ -4012,7 +4012,7 @@ class Raster:
         gpd_dtypes = ["uint8", "uint16", "int16", "int32", "float32"]
         list_common_dtype_index = []
         for gpd_type in gpd_dtypes:
-            polygonize_dtype = np.promote_types(gpd_type, self.dtypes[0])
+            polygonize_dtype = np.promote_types(gpd_type, self.dtype)
             if str(polygonize_dtype) in gpd_dtypes:
                 list_common_dtype_index.append(gpd_dtypes.index(gpd_type))
         if len(list_common_dtype_index) == 0:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -236,7 +236,7 @@ class TestRaster:
         assert r.count_on_disk == 1
         assert r.bands == (1,)
         assert r.bands_on_disk == (1,)
-        assert np.array_equal(r.dtype, ["uint8"])
+        assert r.dtype == "uint8"
         assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
         assert np.array_equal(r.res, [30.0, 30.0])
         assert r.bounds == rio.coords.BoundingBox(left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0)
@@ -254,7 +254,7 @@ class TestRaster:
         assert r.count_on_disk == 1
         assert r.bands == (1,)
         assert r.bands_on_disk == (1,)
-        assert np.array_equal(r2.dtype, ["float32"])
+        assert r2.dtype == "float32"
         assert r2.transform == rio.transform.Affine(30.0, 0.0, 627175.0, 0.0, -30.0, 4852085.0)
         assert np.array_equal(r2.res, [30.0, 30.0])
         assert r2.bounds == rio.coords.BoundingBox(left=627175.0, bottom=4833545.0, right=643345.0, top=4852085.0)
@@ -910,17 +910,17 @@ class TestRaster:
         # Test negation
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert np.array_equal(r3.dtype, ["uint8"])
+        assert r3.dtype == "uint8"
 
         # Test addition
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert np.array_equal(r3.dtype, ["uint8"])
+        assert r3.dtype == "uint8"
 
         # Test subtraction
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert np.array_equal(r3.dtype, ["uint8"])
+        assert r3.dtype == "uint8"
 
         # Test with dtype Float32
         r1 = gu.Raster.from_array(
@@ -928,15 +928,15 @@ class TestRaster:
         )
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert np.array_equal(r3.dtype, ["float32"])
+        assert r3.dtype == "float32"
 
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert np.array_equal(r3.dtype, ["float32"])
+        assert r3.dtype == "float32"
 
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert np.array_equal(r3.dtype, ["float32"])
+        assert r3.dtype == "float32"
 
         # Check that errors are properly raised
         # different shapes

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -188,13 +188,13 @@ class TestRaster:
             stats = r.info(stats=True, verbose=False)
 
         # Check the stats adapt to nodata values
-        if r.dtypes[0] == "uint8":
+        if r.dtype == "uint8":
             # Validate that the mask is respected by adding 0 values (there are none to begin with.)
             r.data.ravel()[:1000] = 0
             # Set the nodata value to 0, then validate that they are excluded from the new minimum, and warning raised
             with pytest.warns(UserWarning):
                 r.set_nodata(0)
-        elif r.dtypes[0] == "float32":
+        elif r.dtype == "float32":
             # We do the same with -99999 here
             r.data.ravel()[:1000] = -99999
             # And replace the nodata value, and warning raised
@@ -236,7 +236,7 @@ class TestRaster:
         assert r.count_on_disk == 1
         assert r.bands == (1,)
         assert r.bands_on_disk == (1,)
-        assert np.array_equal(r.dtypes, ["uint8"])
+        assert np.array_equal(r.dtype, ["uint8"])
         assert r.transform == rio.transform.Affine(30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
         assert np.array_equal(r.res, [30.0, 30.0])
         assert r.bounds == rio.coords.BoundingBox(left=478000.0, bottom=3088490.0, right=502000.0, top=3108140.0)
@@ -254,7 +254,7 @@ class TestRaster:
         assert r.count_on_disk == 1
         assert r.bands == (1,)
         assert r.bands_on_disk == (1,)
-        assert np.array_equal(r2.dtypes, ["float32"])
+        assert np.array_equal(r2.dtype, ["float32"])
         assert r2.transform == rio.transform.Affine(30.0, 0.0, 627175.0, 0.0, -30.0, 4852085.0)
         assert np.array_equal(r2.res, [30.0, 30.0])
         assert r2.bounds == rio.coords.BoundingBox(left=627175.0, bottom=4833545.0, right=643345.0, top=4852085.0)
@@ -427,13 +427,13 @@ class TestRaster:
         assert rst.astype("float32", convert_nodata=False).raster_equal(rst2, strict_masked=False)
 
         # Test with the dtype argument to convert back to original raster even if integer-type
-        if np.issubdtype(rst.dtypes[0], np.integer):
+        if np.issubdtype(rst.dtype, np.integer):
             # Set an existing nodata value, because all of our integer-type example datasets currently have "None"
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message="New nodata value cells already exist.*")
                 rst.set_nodata(new_nodata=255)
             ds = rst.to_xarray()
-            rst3 = gu.Raster.from_xarray(ds=ds, dtype=rst.dtypes[0])
+            rst3 = gu.Raster.from_xarray(ds=ds, dtype=rst.dtype)
             assert rst3.raster_equal(rst, strict_masked=False)
 
     @pytest.mark.parametrize("nodata_init", [None, "type_default"])  # type: ignore
@@ -910,17 +910,17 @@ class TestRaster:
         # Test negation
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert np.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtype, ["uint8"])
 
         # Test addition
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert np.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtype, ["uint8"])
 
         # Test subtraction
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert np.array_equal(r3.dtypes, ["uint8"])
+        assert np.array_equal(r3.dtype, ["uint8"])
 
         # Test with dtype Float32
         r1 = gu.Raster.from_array(
@@ -928,15 +928,15 @@ class TestRaster:
         )
         r3 = -r1
         assert np.all(r3.data == -r1.data)
-        assert np.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtype, ["float32"])
 
         r3 = r1 + r2
         assert np.all(r3.data == r1.data + r2.data)
-        assert np.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtype, ["float32"])
 
         r3 = r1 - r2
         assert np.all(r3.data == r1.data - r2.data)
-        assert np.array_equal(r3.dtypes, ["float32"])
+        assert np.array_equal(r3.dtype, ["float32"])
 
         # Check that errors are properly raised
         # different shapes
@@ -1043,13 +1043,13 @@ class TestRaster:
         assert r.raster_equal(r2)
 
         # -- Fifth test: check that the new_array argument works when providing a new dtype ##
-        if "int" in r.dtypes[0]:
+        if "int" in r.dtype:
             new_dtype = "float32"
         else:
             new_dtype = "uint8"
         r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype))
 
-        assert r2.dtypes[0] == new_dtype
+        assert r2.dtype == new_dtype
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_is_modified(self, example: str) -> None:
@@ -1499,7 +1499,7 @@ class TestRaster:
         assert np.count_nonzero(r_nodata.data.mask) > 0
 
         # make sure at least one pixel is set at default nodata for test
-        default_nodata = _default_nodata(r_nodata.dtypes[0])
+        default_nodata = _default_nodata(r_nodata.dtype)
         rand_indices = gu.raster.subsample_array(r_nodata.data, 10, return_indices=True)
         r_nodata.data[rand_indices] = default_nodata
         assert np.count_nonzero(r_nodata.data == default_nodata) > 0
@@ -1519,7 +1519,7 @@ class TestRaster:
             UserWarning,
             match=re.escape(
                 f"For reprojection, nodata must be set. Default chosen value "
-                f"{_default_nodata(r_nodata.dtypes[0])} exists in self.data. This may have unexpected "
+                f"{_default_nodata(r_nodata.dtype)} exists in self.data. This may have unexpected "
                 f"consequences. Consider setting a different nodata with self.set_nodata()."
             ),
         ):
@@ -2379,7 +2379,7 @@ class TestRaster:
         old_nodata = r.nodata
         # We chose nodata that doesn't exist in the raster yet for both our examples (for uint8, the default value of
         # 255 exist, so we replace by 0)
-        new_nodata = _default_nodata(r.dtypes[0]) if not r.dtypes[0] == "uint8" else 0
+        new_nodata = _default_nodata(r.dtype) if not r.dtype == "uint8" else 0
 
         # -- First, test set_nodata() with default parameters --
 
@@ -2542,11 +2542,11 @@ class TestRaster:
 
         # A ValueError if nodata value is incompatible with dtype
         expected_message = r"nodata value .* incompatible with self.dtype .*"
-        if "int" in r.dtypes[0]:
+        if "int" in r.dtype:
             with pytest.raises(ValueError, match=expected_message):
                 # Feed a floating numeric to an integer type
                 r.set_nodata(0.5)
-        elif "float" in r.dtypes[0]:
+        elif "float" in r.dtype:
             # Feed a floating value not supported by our example data
             with pytest.raises(ValueError, match=expected_message):
                 r.set_nodata(np.finfo("longdouble").min)
@@ -2586,8 +2586,8 @@ class TestRaster:
             warnings.filterwarnings(
                 "ignore", category=UserWarning, message="New nodata value cells already exist in the data array.*"
             )
-            r.set_nodata(_default_nodata(r.dtypes[0]))
-            r_copy.nodata = _default_nodata(r.dtypes[0])
+            r.set_nodata(_default_nodata(r.dtype))
+            r_copy.nodata = _default_nodata(r.dtype)
 
         assert r.raster_equal(r_copy)
 
@@ -2634,7 +2634,7 @@ class TestRaster:
 
         all_dtypes = ["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"]
 
-        dtypes_preserving = list({np.promote_types(r.dtypes[0], dtype) for dtype in all_dtypes})
+        dtypes_preserving = list({np.promote_types(r.dtype, dtype) for dtype in all_dtypes})
         dtypes_nonpreserving = [dtype for dtype in all_dtypes if dtype not in dtypes_preserving]
 
         # Test changing dtypes that does not modify the data
@@ -2647,7 +2647,7 @@ class TestRaster:
                 assert np.array_equal(r.data.data, rout.data.data)  # Not the same array anymore with conversion
                 assert np.array_equal(r.data.mask, rout.data.mask)
 
-            assert np.dtype(rout.dtypes[0]) == target_dtype
+            assert np.dtype(rout.dtype) == target_dtype
             assert rout.data.dtype == target_dtype
             # For any data type, data should be recast to the new type
             assert rout.nodata == _default_nodata(target_dtype)
@@ -2662,7 +2662,7 @@ class TestRaster:
                 r.data.data.astype(target_dtype2), rout.data.data
             )  # Not the same array anymore with conversion
 
-            assert np.dtype(rout.dtypes[0]) == target_dtype2
+            assert np.dtype(rout.dtype) == target_dtype2
             assert rout.data.dtype == target_dtype2
             assert rout.nodata == _default_nodata(target_dtype2)
 
@@ -2672,7 +2672,7 @@ class TestRaster:
         out = r2.astype(dtype, inplace=True)
         assert out is None
         assert np.ma.allequal(r.data, r2.data)
-        assert np.dtype(r2.dtypes[0]) == dtype
+        assert np.dtype(r2.dtype) == dtype
         assert r2.data.dtype == dtype
         assert r2.nodata == _default_nodata(dtype)
 
@@ -2682,7 +2682,7 @@ class TestRaster:
         out = r3.astype(dtype, inplace=True, convert_nodata=False)
         assert out is None
         assert np.ma.allequal(r.data, r3.data)
-        assert np.dtype(r3.dtypes[0]) == dtype
+        assert np.dtype(r3.dtype) == dtype
         assert r3.data.dtype == dtype
         assert r3.nodata == r.nodata
 
@@ -3370,7 +3370,7 @@ class TestMask:
         # Check output is the correct instance
         assert isinstance(mask, gu.Mask)
         # Check the dtypes metadata
-        assert mask.dtypes[0] == "bool"
+        assert mask.dtype == "bool"
         # Check the nodata
         assert mask.nodata is None
         # Check the nbands metadata

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -118,7 +118,9 @@ class TestSatelliteImage:
         assert isinstance(r2, gu.SatelliteImage)
 
         # Check all immutable attributes are equal
-        raster_attrs = [attr for attr in gu.raster.raster._default_rio_attrs if attr not in ["driver", "filename", "name"]]
+        raster_attrs = [
+            attr for attr in gu.raster.raster._default_rio_attrs if attr not in ["driver", "filename", "name"]
+        ]
         satimg_attrs = ["satellite", "sensor", "product", "version", "tile_name", "datetime"]
         # Using list directly available in class
         attrs = raster_attrs + satimg_attrs

--- a/tests/test_satimg.py
+++ b/tests/test_satimg.py
@@ -117,22 +117,10 @@ class TestSatelliteImage:
         # Check the object is a SatelliteImage
         assert isinstance(r2, gu.SatelliteImage)
 
-        # check all immutable attributes are equal
-        raster_attrs = [
-            "bounds",
-            "count",
-            "crs",
-            "dtypes",
-            "height",
-            "indexes",
-            "nodata",
-            "res",
-            "shape",
-            "transform",
-            "width",
-        ]
+        # Check all immutable attributes are equal
+        raster_attrs = [attr for attr in gu.raster.raster._default_rio_attrs if attr not in ["driver", "filename", "name"]]
         satimg_attrs = ["satellite", "sensor", "product", "version", "tile_name", "datetime"]
-        # using list directly available in Class
+        # Using list directly available in class
         attrs = raster_attrs + satimg_attrs
         all_attrs = attrs + gu.raster.satimg.satimg_attrs
         for attr in all_attrs:


### PR DESCRIPTION
Having `dtypes` as a tuple is effectively never used, even in Rasterio if I'm not mistaken, like for `nodata`.

Having a single value makes things much more straightforward for the user (and us).

Resolves #520
