### PR TITLE
Make `nodata` casting consistent based on new array type

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,6 +90,11 @@ jobs:
     - name: Setup pip dependencies
       run: pip install pytest-cov coveralls coveragepy-lcov
 
+    - name: Print conda environment (for debugging)
+      run: |
+        conda info
+        conda list
+
     - name: Test with pytest
       run: pytest -ra --cov=geoutils/
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -567,7 +567,7 @@ class Raster:
             self.set_area_or_point(filename_or_dataset["area_or_point"], shift_area_or_point=False)
 
             # Need to set nodata before the data setter, which uses it
-            # We trick set_nodata into knowing the data type by fixing self._disk_dtype, then removing it
+            # We trick set_nodata into knowing the data type by setting self._disk_dtype, then unsetting it
             # (as a raster created from an array doesn't have a disk dtype)
             if np.dtype(filename_or_dataset["data"].dtype) != bool:  # Exception for Mask class
                 self._disk_dtype = filename_or_dataset["data"].dtype

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -562,10 +562,19 @@ class Raster:
 
         # This is for Raster.from_array to work.
         if isinstance(filename_or_dataset, dict):
+
             # To have "area_or_point" user input go through checks of the set() function without shifting the transform
             self.set_area_or_point(filename_or_dataset["area_or_point"], shift_area_or_point=False)
-            # Same things here, and also important to pass the nodata before the data setter, which uses it in turn
-            self._nodata = filename_or_dataset["nodata"]
+
+            # Need to set nodata before the data setter, which uses it
+            # We trick set_nodata into knowing the data type by fixing self._disk_dtype, then removing it
+            # (as a raster created from an array doesn't have a disk dtype)
+            if np.dtype(filename_or_dataset["data"].dtype) != bool:  # Exception for Mask class
+                self._disk_dtype = filename_or_dataset["data"].dtype
+                self.set_nodata(filename_or_dataset["nodata"], update_array=False, update_mask=False)
+                self._disk_dtype = None
+
+            # Then, we can set the data, transform and crs
             self.data = filename_or_dataset["data"]
             self.transform: rio.transform.Affine = filename_or_dataset["transform"]
             self.crs: rio.crs.CRS = filename_or_dataset["crs"]
@@ -1021,8 +1030,7 @@ class Raster:
         :param data: Input array, 2D for single band or 3D for multi-band (bands should be first axis).
         :param transform: Affine 2D transform. Either a tuple(x_res, 0.0, top_left_x,
             0.0, y_res, top_left_y) or an affine.Affine object.
-        :param crs: Coordinate reference system. Either a rasterio CRS,
-            or an EPSG integer.
+        :param crs: Coordinate reference system. Any CRS supported by Pyproj (e.g., CRS object, EPSG integer).
         :param nodata: Nodata value.
         :param area_or_point: Pixel interpretation of the raster, will be stored in AREA_OR_POINT metadata.
         :param tags: Metadata stored in a dictionary.
@@ -1038,16 +1046,6 @@ class Raster:
             >>> transform = (30.0, 0.0, 478000.0, 0.0, -30.0, 3108140.0)
             >>> myim = Raster.from_array(data, transform, 32645)
         """
-        if not isinstance(transform, Affine):
-            if isinstance(transform, tuple):
-                transform = Affine(*transform)
-            else:
-                raise TypeError("The transform argument needs to be Affine or tuple.")
-
-        # Enable shortcut to create CRS from an EPSG ID.
-        if isinstance(crs, int):
-            crs = CRS.from_epsg(crs)
-
         # Define tags as empty dictionary if not defined
         if tags is None:
             tags = {}
@@ -1729,7 +1727,7 @@ class Raster:
 
         if new_nodata is not None:
             if not rio.dtypes.can_cast_dtype(new_nodata, self.dtype):
-                raise ValueError(f"nodata value {new_nodata} incompatible with self.dtype {self.dtype}")
+                raise ValueError(f"Nodata value {new_nodata} incompatible with self.dtype {self.dtype}.")
 
         # If we update mask or array, get the masked array
         if update_array or update_mask:
@@ -1787,7 +1785,10 @@ class Raster:
 
         # Update the nodata value
         self._nodata = new_nodata
-        self.data.fill_value = new_nodata
+
+        # Update the fill value only if the data is loaded
+        if self.is_loaded:
+            self.data.fill_value = new_nodata
 
     @property
     def data(self) -> MArrayNum:
@@ -2061,24 +2062,35 @@ class Raster:
         else:
             return "".join(as_str)
 
-    def copy(self: RasterType, new_array: NDArrayNum | None = None) -> RasterType:
+    def copy(self: RasterType, new_array: NDArrayNum | None = None, cast_nodata: bool = True) -> RasterType:
         """
         Copy the raster in-memory.
 
         :param new_array: New array to use in the copied raster.
+        :param cast_nodata: Automatically cast nodata value to the default nodata for the new array type if not
+            compatible. If False, will raise an error when incompatible.
 
         :return: Copy of the raster.
         """
+        # Define new array
         if new_array is not None:
             data = new_array
         else:
             data = self.data.copy()
 
+        # Cast nodata if the new array has incompatible type with the old nodata value, and casting is True
+        # Except if nodata is None or dtype is bool, then just pass it on
+        if new_array is not None and cast_nodata and self.nodata is not None and data.dtype != bool \
+                and not rio.dtypes.can_cast_dtype(self.nodata, data.dtype):
+            nodata = _default_nodata(data.dtype)
+        else:
+            nodata = self.nodata
+
         cp = self.from_array(
             data=data,
             transform=self.transform,
             crs=self.crs,
-            nodata=self.nodata,
+            nodata=nodata,
             area_or_point=self.area_or_point,
             tags=self.tags,
         )

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2080,9 +2080,14 @@ class Raster:
 
         # Cast nodata if the new array has incompatible type with the old nodata value, and casting is True
         # Except if nodata is None or dtype is bool, then just pass it on
-        if new_array is not None and cast_nodata and self.nodata is not None and data.dtype != bool \
-                and not rio.dtypes.can_cast_dtype(self.nodata, data.dtype):
-            nodata = _default_nodata(data.dtype)
+        if (
+            new_array is not None
+            and cast_nodata
+            and self.nodata is not None
+            and data.dtype != bool
+            and not rio.dtypes.can_cast_dtype(self.nodata, data.dtype)
+        ):
+            nodata: int | float | None = _default_nodata(data.dtype)
         else:
             nodata = self.nodata
 

--- a/geoutils/raster/satimg.py
+++ b/geoutils/raster/satimg.py
@@ -428,7 +428,7 @@ class SatelliteImage(Raster):  # type: ignore
 
         return None
 
-    def copy(self, new_array: NDArrayNum | None = None, cast_nodata: bool = False) -> SatelliteImage:
+    def copy(self, new_array: NDArrayNum | None = None, cast_nodata: bool = True) -> SatelliteImage:
         new_satimg = super().copy(new_array=new_array, cast_nodata=cast_nodata)  # type: ignore
         # all objects here are immutable so no need for a copy method (string and datetime)
         # satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime'] #taken outside of class

--- a/geoutils/raster/satimg.py
+++ b/geoutils/raster/satimg.py
@@ -428,8 +428,8 @@ class SatelliteImage(Raster):  # type: ignore
 
         return None
 
-    def copy(self, new_array: NDArrayNum | None = None) -> SatelliteImage:
-        new_satimg = super().copy(new_array=new_array)  # type: ignore
+    def copy(self, new_array: NDArrayNum | None = None, cast_nodata: bool = False) -> SatelliteImage:
+        new_satimg = super().copy(new_array=new_array, cast_nodata=cast_nodata)  # type: ignore
         # all objects here are immutable so no need for a copy method (string and datetime)
         # satimg_attrs = ['satellite', 'sensor', 'product', 'version', 'tile_name', 'datetime'] #taken outside of class
         for attrs in satimg_attrs:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -2945,7 +2945,7 @@ class TestRaster:
         with pytest.raises(TypeError, match="The transform argument needs to be Affine or tuple."):
             gu.Raster.from_array(data=img.data, transform="lol", crs=None, nodata=None)  # type: ignore
 
-    def test_from_array__nodata_casting(self):
+    def test_from_array__nodata_casting(self) -> None:
         """Check nodata casting of from_array that affects of all other functionalities (copy, etc)"""
 
         rst = gu.Raster(self.landsat_b4_path)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1061,13 +1061,31 @@ class TestRaster:
         assert r.raster_equal(r2)
 
         # -- Fifth test: check that the new_array argument works when providing a new dtype ##
+        # For an integer dataset cast to float, or opposite (the exploradores dataset will cast from float to int)
         if "int" in r.dtype:
             new_dtype = "float32"
         else:
             new_dtype = "uint8"
-        r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype))
 
+        # This should work all the types by default due to automatic casting
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Unmasked values equal to the nodata value*")
+            r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype))
         assert r2.dtype == new_dtype
+
+        # However, the new nodata will differ if casting was done
+        if np.promote_types(r.dtype, new_dtype) != new_dtype:
+            assert r2.nodata != r.nodata
+        else:
+            assert r2.nodata == r.nodata
+
+        # The copy should fail if the data type is not compatible
+        if np.promote_types(r.dtype, new_dtype) != new_dtype:
+            with pytest.raises(ValueError, match="Nodata value *"):
+                r.copy(new_array=r_arr.astype(dtype=new_dtype), cast_nodata=False)
+        else:
+            r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype), cast_nodata=False)
+            assert r2.dtype == new_dtype
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_is_modified(self, example: str) -> None:
@@ -2559,7 +2577,7 @@ class TestRaster:
             r.set_nodata(new_nodata="this_should_not_work")  # type: ignore
 
         # A ValueError if nodata value is incompatible with dtype
-        expected_message = r"nodata value .* incompatible with self.dtype .*"
+        expected_message = r"Nodata value .* incompatible with self.dtype .*"
         if "int" in r.dtype:
             with pytest.raises(ValueError, match=expected_message):
                 # Feed a floating numeric to an integer type

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1067,7 +1067,7 @@ class TestRaster:
         else:
             new_dtype = "uint8"
 
-        # This should work all the types by default due to automatic casting
+        # This should work for all the types by default due to automatic casting
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="Unmasked values equal to the nodata value*")
             r2 = r.copy(new_array=r_arr.astype(dtype=new_dtype))


### PR DESCRIPTION
This PR fixes the fact that `set_nodata` was circumvented during `from_array()` creation, making the behaviour fully consistent for checking nodata input and setting. 
Additionally, for practicality, it adds a `cast_nodata` boolean argument to `from_array()` defaulting to `True` which re-casts the input `nodata` to the default of the array type, if the nodata value was incompatible with the input array type.

The impact of this last change was actually much less of a bigger than I thought, because all integer nodata values are compatible with floating array types and the other direction rarely happens. There is almost no NumPy operations that convert from `float` to `int` (even operations like floordiv keep the output a float even if the output of the operation could technically be integers without loss of information, for instance).

So this mostly addresses the cases where the user is copying the data with a new array that has different data type (fairly common), or provided a non-compatible nodata value directly to from_array (less common).

Resolves #517
Resolves #516

TO-DO:

- [x] Use `set_nodata()` in from_array section of `__init__()`,
- [x] Add optional casting of nodata for new array type in `Raster.copy()`,
- [x] Add automatic casting of nodata for NumPy operations.
- [x] Add tests of new behaviour.
