### PR TITLE
Rearrangement of `raster.delayed` to prepare for tiled reprojection implementation with multiprocessing 

### DIFF
--- a/geoutils/raster/distributed_computing/__init__.py
+++ b/geoutils/raster/distributed_computing/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 GeoUtils developers
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from geoutils.raster.distributed_computing.delayed_dask import *  # noqa
+from geoutils.raster.distributed_computing.delayed_multiproc import *  # noqa
+from geoutils.raster.distributed_computing.delayed_utils import *  # noqa

--- a/geoutils/raster/distributed_computing/__init__.py
+++ b/geoutils/raster/distributed_computing/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 GeoUtils developers
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
 #
 # This file is part of the GeoUtils project:
 # https://github.com/glaciohack/geoutils

--- a/geoutils/raster/distributed_computing/delayed_dask.py
+++ b/geoutils/raster/distributed_computing/delayed_dask.py
@@ -26,7 +26,6 @@ import dask.delayed
 import numpy as np
 import rasterio as rio
 from dask.utils import cached_cumsum
-from scipy.interpolate import interpn
 
 from geoutils._typing import NDArrayBool, NDArrayNum
 from geoutils.raster.distributed_computing.delayed_utils import (
@@ -37,6 +36,11 @@ from geoutils.raster.distributed_computing.delayed_utils import (
     _get_indices_block_per_subsample,
     _get_interp_indices_per_block,
     _get_subsample_size_from_user_input,
+    _interp_points_block,
+    _nb_valids,
+    _reproject_per_block,
+    _subsample_block,
+    _subsample_indices_block,
 )
 
 # 1/ SUBSAMPLING
@@ -52,9 +56,7 @@ from geoutils.raster.distributed_computing.delayed_utils import (
 @dask.delayed  # type: ignore
 def _delayed_nb_valids(arr_chunk: NDArrayNum | NDArrayBool) -> NDArrayNum:
     """Count number of valid values per block."""
-    if arr_chunk.dtype == "bool":
-        return np.array([np.count_nonzero(arr_chunk)]).reshape((1, 1))
-    return np.array([np.count_nonzero(np.isfinite(arr_chunk))]).reshape((1, 1))
+    return _nb_valids(arr_chunk)
 
 
 @dask.delayed  # type: ignore
@@ -62,10 +64,7 @@ def _delayed_subsample_block(
     arr_chunk: NDArrayNum | NDArrayBool, subsample_indices: NDArrayNum
 ) -> NDArrayNum | NDArrayBool:
     """Subsample the valid values at the corresponding 1D valid indices per block."""
-
-    if arr_chunk.dtype == "bool":
-        return arr_chunk[arr_chunk][subsample_indices]
-    return arr_chunk[np.isfinite(arr_chunk)][subsample_indices]
+    return _subsample_block(arr_chunk, subsample_indices)
 
 
 @dask.delayed  # type: ignore
@@ -73,20 +72,7 @@ def _delayed_subsample_indices_block(
     arr_chunk: NDArrayNum | NDArrayBool, subsample_indices: NDArrayNum, block_id: dict[str, Any]
 ) -> NDArrayNum:
     """Return 2D indices from the subsampled 1D valid indices per block."""
-
-    if arr_chunk.dtype == "bool":
-        ix, iy = np.unravel_index(np.argwhere(arr_chunk.flatten())[subsample_indices], shape=arr_chunk.shape)
-    else:
-        #  Unravel indices of valid data to the shape of the block
-        ix, iy = np.unravel_index(
-            np.argwhere(np.isfinite(arr_chunk.flatten()))[subsample_indices], shape=arr_chunk.shape
-        )
-
-    # Convert to full-array indexes by adding the row and column starting indexes for this block
-    ix += block_id["xstart"]
-    iy += block_id["ystart"]
-
-    return np.hstack((ix, iy))
+    return _subsample_indices_block(arr_chunk, subsample_indices, block_id)
 
 
 def delayed_subsample(
@@ -218,21 +204,7 @@ def _delayed_interp_points_block(
     """
     Interpolate block in 2D out-of-memory for a regular or equal grid.
     """
-
-    # Extract information out of block_id dictionary
-    xs, ys, xres, yres = (block_id["xstart"], block_id["ystart"], block_id["xres"], block_id["yres"])
-
-    # Reconstruct the coordinates from xi/yi/xres/yres (as it has to be a regular grid)
-    x_coords = np.arange(xs, xs + xres * arr_chunk.shape[0], xres)
-    y_coords = np.arange(ys, ys + yres * arr_chunk.shape[1], yres)
-
-    # TODO: Use scipy.map_coordinates for an equal grid as in Raster.interp_points?
-
-    # Interpolate to points
-    interp_chunk = interpn(points=(x_coords, y_coords), values=arr_chunk, xi=(interp_coords[0, :], interp_coords[1, :]))
-
-    # And return the interpolated array
-    return interp_chunk
+    return _interp_points_block(arr_chunk, block_id, interp_coords)
 
 
 def delayed_interp_points(
@@ -333,46 +305,7 @@ def _delayed_reproject_per_block(
     """
     Delayed reprojection per destination block (also rebuilds a square array combined from intersecting source blocks).
     """
-
-    # If no source chunk intersects, we return a chunk of destination nodata values
-    if len(src_arrs) == 0:
-        # We can use float32 to return NaN, will be cast to other floating type later if that's not source array dtype
-        dst_arr = np.zeros(combined_meta["dst_shape"], dtype=np.dtype("float32"))
-        dst_arr[:] = kwargs["dst_nodata"]
-        return dst_arr
-
-    # First, we build an empty array with the combined shape, only with nodata values
-    comb_src_arr = np.ones((combined_meta["src_shape"]), dtype=src_arrs[0].dtype)
-    comb_src_arr[:] = kwargs["src_nodata"]
-
-    # Then fill it with the source chunks values
-    for i, arr in enumerate(src_arrs):
-        bid = block_ids[i]
-        comb_src_arr[bid["rys"] : bid["rye"], bid["rxs"] : bid["rxe"]] = arr
-
-    # Now, we can simply call Rasterio!
-
-    # We build the combined transform from tuple
-    src_transform = rio.transform.Affine(*combined_meta["src_transform"])
-    dst_transform = rio.transform.Affine(*combined_meta["dst_transform"])
-
-    # Reproject
-    dst_arr = np.zeros(combined_meta["dst_shape"], dtype=comb_src_arr.dtype)
-
-    _ = rio.warp.reproject(
-        comb_src_arr,
-        dst_arr,
-        src_transform=src_transform,
-        src_crs=kwargs["src_crs"],
-        dst_transform=dst_transform,
-        dst_crs=kwargs["dst_crs"],
-        resampling=kwargs["resampling"],
-        src_nodata=kwargs["src_nodata"],
-        dst_nodata=kwargs["dst_nodata"],
-        num_threads=1,  # Force the number of threads to 1 to avoid Dask/Rasterio conflicting on multi-threading
-    )
-
-    return dst_arr
+    return _reproject_per_block(*src_arrs, block_ids=block_ids, combined_meta=combined_meta, **kwargs)
 
 
 def delayed_reproject(

--- a/geoutils/raster/distributed_computing/delayed_dask.py
+++ b/geoutils/raster/distributed_computing/delayed_dask.py
@@ -19,23 +19,25 @@
 """
 Module for dask-delayed functions for out-of-memory raster operations.
 """
-
-from __future__ import annotations
-
-import warnings
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal
 
 import dask.array as da
 import dask.delayed
-import geopandas as gpd
 import numpy as np
-import pandas as pd
 import rasterio as rio
 from dask.utils import cached_cumsum
 from scipy.interpolate import interpn
 
 from geoutils._typing import NDArrayBool, NDArrayNum
-from geoutils.projtools import _get_bounds_projected, _get_footprint_projected
+from geoutils.raster.distributed_computing.delayed_utils import (
+    ChunkedGeoGrid,
+    GeoGrid,
+    _chunks2d_from_chunksizes_shape,
+    _combined_blocks_shape_transform,
+    _get_indices_block_per_subsample,
+    _get_interp_indices_per_block,
+    _get_subsample_size_from_user_input,
+)
 
 # 1/ SUBSAMPLING
 # At the date of April 2024:
@@ -45,73 +47,6 @@ from geoutils.projtools import _get_bounds_projected, _get_footprint_projected
 # output length considerations), which prevents from using high-level functions with good efficiency
 # We thus follow https://blog.dask.org/2021/07/02/ragged-output (the dask.array.map_blocks solution has a larger RAM
 # usage by having to drop an axis and re-chunk along 1D of the 2D array, so we use the dask.delayed solution instead)
-
-
-def _get_subsample_size_from_user_input(
-    subsample: int | float, total_nb_valids: int, silence_max_subsample: bool
-) -> int:
-    """Get subsample size based on a user input of either integer size or fraction of the number of valid points."""
-
-    # If value is between 0 and 1, use a fraction
-    if (subsample <= 1) & (subsample > 0):
-        npoints = int(subsample * total_nb_valids)
-    # Otherwise use the value directly
-    elif subsample > 1:
-        # Use the number of valid points if larger than subsample asked by user
-        npoints = min(int(subsample), total_nb_valids)
-        if subsample > total_nb_valids:
-            if not silence_max_subsample:
-                warnings.warn(
-                    f"Subsample value of {subsample} is larger than the number of valid pixels of {total_nb_valids},"
-                    f"using all valid pixels as a subsample.",
-                    category=UserWarning,
-                )
-    else:
-        raise ValueError("Subsample must be > 0.")
-
-    return npoints
-
-
-def _get_indices_block_per_subsample(
-    indices_1d: NDArrayNum, num_chunks: tuple[int, int], nb_valids_per_block: list[int]
-) -> list[list[int]]:
-    """
-    Get list of 1D valid subsample indices relative to the block for each block.
-
-    The 1D valid subsample indices correspond to the subsample index to apply for a flattened array of valid values.
-    Relative to the block means converted so that the block indexes for valid values starts at 0 up to the number of
-    valid values in that block (while the input indices go from zero to the total number of valid values in the full
-    array).
-
-    :param indices_1d: Subsample 1D indexes among a total number of valid values.
-    :param num_chunks: Number of chunks in X and Y.
-    :param nb_valids_per_block: Number of valid pixels per block.
-
-    :returns: Relative 1D valid subsample index per block.
-    """
-
-    # Apply a cumulative sum to get the first 1D total index of each block
-    valids_cumsum = np.cumsum(nb_valids_per_block)
-
-    # We can write a faster algorithm by sorting
-    indices_1d = np.sort(indices_1d)
-
-    # TODO: Write nested lists into array format to further save RAM?
-    # We define a list of indices per block
-    relative_index_per_block = [[] for _ in range(num_chunks[0] * num_chunks[1])]
-    k = 0  # K is the block number
-    for i in indices_1d:
-
-        # Move to the next block K where current 1D subsample index is, if not in this one
-        while i >= valids_cumsum[k]:
-            k += 1
-
-        # Add 1D subsample index  relative to first subsample index of this block
-        first_index_block = valids_cumsum[k - 1] if k >= 1 else 0  # The first 1D valid subsample index of the block
-        relative_index = i - first_index_block
-        relative_index_per_block[k].append(relative_index)
-
-    return relative_index_per_block
 
 
 @dask.delayed  # type: ignore
@@ -276,37 +211,6 @@ def delayed_subsample(
 # Code structure inspired by https://blog.dask.org/2021/07/02/ragged-output and the "block_id" in map_blocks
 
 
-def _get_interp_indices_per_block(
-    interp_x: NDArrayNum,
-    interp_y: NDArrayNum,
-    starts: list[tuple[int, ...]],
-    num_chunks: tuple[int, int],
-    chunksize: tuple[int, int],
-    xres: float,
-    yres: float,
-) -> list[list[int]]:
-    """Map blocks where each pair of interpolation coordinates will have to be computed."""
-
-    # TODO 1: Check the robustness for chunksize different and X and Y
-
-    # TODO 2: Check if computing block_i_id matricially + using an == comparison (possibly delayed) to get index
-    #  per block is not more computationally efficient?
-    #  (as it uses array instead of nested lists, and nested lists grow in RAM very fast)
-
-    # The argument "starts" contains the list of chunk first X/Y index for the full array, plus the last index
-
-    # We use one bucket per block, assuming a flattened blocks shape
-    ind_per_block = [[] for _ in range(num_chunks[0] * num_chunks[1])]
-    for i, (x, y) in enumerate(zip(interp_x, interp_y)):
-        # Because it is a regular grid, we know exactly in which block ID the coordinate will fall
-        block_i_1d = int((x - starts[0][0]) / (xres * chunksize[0])) * num_chunks[1] + int(
-            (y - starts[1][0]) / (yres * chunksize[1])
-        )
-        ind_per_block[block_i_1d].append(i)
-
-    return ind_per_block
-
-
 @dask.delayed  # type: ignore
 def _delayed_interp_points_block(
     arr_chunk: NDArrayNum, block_id: dict[str, Any], interp_coords: NDArrayNum
@@ -420,224 +324,6 @@ def delayed_interp_points(
 
 # We define a GeoGrid and GeoTiling class (which composes GeoGrid) to consistently deal with georeferenced footprints
 # of chunked grids
-GeoGridType = TypeVar("GeoGridType", bound="GeoGrid")
-
-
-class GeoGrid:
-    """
-    Georeferenced grid class.
-
-    Describes a georeferenced grid through a geotransform (one-sided bounds and resolution), shape and CRS.
-    """
-
-    def __init__(self, transform: rio.transform.Affine, shape: tuple[int, int], crs: rio.crs.CRS | None):
-
-        self._transform = transform
-        self._shape = shape
-        self._crs = crs
-
-    @property
-    def transform(self) -> rio.transform.Affine:
-        return self._transform
-
-    @property
-    def crs(self) -> rio.crs.CRS:
-        return self._crs
-
-    @property
-    def shape(self) -> tuple[int, int]:
-        return self._shape
-
-    @property
-    def height(self) -> int:
-        return self.shape[0]
-
-    @property
-    def width(self) -> int:
-        return self.shape[1]
-
-    @property
-    def res(self) -> tuple[int, int]:
-        return self.transform[0], abs(self.transform[4])
-
-    def bounds_projected(self, crs: rio.crs.CRS = None) -> rio.coords.BoundingBox:
-        if crs is None:
-            crs = self.crs
-        bounds = rio.coords.BoundingBox(*rio.transform.array_bounds(self.height, self.width, self.transform))
-        return _get_bounds_projected(bounds=bounds, in_crs=self.crs, out_crs=crs)
-
-    @property
-    def bounds(self) -> rio.coords.BoundingBox:
-        return self.bounds_projected()
-
-    def footprint_projected(self, crs: rio.crs.CRS = None) -> gpd.GeoDataFrame:
-        if crs is None:
-            crs = self.crs
-        return _get_footprint_projected(self.bounds, in_crs=self.crs, out_crs=crs, densify_points=100)
-
-    @property
-    def footprint(self) -> gpd.GeoDataFrame:
-        return self.footprint_projected()
-
-    @classmethod
-    def from_dict(cls: type[GeoGridType], dict_meta: dict[str, Any]) -> GeoGridType:
-        """Create a GeoGrid from a dictionary containing transform, shape and CRS."""
-        return cls(**dict_meta)
-
-    def translate(
-        self: GeoGridType,
-        xoff: float,
-        yoff: float,
-        distance_unit: Literal["georeferenced"] | Literal["pixel"] = "pixel",
-    ) -> GeoGridType:
-        """Translate into a new geogrid (not inplace)."""
-
-        if distance_unit not in ["georeferenced", "pixel"]:
-            raise ValueError("Argument 'distance_unit' should be either 'pixel' or 'georeferenced'.")
-
-        # Get transform
-        dx, b, xmin, d, dy, ymax = list(self.transform)[:6]
-
-        # Convert pixel offsets to georeferenced units
-        if distance_unit == "pixel":
-            # Can either multiply the offset by the resolution
-            # xoff *= self.res[0]
-            # yoff *= self.res[1]
-
-            # Or use the boundaries instead! (maybe less floating point issues? doesn't seem to matter in tests)
-            xoff = xoff / self.shape[1] * (self.bounds.right - self.bounds.left)
-            yoff = yoff / self.shape[0] * (self.bounds.top - self.bounds.bottom)
-
-        shifted_transform = rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)
-
-        return self.from_dict({"transform": shifted_transform, "crs": self.crs, "shape": self.shape})
-
-
-def _get_block_ids_per_chunk(chunks: tuple[tuple[int, ...], tuple[int, ...]]) -> list[dict[str, int]]:
-    """Get location of chunks based on array shape and list of chunk sizes."""
-
-    # Get number of chunks
-    num_chunks = (len(chunks[0]), len(chunks[1]))
-
-    # Get robust list of chunk locations (using what is done in block_id of dask.array.map_blocks)
-    # https://github.com/dask/dask/blob/24493f58660cb933855ba7629848881a6e2458c1/dask/array/core.py#L908
-    from dask.utils import cached_cumsum
-
-    starts = [cached_cumsum(c, initial_zero=True) for c in chunks]
-    nb_blocks = num_chunks[0] * num_chunks[1]
-    ixi, iyi = np.unravel_index(np.arange(nb_blocks), shape=(num_chunks[0], num_chunks[1]))
-    # Starting and ending indexes "s" and "e" for both X/Y, to place the chunk in the full array
-    block_ids = [
-        {
-            "num_block": i,
-            "ys": starts[0][ixi[i]],
-            "xs": starts[1][iyi[i]],
-            "ye": starts[0][ixi[i] + 1],
-            "xe": starts[1][iyi[i] + 1],
-        }
-        for i in range(nb_blocks)
-    ]
-
-    return block_ids
-
-
-class ChunkedGeoGrid:
-    """
-    Chunked georeferenced grid class.
-
-    Associates a georeferenced grid to chunks (possibly of varying sizes).
-    """
-
-    def __init__(self, grid: GeoGrid, chunks: tuple[tuple[int, ...], tuple[int, ...]]):
-
-        self._grid = grid
-        self._chunks = chunks
-
-    @property
-    def grid(self) -> GeoGrid:
-        return self._grid
-
-    @property
-    def chunks(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
-        return self._chunks
-
-    def get_block_locations(self) -> list[dict[str, int]]:
-        """Get block locations in 2D: xstart, xend, ystart, yend."""
-        return _get_block_ids_per_chunk(self._chunks)
-
-    def get_blocks_as_geogrids(self) -> list[GeoGrid]:
-        """Get blocks as geogrids with updated transform/shape."""
-
-        block_ids = self.get_block_locations()
-
-        list_geogrids = []
-        for bid in block_ids:
-            # We get the block size
-            block_shape = (bid["ye"] - bid["ys"], bid["xe"] - bid["xs"])
-            # Build a temporary geogrid with the same transform as the full grid, but with the chunk shape
-            geogrid_tmp = GeoGrid(transform=self.grid.transform, crs=self.grid.crs, shape=block_shape)
-            # And shift it to the right location (X is positive in index direction, Y is negative)
-            geogrid_block = geogrid_tmp.translate(xoff=bid["xs"], yoff=-bid["ys"])
-            list_geogrids.append(geogrid_block)
-
-        return list_geogrids
-
-    def get_block_footprints(self, crs: rio.crs.CRS = None) -> gpd.GeoDataFrame:
-        """Get block projected footprints as a single geodataframe."""
-
-        geogrids = self.get_blocks_as_geogrids()
-        footprints = [gg.footprint_projected(crs=crs) if crs is not None else gg.footprint for gg in geogrids]
-
-        return pd.concat(footprints)
-
-
-def _chunks2d_from_chunksizes_shape(
-    chunksizes: tuple[int, int], shape: tuple[int, int]
-) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Get tuples of chunk sizes for X/Y dimensions based on chunksizes and array shape."""
-
-    # Chunksize is fixed, except for the last chunk depending on the shape
-    chunks_y = tuple(
-        min(
-            chunksizes[0],
-            shape[0] - i * chunksizes[0],
-        )
-        for i in range(int(np.ceil(shape[0] / chunksizes[0])))
-    )
-    chunks_x = tuple(
-        min(
-            chunksizes[1],
-            shape[1] - i * chunksizes[1],
-        )
-        for i in range(int(np.ceil(shape[1] / chunksizes[1])))
-    )
-
-    return chunks_y, chunks_x
-
-
-def _combined_blocks_shape_transform(
-    sub_block_ids: list[dict[str, int]], src_geogrid: GeoGrid
-) -> tuple[dict[str, Any], list[dict[str, int]]]:
-    """Derive combined shape and transform from a subset of several blocks (for source input during reprojection)."""
-
-    # Get combined shape by taking min of X/Y starting indices, max of X/Y ending indices
-    all_xs, all_ys, all_xe, all_ye = ([b[s] for b in sub_block_ids] for s in ["xs", "ys", "xe", "ye"])
-    minmaxs = {"min_xs": np.min(all_xs), "max_xe": np.max(all_xe), "min_ys": np.min(all_ys), "max_ye": np.max(all_ye)}
-    combined_shape = (minmaxs["max_ye"] - minmaxs["min_ys"], minmaxs["max_xe"] - minmaxs["min_xs"])
-
-    # Shift source transform with start indexes to get the one for combined block location
-    combined_transform = src_geogrid.translate(xoff=minmaxs["min_xs"], yoff=-minmaxs["min_ys"]).transform
-
-    # Compute relative block indexes that will be needed to reconstruct a square array in the delayed function,
-    # by subtracting the minimum starting indices in X/Y
-    relative_block_indexes = [
-        {"r" + s1 + s2: b[s1 + s2] - minmaxs["min_" + s1 + "s"] for s1 in ["x", "y"] for s2 in ["s", "e"]}
-        for b in sub_block_ids
-    ]
-
-    combined_meta = {"src_shape": combined_shape, "src_transform": tuple(combined_transform)}
-
-    return combined_meta, relative_block_indexes
 
 
 @dask.delayed  # type: ignore

--- a/geoutils/raster/distributed_computing/delayed_multiproc.py
+++ b/geoutils/raster/distributed_computing/delayed_multiproc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 GeoUtils developers
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
 #
 # This file is part of the GeoUtils project:
 # https://github.com/glaciohack/geoutils

--- a/geoutils/raster/distributed_computing/delayed_multiproc.py
+++ b/geoutils/raster/distributed_computing/delayed_multiproc.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 GeoUtils developers
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for multiprocessing-delayed functions for out-of-memory raster operations.
+"""

--- a/geoutils/raster/distributed_computing/delayed_utils.py
+++ b/geoutils/raster/distributed_computing/delayed_utils.py
@@ -1,0 +1,358 @@
+# Copyright (c) 2025 GeoUtils developers
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Common module with functions for managing chunks, indices, and grid-based operations for raster data.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Literal, TypeVar
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import rasterio as rio
+
+from geoutils._typing import NDArrayNum
+from geoutils.projtools import _get_bounds_projected, _get_footprint_projected
+
+# 1/ SUBSAMPLING
+
+
+def _get_subsample_size_from_user_input(
+    subsample: int | float, total_nb_valids: int, silence_max_subsample: bool
+) -> int:
+    """Get subsample size based on a user input of either integer size or fraction of the number of valid points."""
+
+    # If value is between 0 and 1, use a fraction
+    if (subsample <= 1) & (subsample > 0):
+        npoints = int(subsample * total_nb_valids)
+    # Otherwise use the value directly
+    elif subsample > 1:
+        # Use the number of valid points if larger than subsample asked by user
+        npoints = min(int(subsample), total_nb_valids)
+        if subsample > total_nb_valids:
+            if not silence_max_subsample:
+                warnings.warn(
+                    f"Subsample value of {subsample} is larger than the number of valid pixels of {total_nb_valids},"
+                    f"using all valid pixels as a subsample.",
+                    category=UserWarning,
+                )
+    else:
+        raise ValueError("Subsample must be > 0.")
+
+    return npoints
+
+
+def _get_indices_block_per_subsample(
+    indices_1d: NDArrayNum, num_chunks: tuple[int, int], nb_valids_per_block: list[int]
+) -> list[list[int]]:
+    """
+    Get list of 1D valid subsample indices relative to the block for each block.
+
+    The 1D valid subsample indices correspond to the subsample index to apply for a flattened array of valid values.
+    Relative to the block means converted so that the block indexes for valid values starts at 0 up to the number of
+    valid values in that block (while the input indices go from zero to the total number of valid values in the full
+    array).
+
+    :param indices_1d: Subsample 1D indexes among a total number of valid values.
+    :param num_chunks: Number of chunks in X and Y.
+    :param nb_valids_per_block: Number of valid pixels per block.
+
+    :returns: Relative 1D valid subsample index per block.
+    """
+
+    # Apply a cumulative sum to get the first 1D total index of each block
+    valids_cumsum = np.cumsum(nb_valids_per_block)
+
+    # We can write a faster algorithm by sorting
+    indices_1d = np.sort(indices_1d)
+
+    # TODO: Write nested lists into array format to further save RAM?
+    # We define a list of indices per block
+    relative_index_per_block = [[] for _ in range(num_chunks[0] * num_chunks[1])]
+    k = 0  # K is the block number
+    for i in indices_1d:
+
+        # Move to the next block K where current 1D subsample index is, if not in this one
+        while i >= valids_cumsum[k]:
+            k += 1
+
+        # Add 1D subsample index  relative to first subsample index of this block
+        first_index_block = valids_cumsum[k - 1] if k >= 1 else 0  # The first 1D valid subsample index of the block
+        relative_index = i - first_index_block
+        relative_index_per_block[k].append(relative_index)
+
+    return relative_index_per_block
+
+
+# 2/ POINT INTERPOLATION ON REGULAR OR EQUAL GRID
+
+
+def _get_interp_indices_per_block(
+    interp_x: NDArrayNum,
+    interp_y: NDArrayNum,
+    starts: list[tuple[int, ...]],
+    num_chunks: tuple[int, int],
+    chunksize: tuple[int, int],
+    xres: float,
+    yres: float,
+) -> list[list[int]]:
+    """Map blocks where each pair of interpolation coordinates will have to be computed."""
+
+    # TODO 1: Check the robustness for chunksize different and X and Y
+
+    # TODO 2: Check if computing block_i_id matricially + using an == comparison (possibly delayed) to get index
+    #  per block is not more computationally efficient?
+    #  (as it uses array instead of nested lists, and nested lists grow in RAM very fast)
+
+    # The argument "starts" contains the list of chunk first X/Y index for the full array, plus the last index
+
+    # We use one bucket per block, assuming a flattened blocks shape
+    ind_per_block = [[] for _ in range(num_chunks[0] * num_chunks[1])]
+    for i, (x, y) in enumerate(zip(interp_x, interp_y)):
+        # Because it is a regular grid, we know exactly in which block ID the coordinate will fall
+        block_i_1d = int((x - starts[0][0]) / (xres * chunksize[0])) * num_chunks[1] + int(
+            (y - starts[1][0]) / (yres * chunksize[1])
+        )
+        ind_per_block[block_i_1d].append(i)
+
+    return ind_per_block
+
+
+# 3/ REPROJECT
+# The following GeoGrid and GeoTiling classes assist in managing georeferenced grids and performing reprojection
+GeoGridType = TypeVar("GeoGridType", bound="GeoGrid")
+
+
+class GeoGrid:
+    """
+    Georeferenced grid class.
+
+    Describes a georeferenced grid through a geotransform (one-sided bounds and resolution), shape and CRS.
+    """
+
+    def __init__(self, transform: rio.transform.Affine, shape: tuple[int, int], crs: rio.crs.CRS | None):
+
+        self._transform = transform
+        self._shape = shape
+        self._crs = crs
+
+    @property
+    def transform(self) -> rio.transform.Affine:
+        return self._transform
+
+    @property
+    def crs(self) -> rio.crs.CRS:
+        return self._crs
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self._shape
+
+    @property
+    def height(self) -> int:
+        return self.shape[0]
+
+    @property
+    def width(self) -> int:
+        return self.shape[1]
+
+    @property
+    def res(self) -> tuple[int, int]:
+        return self.transform[0], abs(self.transform[4])
+
+    def bounds_projected(self, crs: rio.crs.CRS = None) -> rio.coords.BoundingBox:
+        if crs is None:
+            crs = self.crs
+        bounds = rio.coords.BoundingBox(*rio.transform.array_bounds(self.height, self.width, self.transform))
+        return _get_bounds_projected(bounds=bounds, in_crs=self.crs, out_crs=crs)
+
+    @property
+    def bounds(self) -> rio.coords.BoundingBox:
+        return self.bounds_projected()
+
+    def footprint_projected(self, crs: rio.crs.CRS = None) -> gpd.GeoDataFrame:
+        if crs is None:
+            crs = self.crs
+        return _get_footprint_projected(self.bounds, in_crs=self.crs, out_crs=crs, densify_points=100)
+
+    @property
+    def footprint(self) -> gpd.GeoDataFrame:
+        return self.footprint_projected()
+
+    @classmethod
+    def from_dict(cls: type[GeoGridType], dict_meta: dict[str, Any]) -> GeoGridType:
+        """Create a GeoGrid from a dictionary containing transform, shape and CRS."""
+        return cls(**dict_meta)
+
+    def translate(
+        self: GeoGridType,
+        xoff: float,
+        yoff: float,
+        distance_unit: Literal["georeferenced"] | Literal["pixel"] = "pixel",
+    ) -> GeoGridType:
+        """Translate into a new geogrid (not inplace)."""
+
+        if distance_unit not in ["georeferenced", "pixel"]:
+            raise ValueError("Argument 'distance_unit' should be either 'pixel' or 'georeferenced'.")
+
+        # Get transform
+        dx, b, xmin, d, dy, ymax = list(self.transform)[:6]
+
+        # Convert pixel offsets to georeferenced units
+        if distance_unit == "pixel":
+            # Can either multiply the offset by the resolution
+            # xoff *= self.res[0]
+            # yoff *= self.res[1]
+
+            # Or use the boundaries instead! (maybe less floating point issues? doesn't seem to matter in tests)
+            xoff = xoff / self.shape[1] * (self.bounds.right - self.bounds.left)
+            yoff = yoff / self.shape[0] * (self.bounds.top - self.bounds.bottom)
+
+        shifted_transform = rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)
+
+        return self.from_dict({"transform": shifted_transform, "crs": self.crs, "shape": self.shape})
+
+
+class ChunkedGeoGrid:
+    """
+    Chunked georeferenced grid class.
+
+    Associates a georeferenced grid to chunks (possibly of varying sizes).
+    """
+
+    def __init__(self, grid: GeoGrid, chunks: tuple[tuple[int, ...], tuple[int, ...]]):
+
+        self._grid = grid
+        self._chunks = chunks
+
+    @property
+    def grid(self) -> GeoGrid:
+        return self._grid
+
+    @property
+    def chunks(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return self._chunks
+
+    def get_block_locations(self) -> list[dict[str, int]]:
+        """Get block locations in 2D: xstart, xend, ystart, yend."""
+        return _get_block_ids_per_chunk(self._chunks)
+
+    def get_blocks_as_geogrids(self) -> list[GeoGrid]:
+        """Get blocks as geogrids with updated transform/shape."""
+
+        block_ids = self.get_block_locations()
+
+        list_geogrids = []
+        for bid in block_ids:
+            # We get the block size
+            block_shape = (bid["ye"] - bid["ys"], bid["xe"] - bid["xs"])
+            # Build a temporary geogrid with the same transform as the full grid, but with the chunk shape
+            geogrid_tmp = GeoGrid(transform=self.grid.transform, crs=self.grid.crs, shape=block_shape)
+            # And shift it to the right location (X is positive in index direction, Y is negative)
+            geogrid_block = geogrid_tmp.translate(xoff=bid["xs"], yoff=-bid["ys"])
+            list_geogrids.append(geogrid_block)
+
+        return list_geogrids
+
+    def get_block_footprints(self, crs: rio.crs.CRS = None) -> gpd.GeoDataFrame:
+        """Get block projected footprints as a single geodataframe."""
+
+        geogrids = self.get_blocks_as_geogrids()
+        footprints = [gg.footprint_projected(crs=crs) if crs is not None else gg.footprint for gg in geogrids]
+
+        return pd.concat(footprints)
+
+
+def _get_block_ids_per_chunk(chunks: tuple[tuple[int, ...], tuple[int, ...]]) -> list[dict[str, int]]:
+    """Get location of chunks based on array shape and list of chunk sizes."""
+
+    # Get number of chunks
+    num_chunks = (len(chunks[0]), len(chunks[1]))
+
+    # Calculate the cumulative sum of the chunk sizes to determine block start/end indices
+    starts = [np.cumsum([0] + list(c)) for c in chunks]  # Add initial zero for the start
+
+    nb_blocks = num_chunks[0] * num_chunks[1]
+    ixi, iyi = np.unravel_index(np.arange(nb_blocks), shape=(num_chunks[0], num_chunks[1]))
+
+    # Starting and ending indexes "s" and "e" for both X/Y, to place the chunk in the full array
+    block_ids = [
+        {
+            "num_block": i,
+            "ys": starts[0][ixi[i]],
+            "xs": starts[1][iyi[i]],
+            "ye": starts[0][ixi[i] + 1],
+            "xe": starts[1][iyi[i] + 1],
+        }
+        for i in range(nb_blocks)
+    ]
+
+    return block_ids
+
+
+def _chunks2d_from_chunksizes_shape(
+    chunksizes: tuple[int, int], shape: tuple[int, int]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Get tuples of chunk sizes for X/Y dimensions based on chunksizes and array shape."""
+
+    # Chunksize is fixed, except for the last chunk depending on the shape
+    chunks_y = tuple(
+        min(
+            chunksizes[0],
+            shape[0] - i * chunksizes[0],
+        )
+        for i in range(int(np.ceil(shape[0] / chunksizes[0])))
+    )
+    chunks_x = tuple(
+        min(
+            chunksizes[1],
+            shape[1] - i * chunksizes[1],
+        )
+        for i in range(int(np.ceil(shape[1] / chunksizes[1])))
+    )
+
+    return chunks_y, chunks_x
+
+
+def _combined_blocks_shape_transform(
+    sub_block_ids: list[dict[str, int]], src_geogrid: GeoGrid
+) -> tuple[dict[str, Any], list[dict[str, int]]]:
+    """Derive combined shape and transform from a subset of several blocks (for source input during reprojection)."""
+
+    # Get combined shape by taking min of X/Y starting indices, max of X/Y ending indices
+    all_xs, all_ys, all_xe, all_ye = ([b[s] for b in sub_block_ids] for s in ["xs", "ys", "xe", "ye"])
+    minmaxs = {"min_xs": np.min(all_xs), "max_xe": np.max(all_xe), "min_ys": np.min(all_ys), "max_ye": np.max(all_ye)}
+    combined_shape = (minmaxs["max_ye"] - minmaxs["min_ys"], minmaxs["max_xe"] - minmaxs["min_xs"])
+
+    # Shift source transform with start indexes to get the one for combined block location
+    combined_transform = src_geogrid.translate(xoff=minmaxs["min_xs"], yoff=-minmaxs["min_ys"]).transform
+
+    # Compute relative block indexes that will be needed to reconstruct a square array in the delayed function,
+    # by subtracting the minimum starting indices in X/Y
+    relative_block_indexes = [
+        {"r" + s1 + s2: b[s1 + s2] - minmaxs["min_" + s1 + "s"] for s1 in ["x", "y"] for s2 in ["s", "e"]}
+        for b in sub_block_ids
+    ]
+
+    combined_meta = {"src_shape": combined_shape, "src_transform": tuple(combined_transform)}
+
+    return combined_meta, relative_block_indexes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Configuration of pytest."""
 
-from pytest import DoctestItem
+from _pytest.doctest import DoctestItem
 
 
 # To order test modules logically during execution
@@ -20,8 +20,8 @@ def pytest_collection_modifyitems(items):  # type: ignore
     module_names = list(module_mapping.values())
     module_items = list(module_mapping.keys())
 
-    module_items_reordered = [it for k, it in enumerate(module_items) if module_names[k] != "test_delayed"] + [
-        it for k, it in enumerate(module_items) if module_names[k] == "test_delayed"
+    module_items_reordered = [it for k, it in enumerate(module_items) if module_names[k] != "test_delayed_dask"] + [
+        it for k, it in enumerate(module_items) if module_names[k] == "test_delayed_dask"
     ]
 
     # And write back items in that order, with doctests first

--- a/tests/test_raster/test_distributing_computing/test_delayed_dask.py
+++ b/tests/test_raster/test_distributing_computing/test_delayed_dask.py
@@ -19,7 +19,7 @@ from pluggy import PluggyTeardownRaisedWarning
 from pyproj import CRS
 
 from geoutils.examples import _EXAMPLES_DIRECTORY
-from geoutils.raster.delayed import (
+from geoutils.raster.distributed_computing.delayed_dask import (
     delayed_interp_points,
     delayed_reproject,
     delayed_subsample,
@@ -234,9 +234,9 @@ def _build_dst_transform_shifted_newres(
     return dst_transform
 
 
-class TestDelayed:
+class TestDelayedDask:
     """
-    Testing class for delayed functions.
+    Testing class for delayed-dask functions.
 
     We test on a first set of rasters big enough to clearly monitor the memory usage, and a second set small enough
     to run fast to check a wide range of input parameters.


### PR DESCRIPTION
Resolves #647.

## Context
The aim of this ticket is to separate the functions in `raster.delayed` that use dask from those that do not. The functions that do not use `dask` will form a common basis for tiled reprojection with both `dask` and `multiprocessing`, which will be introduced in a future ticket (#648) .

## Changes
- Creation of new repertory `raster.distributed_computing` to organize the new delayed structure of `raster`.
- Creation of new file `raster.distributed_computing.delayed_multiproc` to prepare the next implementations.
- Function from `raster.delayed` that do not use dask have been moved to `raster.distributed_computing.delayed_utils`.
- Function from `raster.delayed` that use dask have been moved to `raster.distributed_computing.delayed_dask`.
- In `_get_block_ids_per_chunk`, `cached_cumsum` has been replaced by `np.cumsum` to avoid using dask, and then keep the function common for both `dask` and `multiprocessing`.

## Tests
- The test structure of  `test_raster.delayed` has been updated in compliance with the new `raster.distributed_computing` directory.