### PR TITLE
Fix `interpn` option of `interp_points`

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3729,7 +3729,7 @@ class Raster:
         # Otherwise, use scipy.interpolate.interpn
         else:
             # Get lower-left corner coordinates
-            xycoords = self.coords(grid=False, force_offset="ll")
+            xycoords = self.coords(grid=False, shift_area_or_point=shift_area_or_point)
 
             # Let interpolation outside the bounds not raise any error by default
             if "bounds_error" not in kwargs.keys():
@@ -3738,7 +3738,7 @@ class Raster:
             if "fill_value" not in kwargs.keys():
                 kwargs.update({"fill_value": np.nan})
 
-            rpoints = interpn(xycoords, self.get_nanarray(), np.array([i, j]).T, method=method, **kwargs)
+            rpoints = interpn((np.flip(xycoords[1], axis=0), xycoords[0]), self.get_nanarray(), (y, x), method=method, **kwargs)
 
         rpoints = np.array(rpoints, dtype=np.float32)
         rpoints[np.array(ind_invalid)] = np.nan

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3738,6 +3738,7 @@ class Raster:
             if "fill_value" not in kwargs.keys():
                 kwargs.update({"fill_value": np.nan})
 
+            # Using direct coordinates, Y is the first axis, and we need to flip it
             rpoints = interpn(
                 (np.flip(xycoords[1], axis=0), xycoords[0]), self.get_nanarray(), (y, x), method=method, **kwargs
             )

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3738,7 +3738,9 @@ class Raster:
             if "fill_value" not in kwargs.keys():
                 kwargs.update({"fill_value": np.nan})
 
-            rpoints = interpn((np.flip(xycoords[1], axis=0), xycoords[0]), self.get_nanarray(), (y, x), method=method, **kwargs)
+            rpoints = interpn(
+                (np.flip(xycoords[1], axis=0), xycoords[0]), self.get_nanarray(), (y, x), method=method, **kwargs
+            )
 
         rpoints = np.array(rpoints, dtype=np.float32)
         rpoints[np.array(ind_invalid)] = np.nan

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2270,7 +2270,7 @@ class TestRaster:
             assert all(~np.isfinite(raster_points_mapcoords_edge))
             assert all(~np.isfinite(raster_points_interpn_edge))
 
-    def test_interp_points__real(self):
+    def test_interp_points__real(self) -> None:
         """Test interp_points for real data."""
 
         r = gu.Raster(self.landsat_b4_path)
@@ -2292,8 +2292,6 @@ class TestRaster:
         lat, lon = gu.projtools.reproject_to_latlon([x, y], in_crs=r.crs)
         val_latlon = r.interp_points((lat, lon), method="linear", input_latlon=True)[0]
         assert val == pytest.approx(val_latlon, abs=0.0001)
-
-
 
     def test_value_at_coords(self) -> None:
         """


### PR DESCRIPTION
An error had made its way through the test because the synthetic DEM coordinates started on (0,0)!

In practice this option of the algorithm was never used because the grid is almost always of equal resolution (Xres=Yres). As `map_coordinates` is faster, we could actually test if the interpolated results still match for different X/Y res, and remove `interpn` entirely if that is the case, but I'm not sure...
