### PR TITLE
Fix documentation warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -52,6 +52,7 @@ nb_kernel_rgx_aliases = {".*geoutils.*": "python3"}
 # To raise a Sphinx build error on notebook failure
 nb_execution_raise_on_error = True  # To fail documentation build on notebook execution error
 nb_execution_show_tb = True  # To show full traceback on notebook execution error
+nb_output_stderr = "warn"  # To warn if an error is raised in a notebook cell (if intended, override to "show" in cell)
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),

--- a/doc/source/core_lazy_load.md
+++ b/doc/source/core_lazy_load.md
@@ -57,6 +57,11 @@ For instance, using any {class}`~geoutils.Raster` or {class}`~geoutils.Vector` a
 always conserve the lazy loading of that match-reference object.
 
 ```{code-cell} ipython3
+---
+mystnb:
+  output_stderr: show
+---
+
 # Use a smaller Raster as reference to crop the initial one
 smaller_rast = gu.Raster(gu.examples.get_path("everest_landsat_b4_cropped"))
 rast.crop(smaller_rast)

--- a/doc/source/geotransformations.md
+++ b/doc/source/geotransformations.md
@@ -104,7 +104,7 @@ and resolution:
 ```{code-cell} ipython3
 ---
 mystnb:
-  output_stderr: warn
+  output_stderr: show
 ---
 # Reproject vector to CRS of raster by simply passing the raster
 rast_reproj2 = rast.reproject(rast2)

--- a/doc/source/quick_start.md
+++ b/doc/source/quick_start.md
@@ -54,10 +54,15 @@ a buffer of the vector, perform calculations on the modified raster, and finally
 :class: margin
 
 **We notice a ``Userwarning``:** No nodata value was defined in the GeoTIFF file, so GeoUtils automatically defined
-one compatible with the data type to use during operations.
+one compatible with the data type derived during operations.
 ```
 
 ```{code-cell} ipython3
+---
+mystnb:
+  output_stderr: show
+---
+
 import geoutils as gu
 
 # Examples files: paths to a GeoTIFF file and an ESRI shapefile

--- a/doc/source/vector_class.md
+++ b/doc/source/vector_class.md
@@ -106,6 +106,10 @@ vect.boundary
 
 ```{code-cell} ipython3
 :tags: [hide-output]
+---
+mystnb:
+  output_stderr: show
+---
 
 # Example of method with non-geometry output
 vect.area

--- a/doc/source/vector_class.md
+++ b/doc/source/vector_class.md
@@ -98,14 +98,11 @@ These behaviours aim to simplify the analysis of vectors, removing the need to o
 ({class}`geopandas.GeoDataFrame`, {class}`geopandas.GeoSeries`, {class}`shapely.Geometry`, {class}`pandas.Series`).
 
 ```{code-cell} ipython3
-:tags: [hide-output]
-
 # Example of method with geometric output
 vect.boundary
 ```
 
 ```{code-cell} ipython3
-:tags: [hide-output]
 ---
 mystnb:
   output_stderr: show
@@ -116,8 +113,6 @@ vect.area
 ```
 
 ```{code-cell} ipython3
-:tags: [hide-output]
-
 # Example of method with other output type
 vect.to_json()
 ```

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -26,13 +26,13 @@ def load_multiple_rasters(
     Optionally, reproject all rasters to the grid of one raster set as reference (after optional crop).
     Otherwise, simply load the full rasters.
 
-    :param raster_paths: List of paths to the rasters to be loaded
-    :param crop: if set to True, will only load rasters in the area they intersect
+    :param raster_paths: List of paths to the rasters to be loaded.
+    :param crop: If set to True, will only load rasters in the area they intersect.
     :param ref_grid: If set to an integer value, the raster with that index will be considered as the reference
-    and all other rasters will be reprojected on the same grid (after optional crop)
-    :param kwargs: optional arguments to be passed to Raster.reproject, e.g. the resampling method
+        and all other rasters will be reprojected on the same grid (after optional crop).
+    :param kwargs: Optional arguments to be passed to Raster.reproject, e.g. the resampling method.
 
-    :returns: a list of loaded Raster instances
+    :returns: List of loaded Raster instances.
     """
     # If ref_grid is provided, need to reproject
     if isinstance(ref_grid, int):

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3686,7 +3686,7 @@ class Raster:
          of shift_area_or_point for more details.
 
         :param points: Point(s) at which to interpolate raster value (tuple of X/Y array-likes). If points fall
-        outside of image, value returned is nan.
+            outside of image, value returned is nan.
         :param method: Interpolation method, one of 'nearest', 'linear', 'cubic', or 'quintic'. For more information,
             see scipy.ndimage.map_coordinates and scipy.interpolate.interpn. Default is linear.
         :param band: Band to use (from 1 to self.count).


### PR DESCRIPTION
This PR fixes two sphinx warnings due to line indent in docstrings.
It also changes the default behaviour for warning raising in a notebook cell to "warn", to catch unintended warnings/errors raised by notebook cells during documentation build. Cells that are expected to show a warning/error need to be overridden locally using the `output_stderr: show` setting.

Resolves #592
