### PR TITLE
Temporarily pin `coverage` version in CI for `coveragepy-lcov` to work

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -88,7 +88,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Setup pip dependencies
-      run: pip install pytest-cov coveralls coveragepy-lcov
+      run: pip install pytest-cov coveralls coveragepy-lcov 'coverage<7'
 
     - name: Print conda environment (for debugging)
       run: |


### PR DESCRIPTION
Resolves #541 

Opened #543 