### PR TITLE
Fix resampling not being passed to `stack_rasters` and add tests

### DIFF
--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -181,6 +181,7 @@ def stack_rasters(
             crs=reference_raster.crs,
             dtype=reference_raster.data.dtype,
             nodata=reference_raster.nodata,
+            resampling=resampling_method,
             silent=True,
         )
         reprojected_raster.set_nodata(nodata)


### PR DESCRIPTION
The `resampling` argument was not passed to `reproject()` in `stack_rasters`.

Added new tests that ensure it is done consistently now.

Resolves #599
