### PR TITLE
Add percentage valid points in `get_stats()`

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -107,6 +107,15 @@ documentation.
     Raster.plot
 ```
 
+### Get statistics
+
+```{eval-rst}
+.. autosummary::
+    :toctree: gen_modules/
+
+    Raster.get_stats
+```
+
 ### Get or update data methods
 
 ```{eval-rst}

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -361,8 +361,9 @@ rast_reproj.to_xarray()
 
 ## Obtain Statistics
 The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, std, valid points and
-percentage valid points.
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points
+and percentage valid points.
+The RMSE is only relevant when the raster represents a difference of two objects.
 Callable functions are supported as well.
 
 ### Usage Examples:

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -360,10 +360,23 @@ rast_reproj.to_xarray()
 ```
 
 ## Obtain Statistics
-The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points,
-percentage valid points, valid points all data, percentage valid points all data.
-The RMSE is only relevant when the raster represents a difference of two objects.
+The {func}`~geoutils.Raster.get_stats` method allows to extract key statistical information from a raster in a dictionary.
+Supported statistics are :
+- **Mean:** arithmetic mean of the data, ignoring masked values.
+- **Median:** middle value when the valid data points are sorted in increasing order, ignoring masked values.
+- **Max:** maximum value among the data, ignoring masked values.
+- **Min:** minimum value among the data, ignoring masked values.
+- **Sum:** sum of all data, ignoring masked values.
+- **Sum of squares:** sum of the squares of all data, ignoring masked values.
+- **90th percentile:** point below which 90% of the data falls, ignoring masked values.
+- **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
+- **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
+- **Std (Standard deviation):** Measures the spread or dispersion of the data around the mean, ignoring masked values.
+- **Valid count:** The number of valid (unmasked) data points in the array. It counts the non-masked elements.
+- **Total count:** The total number of finite data points in the array, including masked elements.
+- **Percentage valid points:** The percentage of unmasked data points out of the total number of finite points. Useful for classification statistics.
+- **Size:** Total size of the raster.
+
 Callable functions are supported as well.
 
 ### Usage Examples:

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -374,9 +374,12 @@ Supported statistics are :
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
 - **Std (Standard deviation):** Measures the spread or dispersion of the data around the mean, ignoring masked values.
 - **Valid count:** The number of valid (unmasked) data points in the array. It counts the non-masked elements.
-- **Total count:** The total number of finite data points in the array, including masked elements.
-- **Percentage valid points:** The percentage of unmasked data points out of the total number of finite points. Useful for classification statistics.
 - **Size:** Total size of the raster.
+
+If an inlier mask is passed:
+- **Total count:** The number of unmasked data points in the array before applying the inlier mask.
+- **Percentage valid points:** The ration between `valid_count` and `total_count` Useful for classification statistics.
+
 
 Callable functions are supported as well.
 
@@ -401,4 +404,12 @@ rast.get_stats(["mean", "max", "std"])
 def custom_stat(data):
     return np.nansum(data > 100)  # Count the number of pixels above 100
 rast.get_stats(custom_stat)
+```
+
+- Passing an inlier mask:
+```{code-cell} ipython3
+inlier_mask = np.array([[False, False , True],
+                        [False, True , False],
+                        [True, False , True]])
+rast.get_stats(inlier_mask=inlier_mask)
 ```

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -361,7 +361,7 @@ rast_reproj.to_xarray()
 
 ## Obtain Statistics
 The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, std, count and
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, std, valid points and
 percentage valid points.
 Callable functions are supported as well.
 

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -260,14 +260,14 @@ The {func}`~geoutils.Raster.icrop` function accepts only a bounding box in pixel
 By default, {func}`~geoutils.Raster.crop` and {func}`~geoutils.Raster.icrop` return a new Raster unless the inplace parameter is set to True, in which case the cropping operation is performed directly on the original raster object.
 For more details, see the {ref}`specific section and function descriptions in the API<api-geo-handle>`.
 
-### Example for `crop`
+### Example for {func}`~geoutils.Raster.crop`
 ```{code-cell} ipython3
 # Crop raster to smaller bounds
 rast_crop = rast.crop(bbox=(0.3, 0.3, 1, 1))
 print(rast_crop.bounds)
 ```
 
-### Example for `icrop`
+### Example for {func}`~geoutils.Raster.icrop`
 ```{code-cell} ipython3
 # Crop raster using pixel coordinates
 rast_icrop = rast.icrop(bbox=(2, 2, 6, 6))

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -361,8 +361,8 @@ rast_reproj.to_xarray()
 
 ## Obtain Statistics
 The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points
-and percentage valid points.
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points,
+percentage valid points, valid points all data, percentage valid points all data.
 The RMSE is only relevant when the raster represents a difference of two objects.
 Callable functions are supported as well.
 

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -369,6 +369,7 @@ Supported statistics are :
 - **Sum:** sum of all data, ignoring masked values.
 - **Sum of squares:** sum of the squares of all data, ignoring masked values.
 - **90th percentile:** point below which 90% of the data falls, ignoring masked values.
+- **LE90 (Linear Error with 90% confidence):** Difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
 - **Std (Standard deviation):** Measures the spread or dispersion of the data around the mean, ignoring masked values.

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -361,7 +361,8 @@ rast_reproj.to_xarray()
 
 ## Obtain Statistics
 The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std.
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, std, count and
+percentage valid points.
 Callable functions are supported as well.
 
 ### Usage Examples:
@@ -377,7 +378,7 @@ rast.get_stats("mean")
 
 - Get multiple statistics in a dict:
 ```{code-cell} ipython3
-rast.get_stats(["mean", "max", "rmse"])
+rast.get_stats(["mean", "max", "std"])
 ```
 
 - Using a custom callable statistic:

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -372,13 +372,17 @@ Supported statistics are :
 - **LE90 (Linear Error with 90% confidence):** Difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
-- **Std (Standard deviation):** Measures the spread or dispersion of the data around the mean, ignoring masked values.
-- **Valid count:** The number of valid (unmasked) data points in the array. It counts the non-masked elements.
-- **Size:** Total size of the raster.
+- **Std (Standard deviation):** measures the spread or dispersion of the data around the mean, ignoring masked values.
+- **Valid count:** number of finite data points in the array. It counts the non-masked elements.
+- **Total count:** total size of the raster.
+- **Percentage valid points:** ratio between **Valid count** and **Total count**.
+
 
 If an inlier mask is passed:
-- **Total count:** The number of unmasked data points in the array before applying the inlier mask.
-- **Percentage valid points:** The ration between `valid_count` and `total_count` Useful for classification statistics.
+- **Total inlier count:** number of data points in the inlier mask.
+- **Valid inlier count:** number of unmasked data points in the array after applying the inlier mask.
+- **Percentage inlier points:** ratio between **Valid inlier count** and **Valid count**. Useful for classification statistics.
+- **Percentage valid inlier points:** ratio between **Valid inlier count** and **Total inlier count**.
 
 
 Callable functions are supported as well.

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1897,7 +1897,7 @@ class Raster:
         :param band: The index of the band for which to compute statistics. Default is 1.
 
         :returns: A dictionary containing the calculated statistics for the selected band, including mean, median, max,
-        min, sum, sum of squares, 90th percentile, NMAD, RMSE, and standard deviation.
+        min, sum, sum of squares, 90th percentile, NMAD, standard deviation, and percentile valid points.
         """
         if self.count == 1:
             data = self.data
@@ -1918,7 +1918,6 @@ class Raster:
             "Sum of squares": np.nansum(np.square(data)),
             "90th percentile": np.nanpercentile(data, 90),
             "NMAD": nmad(data),
-            "RMSE": np.sqrt(np.nanmean(np.square(data - np.nanmean(data)))),
             "Standard deviation": np.nanstd(data),
             "Percentile valid points": (np.count_nonzero(~np.isnan(data)) / data.size) * 100,
         }
@@ -1928,7 +1927,18 @@ class Raster:
     def get_stats(
         self,
         stats_name: (
-            Literal["mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std"]
+            Literal[
+                "mean",
+                "median",
+                "max",
+                "min",
+                "sum",
+                "sum of squares",
+                "90th percentile",
+                "nmad",
+                "std",
+                "percentile valid points",
+            ]
             | Callable[[NDArrayNum], np.floating[Any]]
         ),
         band: int = 1,
@@ -1940,7 +1950,16 @@ class Raster:
         stats_name: (
             list[
                 Literal[
-                    "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std"
+                    "mean",
+                    "median",
+                    "max",
+                    "min",
+                    "sum",
+                    "sum of squares",
+                    "90th percentile",
+                    "nmad",
+                    "std",
+                    "percentile valid points",
                 ]
                 | Callable[[NDArrayNum], np.floating[Any]]
             ]
@@ -1952,11 +1971,31 @@ class Raster:
     def get_stats(
         self,
         stats_name: (
-            Literal["mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std"]
+            Literal[
+                "mean",
+                "median",
+                "max",
+                "min",
+                "sum",
+                "sum of squares",
+                "90th percentile",
+                "nmad",
+                "std",
+                "percentile valid points",
+            ]
             | Callable[[NDArrayNum], np.floating[Any]]
             | list[
                 Literal[
-                    "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std"
+                    "mean",
+                    "median",
+                    "max",
+                    "min",
+                    "sum",
+                    "sum of squares",
+                    "90th percentile",
+                    "nmad",
+                    "std",
+                    "percentile valid points",
                 ]
                 | Callable[[NDArrayNum], np.floating[Any]]
             ]
@@ -1970,7 +2009,8 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
                    Accepted names include:
-                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std"
+                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "std",
+                   "percentile valid points".
                    You can also use common aliases for these names (e.g., "average", "maximum", "minimum", etc.).
                    Custom callables can also be provided.
         :param band: The index of the band for which to compute statistics. Default is 1.
@@ -2000,7 +2040,6 @@ class Raster:
             "90percentile": "90th percentile",
             "percentile90": "90th percentile",
             "nmad": "NMAD",
-            "rmse": "RMSE",
             "std": "Standard deviation",
             "stddev": "Standard deviation",
             "standarddev": "Standard deviation",

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1897,7 +1897,7 @@ class Raster:
         :param band: The index of the band for which to compute statistics. Default is 1.
 
         :returns: A dictionary containing the calculated statistics for the selected band, including mean, median, max,
-        min, sum, sum of squares, 90th percentile, NMAD, standard deviation, and percentile valid points.
+        min, sum, sum of squares, 90th percentile, NMAD, standard deviation, count, and percentage valid points.
         """
         if self.count == 1:
             data = self.data
@@ -1909,6 +1909,7 @@ class Raster:
             data = data.compressed()
 
         # Compute the statistics
+        count = np.count_nonzero(np.isfinite(data))
         stats_dict = {
             "Mean": np.nanmean(data),
             "Median": np.nanmedian(data),
@@ -1919,7 +1920,8 @@ class Raster:
             "90th percentile": np.nanpercentile(data, 90),
             "NMAD": nmad(data),
             "Standard deviation": np.nanstd(data),
-            "Percentile valid points": (np.count_nonzero(~np.isnan(data)) / data.size) * 100,
+            "Valid count": count,
+            "Percentage valid points": (count / data.size) * 100,
         }
         return stats_dict
 
@@ -1937,7 +1939,8 @@ class Raster:
                 "90th percentile",
                 "nmad",
                 "std",
-                "percentile valid points",
+                "count",
+                "percentage valid points",
             ]
             | Callable[[NDArrayNum], np.floating[Any]]
         ),
@@ -1959,7 +1962,8 @@ class Raster:
                     "90th percentile",
                     "nmad",
                     "std",
-                    "percentile valid points",
+                    "count",
+                    "percentage valid points",
                 ]
                 | Callable[[NDArrayNum], np.floating[Any]]
             ]
@@ -1981,7 +1985,8 @@ class Raster:
                 "90th percentile",
                 "nmad",
                 "std",
-                "percentile valid points",
+                "count",
+                "percentage valid points",
             ]
             | Callable[[NDArrayNum], np.floating[Any]]
             | list[
@@ -1995,7 +2000,8 @@ class Raster:
                     "90th percentile",
                     "nmad",
                     "std",
-                    "percentile valid points",
+                    "count",
+                    "percentage valid points",
                 ]
                 | Callable[[NDArrayNum], np.floating[Any]]
             ]
@@ -2009,8 +2015,8 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
                    Accepted names include:
-                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "std",
-                   "percentile valid points".
+                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "std", "count",
+                   "percentage valid points".
                    You can also use common aliases for these names (e.g., "average", "maximum", "minimum", etc.).
                    Custom callables can also be provided.
         :param band: The index of the band for which to compute statistics. Default is 1.
@@ -2026,7 +2032,6 @@ class Raster:
         # Define the metric aliases and their actual names
         stats_aliases = {
             "mean": "Mean",
-            "average": "Mean",
             "median": "Median",
             "max": "Max",
             "maximum": "Max",
@@ -2035,17 +2040,13 @@ class Raster:
             "sum": "Sum",
             "sumofsquares": "Sum of squares",
             "sum2": "Sum of squares",
-            "percentile": "90th percentile",
             "90thpercentile": "90th percentile",
             "90percentile": "90th percentile",
-            "percentile90": "90th percentile",
             "nmad": "NMAD",
             "std": "Standard deviation",
-            "stddev": "Standard deviation",
-            "standarddev": "Standard deviation",
-            "standarddeviation": "Standard deviation",
-            "percentvalidpoint": "Percentile valid point",
-            "validpoint": "Percentile valid point",
+            "count": "Valid count",
+            "percentagevalidpoint": "Percentage valid point",
+            "validpoint": "Percentage valid point",
         }
         if isinstance(stats_name, list):
             result = {}

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1897,7 +1897,8 @@ class Raster:
         :param band: The index of the band for which to compute statistics. Default is 1.
 
         :returns: A dictionary containing the calculated statistics for the selected band, including mean, median, max,
-        min, sum, sum of squares, 90th percentile, NMAD, standard deviation, valid points, and percentage valid points.
+        min, sum, sum of squares, 90th percentile, NMAD, RMSE, standard deviation, valid points, and percentage
+        valid points.
         """
 
         if self.count == 1:
@@ -1921,6 +1922,7 @@ class Raster:
             "Sum of squares": np.nansum(np.square(data)),
             "90th percentile": np.nanpercentile(data, 90),
             "NMAD": nmad(data),
+            "RMSE": np.sqrt(np.nanmean(np.square(data))),
             "Standard deviation": np.nanstd(data),
             "Valid points": valid_points,
             "Percentage valid points": (valid_points / data.size) * 100,
@@ -1942,6 +1944,7 @@ class Raster:
                 "sum of squares",
                 "90th percentile",
                 "nmad",
+                "rmse",
                 "std",
                 "valid points",
                 "percentage valid points",
@@ -1965,6 +1968,7 @@ class Raster:
                     "sum of squares",
                     "90th percentile",
                     "nmad",
+                    "rmse",
                     "std",
                     "valid points",
                     "percentage valid points",
@@ -1988,6 +1992,7 @@ class Raster:
                 "sum of squares",
                 "90th percentile",
                 "nmad",
+                "rmse",
                 "std",
                 "valid points",
                 "percentage valid points",
@@ -2003,6 +2008,7 @@ class Raster:
                     "sum of squares",
                     "90th percentile",
                     "nmad",
+                    "rmse",
                     "std",
                     "valid points",
                     "percentage valid points",
@@ -2019,9 +2025,8 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
                    Accepted names include:
-                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "std",
+                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std",
                    "valid points", "percentage valid points".
-                   You can also use common aliases for these names (e.g., "average", "maximum", "minimum", etc.).
                    Custom callables can also be provided.
         :param band: The index of the band for which to compute statistics. Default is 1.
 
@@ -2047,6 +2052,8 @@ class Raster:
             "90thpercentile": "90th percentile",
             "90percentile": "90th percentile",
             "nmad": "NMAD",
+            "rmse": "RMSE",
+            "rms": "RMSE",
             "std": "Standard deviation",
             "validpoints": "Valid points",
             "percentagevalidpoints": "Percentage valid point",

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -89,7 +89,7 @@ from geoutils.raster.satimg import (
     decode_sensor_metadata,
     parse_and_convert_metadata_from_filename,
 )
-from geoutils.stats import nmad
+from geoutils.stats import linear_error, nmad
 from geoutils.vector.vector import Vector
 
 # If python38 or above, Literal is builtin. Otherwise, use typing_extensions
@@ -1897,7 +1897,7 @@ class Raster:
         :param band: The index of the band for which to compute statistics. Default is 1.
 
         :returns: A dictionary containing the calculated statistics for the selected band, including mean, median, max,
-        min, sum, sum of squares, 90th percentile, NMAD, RMSE, standard deviation, valid count, total count,
+        min, sum, sum of squares, 90th percentile, LE90, NMAD, RMSE, standard deviation, valid count, total count,
         percentage valid points, size.
         """
 
@@ -1918,6 +1918,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
+            "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),
             "Standard deviation": np.ma.std(data),
@@ -1955,8 +1956,8 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
                    Accepted names include:
-                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "nmad", "rmse", "std",
-                   "valid count", "total count", "percentage valid points", "size".
+                   - "mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "LE90", "nmad", "rmse",
+                    "std", "valid count", "total count", "percentage valid points", "size".
                    Custom callables can also be provided.
         :param band: The index of the band for which to compute statistics. Default is 1.
 
@@ -1981,6 +1982,7 @@ class Raster:
             "sum2": "Sum of squares",
             "90thpercentile": "90th percentile",
             "90percentile": "90th percentile",
+            "le90": "LE90",
             "nmad": "NMAD",
             "rmse": "RMSE",
             "rms": "RMSE",

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1920,6 +1920,7 @@ class Raster:
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.nanmean(np.square(data - np.nanmean(data)))),
             "Standard deviation": np.nanstd(data),
+            "Percentile valid points": (np.count_nonzero(~np.isnan(data)) / data.size) * 100,
         }
         return stats_dict
 
@@ -2004,6 +2005,8 @@ class Raster:
             "stddev": "Standard deviation",
             "standarddev": "Standard deviation",
             "standarddeviation": "Standard deviation",
+            "percentvalidpoint": "Percentile valid point",
+            "validpoint": "Percentile valid point",
         }
         if isinstance(stats_name, list):
             result = {}

--- a/geoutils/stats.py
+++ b/geoutils/stats.py
@@ -40,3 +40,29 @@ def nmad(data: NDArrayNum, nfact: float = 1.4826) -> np.floating[Any]:
     if isinstance(data, np.ma.masked_array):
         return nfact * np.ma.median(np.abs(data - np.ma.median(data)))
     return nfact * np.nanmedian(np.abs(data - np.nanmedian(data)))
+
+
+def linear_error(data: NDArrayNum, interval: float = 90) -> np.floating[Any]:
+    """
+    Compute the linear error (LE) for a given dataset, representing the range of differences between the upper and
+    lower percentiles of the data. By default, this calculates the 90% confidence interval (LE90).
+
+    :param data: A numpy array or masked array of data, typically representing the differences (errors) in elevation or
+    another quantity.
+    :param interval: The confidence interval to compute, specified as a percentage. For example, an interval of 90 will
+    compute the range between the 5th and 95th percentiles (LE90). This value must be between 0 and 100.
+
+    return: The computed linear error, which is the difference between the upper and lower percentiles.
+
+    raises: ValueError if the `interval` is not between 0 and 100.
+    """
+    # Validate the interval
+    if not (0 < interval <= 100):
+        raise ValueError("Interval must be between 0 and 100")
+
+    if isinstance(data, np.ma.masked_array):
+        mdata = np.ma.filled(data.astype(float), np.nan)
+    else:
+        mdata = data
+    le = np.nanpercentile(mdata, 50 + interval / 2) - np.nanpercentile(mdata, 50 - interval / 2)
+    return le

--- a/geoutils/stats.py
+++ b/geoutils/stats.py
@@ -38,7 +38,5 @@ def nmad(data: NDArrayNum, nfact: float = 1.4826) -> np.floating[Any]:
     :returns nmad: (normalized) median absolute deviation of data.
     """
     if isinstance(data, np.ma.masked_array):
-        data_arr = data.compressed()
-    else:
-        data_arr = np.asarray(data)
-    return nfact * np.nanmedian(np.abs(data_arr - np.nanmedian(data_arr)))
+        return nfact * np.ma.median(np.abs(data - np.ma.median(data)))
+    return nfact * np.nanmedian(np.abs(data - np.nanmedian(data)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Configuration of pytest."""
 
-from pytest import DoctestItem
+from _pytest.doctest import DoctestItem
 
 
 # To order test modules logically during execution

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1985,8 +1985,6 @@ class TestRaster:
     def test_stats(self, example: str, caplog) -> None:
         raster = gu.Raster(example)
 
-        # Full stats
-        stats = raster.get_stats()
         expected_stats = [
             "Mean",
             "Median",
@@ -2000,17 +1998,22 @@ class TestRaster:
             "Standard deviation",
             "Valid points",
             "Percentage valid points",
-            "Valid points no mask",
-            "Percentage valid points no mask",
+            "Valid points all data",
+            "Percentage valid points all data",
         ]
+
+        # Full stats
+        stats = raster.get_stats()
         for name in expected_stats:
             assert name in stats
             assert stats.get(name) is not None
 
         # Single stat
-        stat = raster.get_stats(stats_name="mean")
-        assert isinstance(stat, np.floating)
+        for name in expected_stats:
+            stat = raster.get_stats(stats_name=name)
+            assert np.isfinite(stat)
 
+        # Callable
         def percentile_95(data: NDArrayNum) -> np.floating[Any]:
             if isinstance(data, np.ma.MaskedArray):
                 data = data.compressed()

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1996,6 +1996,7 @@ class TestRaster:
             "Sum of squares",
             "90th percentile",
             "NMAD",
+            "RMSE",
             "Standard deviation",
             "Valid points",
             "Percentage valid points",

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1993,6 +1993,7 @@ class TestRaster:
             "Sum",
             "Sum of squares",
             "90th percentile",
+            "LE90",
             "NMAD",
             "RMSE",
             "Standard deviation",
@@ -2007,6 +2008,11 @@ class TestRaster:
         for name in expected_stats:
             assert name in stats
             assert stats.get(name) is not None
+
+        # With mask
+        inlier_mask = raster.get_mask()
+        stats_masked = raster.get_stats(inlier_mask=inlier_mask)
+        assert stats_masked == stats
 
         # Single stat
         for name in expected_stats:

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1997,8 +1997,10 @@ class TestRaster:
             "90th percentile",
             "NMAD",
             "Standard deviation",
-            "Count",
+            "Valid points",
             "Percentage valid points",
+            "Valid points no mask",
+            "Percentage valid points no mask",
         ]
         for name in expected_stats:
             assert name in stats

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1998,13 +1998,14 @@ class TestRaster:
             "NMAD",
             "RMSE",
             "Standard deviation",
+            "Percentile valid points",
         ]
         for name in expected_stats:
             assert name in stats
             assert stats.get(name) is not None
 
         # Single stat
-        stat = raster.get_stats(stats_name="Average")
+        stat = raster.get_stats(stats_name="average")
         assert isinstance(stat, np.floating)
 
         def percentile_95(data: NDArrayNum) -> np.floating[Any]:

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1998,8 +1998,6 @@ class TestRaster:
             "RMSE",
             "Standard deviation",
             "Valid count",
-            "Total count",
-            "Percentage valid points",
             "Size",
         ]
 
@@ -2012,6 +2010,10 @@ class TestRaster:
         # With mask
         inlier_mask = raster.get_mask()
         stats_masked = raster.get_stats(inlier_mask=inlier_mask)
+        for name in ["Total count", "Percentage valid points"]:
+            assert name in stats_masked
+            assert stats_masked.get(name) is not None
+            stats_masked.pop(name)
         assert stats_masked == stats
 
         # Single stat

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1996,7 +1996,6 @@ class TestRaster:
             "Sum of squares",
             "90th percentile",
             "NMAD",
-            "RMSE",
             "Standard deviation",
             "Percentile valid points",
         ]

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1998,7 +1998,8 @@ class TestRaster:
             "RMSE",
             "Standard deviation",
             "Valid count",
-            "Size",
+            "Total count",
+            "Percentage valid points",
         ]
 
         # Full stats
@@ -2010,7 +2011,12 @@ class TestRaster:
         # With mask
         inlier_mask = raster.get_mask()
         stats_masked = raster.get_stats(inlier_mask=inlier_mask)
-        for name in ["Total count", "Percentage valid points"]:
+        for name in [
+            "Valid inlier count",
+            "Total inlier count",
+            "Percentage inlier points",
+            "Percentage valid inlier points",
+        ]:
             assert name in stats_masked
             assert stats_masked.get(name) is not None
             stats_masked.pop(name)

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1996,10 +1996,10 @@ class TestRaster:
             "NMAD",
             "RMSE",
             "Standard deviation",
-            "Valid points",
+            "Valid count",
+            "Total count",
             "Percentage valid points",
-            "Valid points all data",
-            "Percentage valid points all data",
+            "Size",
         ]
 
         # Full stats

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1997,14 +1997,15 @@ class TestRaster:
             "90th percentile",
             "NMAD",
             "Standard deviation",
-            "Percentile valid points",
+            "Count",
+            "Percentage valid points",
         ]
         for name in expected_stats:
             assert name in stats
             assert stats.get(name) is not None
 
         # Single stat
-        stat = raster.get_stats(stats_name="average")
+        stat = raster.get_stats(stats_name="mean")
         assert isinstance(stat, np.floating)
 
         def percentile_95(data: NDArrayNum) -> np.floating[Any]:
@@ -2016,8 +2017,8 @@ class TestRaster:
         assert isinstance(stat, np.floating)
 
         # Selected stats and callable
-        stats_name = ["mean", "maximum", "std", "percentile_95"]
-        stats = raster.get_stats(stats_name=["mean", "maximum", "std", percentile_95])
+        stats_name = ["mean", "max", "std", "percentile_95"]
+        stats = raster.get_stats(stats_name=["mean", "max", "std", percentile_95])
         for name in stats_name:
             assert name in stats
             assert stats.get(name) is not None

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -2,10 +2,11 @@
 Test functions for stats
 """
 
+import numpy as np
 import scipy
 
 from geoutils import Raster, examples
-from geoutils.stats import nmad
+from geoutils.stats import linear_error, nmad
 
 
 class TestStats:
@@ -28,3 +29,36 @@ class TestStats:
         nmad_2 = nmad(self.landsat_raster.data, nfact=2)
 
         assert nmad_1 * 2 == nmad_2
+
+    def test_linear_error(self) -> None:
+        """Test linear error (LE) functionality runs on any type of input"""
+
+        # Compute LE on the landsat raster data for a default interval (LE90)
+        le_ma = linear_error(self.landsat_raster.data)
+        le_nan_array = linear_error(self.landsat_raster.get_nanarray())
+
+        # Assert the LE90 is computed the same for masked array and NaN array
+        assert le_ma == le_nan_array
+
+        # Check that the function works for different intervals
+        le90 = linear_error(self.landsat_raster.data, interval=90)
+        le50 = linear_error(self.landsat_raster.data, interval=50)
+
+        # Verify that LE50 (interquartile range) is smaller than LE90
+        assert le50 < le90
+
+        # Test a known dataset
+        test_data = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        le90_test = linear_error(test_data, interval=90)
+        le50_test = linear_error(test_data, interval=50)
+
+        assert le90_test == 9
+        assert le50_test == 5
+
+        # Test masked arrays with invalid data (should ignore NaNs/masked values)
+        masked_data = np.ma.masked_array(test_data, mask=[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+        le90_masked = linear_error(masked_data, interval=90)
+        le50_masked = linear_error(masked_data, interval=50)
+
+        assert le90_masked == 4.5
+        assert le50_masked == 2.5


### PR DESCRIPTION
Resolves GlacioHack/xdem#679.
Resolves GlacioHack/xdem#685

## Description
- Add `valid points` and `percentage valid points` statistic calculation, as the number of finite values divided by the number of values in the unmasked Raster.
- Add `valid points` and `percentage valid points` in the `dict` returned by `get_stats`, add aliases.
- Add `valid points` and `percentage valid points` in `test_stats` method in `test_raster`.
- Add `valid points no mask` and `percentage valid points no mask` to compute the same stats as above but without masking 
values.
- Add `LE90` in `stats.py` and in `Raster.get_stats`, and test it in `test_stats.py`.