### PR TITLE
Fix bug for raster with nodata equal to 0 in `stack_rasters`

### DIFF
--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -180,10 +180,14 @@ def stack_rasters(
             res=reference_raster.res,
             crs=reference_raster.crs,
             dtype=reference_raster.data.dtype,
-            nodata=reference_raster.nodata,
+            nodata=nodata,
             resampling=resampling_method,
             silent=True,
         )
+        # If the georeferenced grid was the same, reproject() will have returned self with a warning (silenced here),
+        # and we want to copy the raster before modifying its nodata (or it will modify raster inputs of this function)
+        if reprojected_raster.georeferenced_grid_equal(raster):
+            reprojected_raster = reprojected_raster.copy()
         reprojected_raster.set_nodata(nodata)
 
         # Optionally calculate difference

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -165,7 +165,7 @@ def stack_rasters(
             return_rio_bbox=True,
         )
 
-    # Make a data list and add all of the reprojected rasters into it.
+    # Make a data list and add all the reprojected rasters into it.
     data: list[NDArrayNum] = []
 
     for raster in tqdm(rasters, disable=not progress):
@@ -173,7 +173,7 @@ def stack_rasters(
         if not raster.is_loaded:
             raster.load()
 
-        nodata = reference_raster.nodata or gu.raster.raster._default_nodata(reference_raster.data.dtype)
+        nodata = reference_raster.nodata if not None else gu.raster.raster._default_nodata(reference_raster.data.dtype)
         # Reproject to reference grid
         reprojected_raster = raster.reproject(
             bounds=dst_bounds,

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -185,10 +185,10 @@ def stack_rasters(
             silent=True,
         )
         # If the georeferenced grid was the same, reproject() will have returned self with a warning (silenced here),
-        # and we want to copy the raster before modifying its nodata (or it will modify raster inputs of this function)
+        # and we want to copy the raster and just modify its nodata (or would modify raster inputs of this function)
         if reprojected_raster.georeferenced_grid_equal(raster):
             reprojected_raster = reprojected_raster.copy()
-        reprojected_raster.set_nodata(nodata)
+            reprojected_raster.set_nodata(nodata)
 
         # Optionally calculate difference
         if diff:

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -67,16 +67,16 @@ class RealImageStack:
             inplace=True,
         )
 
+
 class SyntheticImageStack:
     """
     Synthetic image stack for tests
 
     Create a small synthetic example, where one can specify nodata value, values in second image (and potentially more
     in the future).
-   """
+    """
 
     def __init__(self, nodata: int | float, img2_value: int | float):
-
 
         shape = (10, 10)
         data_int = np.ones(shape).astype(np.uint16)
@@ -151,9 +151,11 @@ def sat_images():  # type: ignore
 def images_3d():  # type: ignore
     return RealImageStack("everest_landsat_rgb")
 
+
 @pytest.fixture
 def images_nodata_zero():  # type: ignore
     return SyntheticImageStack(nodata=0, img2_value=65534)
+
 
 class TestMultiRaster:
     @pytest.mark.parametrize(
@@ -163,7 +165,7 @@ class TestMultiRaster:
             pytest.lazy_fixture("sat_images"),
             pytest.lazy_fixture("images_different_crs"),
             pytest.lazy_fixture("images_3d"),
-            pytest.lazy_fixture("images_nodata_zero")
+            pytest.lazy_fixture("images_nodata_zero"),
         ],
     )  # type: ignore
     def test_stack_rasters(self, rasters) -> None:  # type: ignore

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -243,6 +243,10 @@ class TestMultiRaster:
         stacked_img = gu.raster.stack_rasters([rasters.img1, rasters.img2], resampling_method="bilinear")
         assert not np.array_equal(np.unique(stacked_img.data.compressed()), np.array([1, 5]))
 
+        # Check input nodata is not modified inplace (issue 609)
+        new_nodata_ref = rasters.img1.nodata
+        assert nodata_ref == new_nodata_ref
+
         # Check nodata value output is consistent with reference input
         if nodata_ref is not None:
             assert stacked_img.nodata == nodata_ref


### PR DESCRIPTION
Bug fixed, and new tests added largely based on the examples provided by @axeldolce in #608 

Resolves #608 
