### PR TITLE
Cluster Classes and Testing Implementation

### DIFF
--- a/geoutils/raster/distributed_computing/cluster.py
+++ b/geoutils/raster/distributed_computing/cluster.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module defines the cluster configurations."""
+
+import multiprocessing
+from multiprocessing.pool import Pool
+from typing import Any, Callable, Dict, List, Optional
+
+
+class ClusterGenerator:
+    def __new__(cls, name: str, nb_workers: int = 2) -> "AbstractCluster":  # type: ignore
+        """
+        Factory method to create different types of clusters based on the name argument.
+        - If 'basic' is provided, a BasicCluster is instantiated.
+        - Otherwise, an MpCluster (multiprocessing) is created with the given number of workers.
+        """
+        if name == "basic":
+            cluster: AbstractCluster = BasicCluster()
+        else:
+            cluster = MpCluster(conf={"nb_workers": nb_workers})
+        return cluster
+
+
+class AbstractCluster:
+    def __init__(self) -> None:
+        """
+        Base class for clusters. Initializes the pool attribute.
+        Meant to be subclassed and extended.
+        """
+        self.pool: Optional[Pool] = None
+
+    def __enter__(self) -> "AbstractCluster":
+        """Context manager entry point, returning the cluster instance."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit point, ensures the cluster is properly closed."""
+        self.close()
+
+    def close(self) -> None:
+        """Method to clean up resources. To be implemented by subclasses."""
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Method to launch a task. This should be implemented by subclasses.
+        :param fun: The function to run.
+        :param args: Positional arguments for the function.
+        :param kwargs: Keyword arguments for the function.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def get_res(self, future: Any) -> Any:
+        """
+        Retrieve the result from a launched task. Meant to be subclassed.
+        :param future: The future object representing the result of an asynchronous task.
+        """
+        return future
+
+    def return_wrapper(self) -> None:
+        """Wrapper for returned values, should be customized in subclasses if needed."""
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def tile_retriever(self, res: Any) -> None:
+        """Method to retrieve and process tiles, specific to subclasses."""
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+
+class BasicCluster(AbstractCluster):
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Launches a task synchronously in a basic cluster (no multiprocessing).
+        """
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+        return fun(*args, **kwargs)
+
+
+class MpCluster(AbstractCluster):
+    def __init__(self, conf: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Initializes a multiprocessing cluster.
+        :param conf: Configuration dictionary, which may contain the number of workers.
+        """
+        super().__init__()
+        nb_workers = 1
+        if conf is not None:
+            nb_workers = conf.get("nb_workers", 1)
+        # Using the 'forkserver' context for more controlled process handling
+        ctx_in_main = multiprocessing.get_context("forkserver")
+        # Create a pool of workers with max 10 tasks per child process
+        self.pool = ctx_in_main.Pool(processes=nb_workers, maxtasksperchild=10)
+
+    def close(self) -> None:
+        """Closes the multiprocessing pool by terminating and joining workers."""
+        if self.pool is not None:
+            self.pool.terminate()
+            self.pool.join()
+
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Launches a task asynchronously in the multiprocessing pool.
+        :param fun: The function to execute in parallel.
+        :param args: The positional arguments for the function.
+        :param kwargs: The keyword arguments for the function.
+
+        :return: an asynchronous result (future object).
+        """
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+        if self.pool is not None:
+            return self.pool.apply_async(fun, args=args, kwds=kwargs)
+
+    def get_res(self, future: Any) -> Any:
+        """
+        Retrieves the result of a completed asynchronous task.
+        """
+        return future.get(timeout=5000)

--- a/tests/test_raster/test_distributing_computing/test_cluster.py
+++ b/tests/test_raster/test_distributing_computing/test_cluster.py
@@ -1,0 +1,62 @@
+""" Functions to test the clusters."""
+
+import time
+
+import pytest
+
+from geoutils.raster.distributed_computing.cluster import (
+    BasicCluster,
+    ClusterGenerator,
+    MpCluster,
+)
+
+
+# Sample function for testing
+def sample_function(x: float, y: float) -> float:
+    return x + y
+
+
+# Function to simulate a long-running task
+def long_running_task(x: float) -> float:
+    time.sleep(1)
+    return x * 2
+
+
+class TestClusterGenerator:
+    def test_basic_cluster(self) -> None:
+        # Test that tasks are run synchronously in BasicCluster
+        cluster = ClusterGenerator(name="basic")
+        assert isinstance(cluster, BasicCluster)
+
+        result = cluster.launch_task(sample_function, args=[2, 3])
+        assert result == 5
+
+    def test_mp_cluster_task(self) -> None:
+        # Test that tasks are launched asynchronously in MpCluster
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        future = cluster.launch_task(sample_function, args=[2, 3])
+        result = cluster.get_res(future)
+        assert result == 5
+
+    def test_mp_cluster_parallelism(self) -> None:
+        # Test that multiple tasks are run in parallel
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        futures = [cluster.launch_task(long_running_task, args=[i]) for i in range(4)]
+        results = [cluster.get_res(f) for f in futures]
+        assert results == [0, 2, 4, 6]
+
+    def test_mp_cluster_termination(self) -> None:
+        # Test that the pool terminates correctly after closing
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        # Close the cluster
+        cluster.close()
+
+        # Expect an error when trying to launch a task after closing
+        with pytest.raises(ValueError):
+            cluster.launch_task(sample_function, args=[2, 3])


### PR DESCRIPTION
Resolves GlacioHack/xdem#681.

## Overview
This PR introduces a set of classes designed to handle the execution of tasks in either a basic or a multi-processing cluster. It also includes a series of tests that verify the correct behavior of the cluster functionalities.

## Key changes
- `ClusterGenerator`: A factory class that decides which type of cluster to create based on the given configuration (`basic` or `multiprocessing`). It can initialize a `BasicCluster` or `MpCluster` with a specified number of worker processes.
- `AbstractCluster`: The base class for both `BasicCluster` and `MpCluster`. It defines methods to launch tasks, retrieve results, and manage resources such as opening and closing the cluster.
- `BasicCluster`: A subclass of `AbstractCluster` where tasks are run synchronously (i.e., in a single process). The launch_task method simply executes the provided function immediately.
- `MpCluster`: A subclass of `AbstractCluster` that utilizes Python’s `multiprocessing` module for parallel task execution. The cluster pool is initialized with a defined number of worker processes, and tasks are executed asynchronously using `apply_async`. The results of tasks can be retrieved via the `get_res` method.

## Test Suite
`TestClusterGenerator`: A test suite implemented with `pytest` to validate the functionality of the cluster system.
- `test_basic_cluster`: Verifies that tasks are executed synchronously in the `BasicCluster`.
- `test_mp_cluster_task`: Confirms that tasks are launched asynchronously in the `MpCluster`.
- `test_mp_cluster_parallelism`: Tests that multiple tasks can be executed concurrently with multiple workers in `MpCluster`.
- `test_mp_cluster_termination`: Ensures that the cluster terminates correctly and no tasks can be launched after termination.