### PR TITLE
Show full traceback on notebook execution error

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,7 +50,8 @@ myst_enable_extensions = ["colon_fence"]
 # For myst-nb to find the Jupyter kernel (=environment) to run from
 nb_kernel_rgx_aliases = {".*geoutils.*": "python3"}
 # To raise a Sphinx build error on notebook failure
-nb_execution_raise_on_error = True
+nb_execution_raise_on_error = True  # To fail documentation build on notebook execution error
+nb_execution_show_tb = True  # To show full traceback on notebook execution error
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),


### PR DESCRIPTION
Mirrors the change in https://github.com/GlacioHack/xdem/pull/531, makes it much easier to debug notebook execution errors (from the `.md` files of the documentation interpreted by `myst-nb`) only happening in CI and not locally.
