### PR TITLE
Rename `Raster.shift()` into `Raster.translate` and add `inplace` argument to `Vector.translate`

### DIFF
--- a/geoutils/raster/delayed.py
+++ b/geoutils/raster/delayed.py
@@ -466,13 +466,13 @@ class GeoGrid:
         """Create a GeoGrid from a dictionary containing transform, shape and CRS."""
         return cls(**dict_meta)
 
-    def shift(
+    def translate(
         self: GeoGridType,
         xoff: float,
         yoff: float,
         distance_unit: Literal["georeferenced"] | Literal["pixel"] = "pixel",
     ) -> GeoGridType:
-        """Shift into a new geogrid (not inplace)."""
+        """Translate into a new geogrid (not inplace)."""
 
         if distance_unit not in ["georeferenced", "pixel"]:
             raise ValueError("Argument 'distance_unit' should be either 'pixel' or 'georeferenced'.")
@@ -559,7 +559,7 @@ class ChunkedGeoGrid:
             # Build a temporary geogrid with the same transform as the full grid, but with the chunk shape
             geogrid_tmp = GeoGrid(transform=self.grid.transform, crs=self.grid.crs, shape=block_shape)
             # And shift it to the right location (X is positive in index direction, Y is negative)
-            geogrid_block = geogrid_tmp.shift(xoff=bid["xs"], yoff=-bid["ys"])
+            geogrid_block = geogrid_tmp.translate(xoff=bid["xs"], yoff=-bid["ys"])
             list_geogrids.append(geogrid_block)
 
         return list_geogrids
@@ -608,7 +608,7 @@ def _combined_blocks_shape_transform(
     combined_shape = (minmaxs["max_ye"] - minmaxs["min_ys"], minmaxs["max_xe"] - minmaxs["min_xs"])
 
     # Shift source transform with start indexes to get the one for combined block location
-    combined_transform = src_geogrid.shift(xoff=minmaxs["min_xs"], yoff=-minmaxs["min_ys"]).transform
+    combined_transform = src_geogrid.translate(xoff=minmaxs["min_xs"], yoff=-minmaxs["min_ys"]).transform
 
     # Compute relative block indexes that will be needed to reconstruct a square array in the delayed function,
     # by subtracting the minimum starting indices in X/Y

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2830,7 +2830,7 @@ class Raster:
             return self.from_array(data, transformed, crs, nodata, self.area_or_point)
 
     @overload
-    def shift(
+    def translate(
         self: RasterType,
         xoff: float,
         yoff: float,
@@ -2841,7 +2841,7 @@ class Raster:
         ...
 
     @overload
-    def shift(
+    def translate(
         self: RasterType,
         xoff: float,
         yoff: float,
@@ -2852,7 +2852,7 @@ class Raster:
         ...
 
     @overload
-    def shift(
+    def translate(
         self: RasterType,
         xoff: float,
         yoff: float,
@@ -2862,7 +2862,7 @@ class Raster:
     ) -> RasterType | None:
         ...
 
-    def shift(
+    def translate(
         self: RasterType,
         xoff: float,
         yoff: float,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -911,7 +911,7 @@ class Raster:
                 xoff = -0.5
                 yoff = 0.5
             # We perform the shift in place
-            self.shift(xoff=xoff, yoff=yoff, distance_unit="pixel", inplace=True)
+            self.translate(xoff=xoff, yoff=yoff, distance_unit="pixel", inplace=True)
 
     @property
     def area_or_point(self) -> Literal["Area", "Point"] | None:

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -559,10 +559,6 @@ class Vector:
         return self._override_gdf_output(self.ds.affine_transform(matrix=matrix))
 
     @copy_doc(gpd.GeoSeries, "Vector")
-    def translate(self, xoff: float = 0.0, yoff: float = 0.0, zoff: float = 0.0) -> Vector:
-        return self._override_gdf_output(self.ds.translate(xoff=xoff, yoff=yoff, zoff=zoff))
-
-    @copy_doc(gpd.GeoSeries, "Vector")
     def rotate(self, angle: float, origin: str = "center", use_radians: bool = False) -> Vector:
         return self._override_gdf_output(self.ds.rotate(angle=angle, origin=origin, use_radians=use_radians))
 
@@ -1134,42 +1130,59 @@ class Vector:
             return Vector(new_ds)
 
     @overload
-    def shift(
+    def translate(
             self: VectorType,
-            xoff: float,
-            yoff: float,
+            xoff: float = 0.0,
+            yoff: float = 0.0,
+            zoff: float = 0.0,
+            *,
             inplace: Literal[False] = False,
     ) -> VectorType:
         ...
 
     @overload
-    def shift(
+    def translate(
             self: VectorType,
-            xoff: float,
-            yoff: float,
+            xoff: float = 0.0,
+            yoff: float = 0.0,
+            zoff: float = 0.0,
+            *,
             inplace: Literal[True],
     ) -> None:
         ...
 
-    def shift(
+    @overload
+    def translate(
             self: VectorType,
-            xoff: float,
-            yoff: float,
+            xoff: float = 0.0,
+            yoff: float = 0.0,
+            zoff: float = 0.0,
+            *,
+            inplace: bool = False,
+    ) -> None:
+        ...
+
+    def translate(
+            self: VectorType,
+            xoff: float = 0.0,
+            yoff: float = 0.0,
+            zoff: float = 0.0,
             inplace: bool = False,
     ) -> VectorType | None:
         """
-        Shift a vector by a (x,y) offset.
+        Shift a vector by a (x,y) offset, and optionally a z offset.
 
         The shifting only updates the coordinates (data is untouched).
 
         :param xoff: Translation x offset.
         :param yoff: Translation y offset.
+        :param zoff: Translation z offset.
         :param inplace: Whether to modify the raster in-place.
 
         :returns: Shifted vector (or None if inplace).
         """
 
-        translated_geoseries = self.geometry.translate(xoff=xoff, yoff=yoff)
+        translated_geoseries = self.geometry.translate(xoff=xoff, yoff=yoff, zoff=zoff)
 
         if inplace:
             # Overwrite transform by shifted transform

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -1131,43 +1131,43 @@ class Vector:
 
     @overload
     def translate(
-            self: VectorType,
-            xoff: float = 0.0,
-            yoff: float = 0.0,
-            zoff: float = 0.0,
-            *,
-            inplace: Literal[False] = False,
+        self: VectorType,
+        xoff: float = 0.0,
+        yoff: float = 0.0,
+        zoff: float = 0.0,
+        *,
+        inplace: Literal[False] = False,
     ) -> VectorType:
         ...
 
     @overload
     def translate(
-            self: VectorType,
-            xoff: float = 0.0,
-            yoff: float = 0.0,
-            zoff: float = 0.0,
-            *,
-            inplace: Literal[True],
+        self: VectorType,
+        xoff: float = 0.0,
+        yoff: float = 0.0,
+        zoff: float = 0.0,
+        *,
+        inplace: Literal[True],
     ) -> None:
         ...
 
     @overload
     def translate(
-            self: VectorType,
-            xoff: float = 0.0,
-            yoff: float = 0.0,
-            zoff: float = 0.0,
-            *,
-            inplace: bool = False,
-    ) -> None:
+        self: VectorType,
+        xoff: float = 0.0,
+        yoff: float = 0.0,
+        zoff: float = 0.0,
+        *,
+        inplace: bool = False,
+    ) -> VectorType | None:
         ...
 
     def translate(
-            self: VectorType,
-            xoff: float = 0.0,
-            yoff: float = 0.0,
-            zoff: float = 0.0,
-            inplace: bool = False,
+        self: VectorType,
+        xoff: float = 0.0,
+        yoff: float = 0.0,
+        zoff: float = 0.0,
+        inplace: bool = False,
     ) -> VectorType | None:
         """
         Shift a vector by a (x,y) offset, and optionally a z offset.

--- a/geoutils/vector.py
+++ b/geoutils/vector.py
@@ -1134,6 +1134,53 @@ class Vector:
             return Vector(new_ds)
 
     @overload
+    def shift(
+            self: VectorType,
+            xoff: float,
+            yoff: float,
+            inplace: Literal[False] = False,
+    ) -> VectorType:
+        ...
+
+    @overload
+    def shift(
+            self: VectorType,
+            xoff: float,
+            yoff: float,
+            inplace: Literal[True],
+    ) -> None:
+        ...
+
+    def shift(
+            self: VectorType,
+            xoff: float,
+            yoff: float,
+            inplace: bool = False,
+    ) -> VectorType | None:
+        """
+        Shift a vector by a (x,y) offset.
+
+        The shifting only updates the coordinates (data is untouched).
+
+        :param xoff: Translation x offset.
+        :param yoff: Translation y offset.
+        :param inplace: Whether to modify the raster in-place.
+
+        :returns: Shifted vector (or None if inplace).
+        """
+
+        translated_geoseries = self.geometry.translate(xoff=xoff, yoff=yoff)
+
+        if inplace:
+            # Overwrite transform by shifted transform
+            self.ds.geometry = translated_geoseries
+            return None
+        else:
+            vector_copy = self.copy()
+            vector_copy.ds.geometry = translated_geoseries
+            return vector_copy
+
+    @overload
     def create_mask(
         self,
         raster: str | gu.Raster | None = None,

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1234,7 +1234,7 @@ class TestRaster:
             rst[arr[:-1, :-1]]
 
         # An error when the georeferencing of the Mask does not match
-        mask.shift(1, 1, inplace=True)
+        mask.translate(1, 1, inplace=True)
         with pytest.raises(ValueError, match=re.escape(message_raster.format(op_name_index))):
             rst[mask]
 
@@ -1466,8 +1466,8 @@ class TestRaster:
         assert r2_crop.area_or_point == "Point"
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path, landsat_rgb_path])  # type: ignore
-    def test_shift(self, example: str) -> None:
-        """Tests shift works as intended"""
+    def test_translate(self, example: str) -> None:
+        """Test translation works as intended"""
 
         r = gu.Raster(example)
 
@@ -1477,11 +1477,11 @@ class TestRaster:
 
         # Shift raster by georeferenced units (default)
         # Check the default behaviour is not inplace
-        r_notinplace = r.shift(xoff=1, yoff=1)
+        r_notinplace = r.translate(xoff=1, yoff=1)
         assert isinstance(r_notinplace, gu.Raster)
 
         # Check inplace
-        r.shift(xoff=1, yoff=1, inplace=True)
+        r.translate(xoff=1, yoff=1, inplace=True)
         # Both shifts should have yielded the same transform
         assert r.transform == r_notinplace.transform
 
@@ -1500,7 +1500,7 @@ class TestRaster:
         orig_transform = r.transform
         orig_bounds = r.bounds
         orig_res = r.res
-        r.shift(xoff=1, yoff=1, distance_unit="pixel", inplace=True)
+        r.translate(xoff=1, yoff=1, distance_unit="pixel", inplace=True)
 
         # Only bounds should change
         assert orig_transform.c + 1 * orig_res[0] == r.transform.c
@@ -1515,7 +1515,7 @@ class TestRaster:
 
         # Check that an error is raised for a wrong distance_unit
         with pytest.raises(ValueError, match="Argument 'distance_unit' should be either 'pixel' or 'georeferenced'."):
-            r.shift(xoff=1, yoff=1, distance_unit="wrong_value")  # type: ignore
+            r.translate(xoff=1, yoff=1, distance_unit="wrong_value")  # type: ignore
 
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])  # type: ignore
     def test_reproject(self, example: str) -> None:

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -241,18 +241,18 @@ class TestVector:
         with pytest.raises(TypeError, match="Crop geometry must be a Raster, Vector, or list of coordinates."):
             outlines.crop(1, inplace=True)  # type: ignore
 
-    def test_shift(self) -> None:
+    def test_translate(self) -> None:
 
         vector = gu.Vector(self.everest_outlines_path)
 
         # Check defaut behaviour is not inplace
-        vector_shifted = vector.shift(xoff=2.5, yoff=5.7)
+        vector_shifted = vector.translate(xoff=2.5, yoff=5.7)
         assert isinstance(vector_shifted, gu.Vector)
         assert_geoseries_equal(vector_shifted.geometry, vector.geometry.translate(xoff=2.5, yoff=5.7))
 
         # Check inplace behaviour works correctly
         vector2 = vector.copy()
-        output = vector2.shift(xoff=2.5, yoff=5.7, inplace=True)
+        output = vector2.translate(xoff=2.5, yoff=5.7, inplace=True)
         assert output is None
         assert_geoseries_equal(vector2.geometry, vector_shifted.geometry)
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -245,7 +245,7 @@ class TestVector:
 
         vector = gu.Vector(self.everest_outlines_path)
 
-        # Check defaut behaviour is not inplace
+        # Check default behaviour is not inplace
         vector_shifted = vector.translate(xoff=2.5, yoff=5.7)
         assert isinstance(vector_shifted, gu.Vector)
         assert_geoseries_equal(vector_shifted.geometry, vector.geometry.translate(xoff=2.5, yoff=5.7))

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -241,6 +241,21 @@ class TestVector:
         with pytest.raises(TypeError, match="Crop geometry must be a Raster, Vector, or list of coordinates."):
             outlines.crop(1, inplace=True)  # type: ignore
 
+    def test_shift(self) -> None:
+
+        vector = gu.Vector(self.everest_outlines_path)
+
+        # Check defaut behaviour is not inplace
+        vector_shifted = vector.shift(xoff=2.5, yoff=5.7)
+        assert isinstance(vector_shifted, gu.Vector)
+        assert_geoseries_equal(vector_shifted.geometry, vector.geometry.translate(xoff=2.5, yoff=5.7))
+
+        # Check inplace behaviour works correctly
+        vector2 = vector.copy()
+        output = vector2.shift(xoff=2.5, yoff=5.7, inplace=True)
+        assert output is None
+        assert_geoseries_equal(vector2.geometry, vector_shifted.geometry)
+
     def test_proximity(self) -> None:
         """
         The core functionality is already tested against GDAL in test_raster: just verify the vector-specific behaviour.


### PR DESCRIPTION
Turns out `Vector.translate` already existed (from Geopandas), so renaming Raster method to match instead.

Resolves #569
