### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # Run all shells using bash (including Windows)
     defaults:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     defaults:
       run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ For more details, see the rest of this document.
 
 ## Development environment
 
-GeoUtils currently supports only Python versions of 3.9 and higher, see `environment.yml` for detailed dependencies.
+GeoUtils currently supports only Python versions of 3.10 to 3.12, see `environment.yml` for detailed dependencies.
 
 ### Setup
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -2,7 +2,7 @@ name: geoutils-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - python>=3.10,<3.13
   - geopandas>=0.12.0
   - matplotlib=3.*
   - pyproj=3.*

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: geoutils
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - python>=3.10,<3.13
   - geopandas>=0.12.0
   - matplotlib=3.*
   - pyproj=3.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version_file = "geoutils/_version.py"
 fallback_version = "0.0.1"
 
 [tool.black]
-target_version = ['py36']
+target_version = ['py310']
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules -W error::UserWarning"

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 scripts = bin/geoviewer.py
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.9,<3.13
+python_requires = >=3.10,<3.13
 # Avoid pinning dependencies in requirements.txt (which we don't do anyways, and we rely mostly on Conda)
 # (https://caremad.io/posts/2013/07/setup-vs-requirement/, https://github.com/pypa/setuptools/issues/1951)
 install_requires = file: requirements.txt


### PR DESCRIPTION
Resolves #615 

 - [x] New optional dependencies or Python version support added to both `dev-environment.yml` and `setup.cfg`,
 - [x] If contributor workflow (test, doc, linting) or Python version support changed, update `CONTRIBUTING.md`.
