### PR TITLE
Optimizing `raster.icrop`

### DIFF
--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -256,7 +256,7 @@ See {ref}`core-match-ref` for more details.
 
 The {func}`~geoutils.Raster.crop` function can also be passed a {class}`list` or {class}`tuple` of bounds (`xmin`, `ymin`, `xmax`, `ymax`). By default,
 {func}`~geoutils.Raster.crop` returns a new Raster.
-The {func}`~geoutils.Raster.icrop` function accepts only a bounding box in pixel coordinates (xmin, ymin, xmax, ymax) and crop the raster accordingly.
+The {func}`~geoutils.Raster.icrop` function accepts only a bounding box in pixel coordinates (colmin, rowmin, colmax, rowmax) and crop the raster accordingly.
 By default, {func}`~geoutils.Raster.crop` and {func}`~geoutils.Raster.icrop` return a new Raster unless the inplace parameter is set to True, in which case the cropping operation is performed directly on the original raster object.
 For more details, see the {ref}`specific section and function descriptions in the API<api-geo-handle>`.
 

--- a/geoutils/raster/georeferencing.py
+++ b/geoutils/raster/georeferencing.py
@@ -173,7 +173,7 @@ def _outside_image(
     """See description of Raster.outside_image."""
 
     if not index:
-        xi, xj = _xy2ij(xi, yj, transform=transform, area_or_point=area_or_point)
+        xi, yj = _xy2ij(xi, yj, transform=transform, area_or_point=area_or_point)
 
     if np.any(np.array((xi, yj)) < 0):
         return True

--- a/geoutils/raster/geotransformations.py
+++ b/geoutils/raster/geotransformations.py
@@ -556,6 +556,6 @@ def _translate(
     # Convert pixel offsets to georeferenced units
     if distance_unit == "pixel":
         xoff *= dx
-        yoff *= abs(dy)  # dy is negative
+        yoff *= dy
 
     return rio.transform.Affine(dx, b, xmin + xoff, d, dy, ymax + yoff)

--- a/geoutils/raster/geotransformations.py
+++ b/geoutils/raster/geotransformations.py
@@ -445,13 +445,12 @@ def _crop(
     source_raster: gu.Raster,
     bbox: gu.Raster | gu.Vector | list[float] | tuple[float, ...],
     mode: Literal["match_pixel"] | Literal["match_extent"] = "match_pixel",
+    distance_unit: Literal["georeferenced", "pixel"] = "georeferenced",
 ) -> tuple[MArrayNum, affine.Affine]:
     """Crop raster. See details in Raster.crop()."""
 
-    assert mode in [
-        "match_extent",
-        "match_pixel",
-    ], "mode must be one of 'match_pixel', 'match_extent'"
+    assert mode in ["match_extent", "match_pixel"], "mode must be one of 'match_pixel', 'match_extent'"
+    assert distance_unit in ["georeferenced", "pixel"], "distance_unit must be 'georeferenced' or 'pixel'"
 
     if isinstance(bbox, (gu.Raster, gu.Vector)):
         # For another Vector or Raster, we reproject the bounding box in the same CRS as self
@@ -460,7 +459,12 @@ def _crop(
             # Raise a warning if the reference is a raster that has a different pixel interpretation
             _cast_pixel_interpretation(source_raster.area_or_point, bbox.area_or_point)
     elif isinstance(bbox, (list, tuple)):
-        xmin, ymin, xmax, ymax = bbox
+        if distance_unit == "georeferenced":
+            xmin, ymin, xmax, ymax = bbox
+        else:
+            colmin, rowmin, colmax, rowmax = bbox
+            xmin, ymax = rio.transform.xy(source_raster.transform, rowmin, colmin, offset="ul")
+            xmax, ymin = rio.transform.xy(source_raster.transform, rowmax, colmax, offset="ul")
     else:
         raise ValueError("cropGeom must be a Raster, Vector, or list of coordinates.")
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -729,17 +729,16 @@ class Raster:
             and isinstance(new_area_or_point, str)
             and old_area_or_point != new_area_or_point
         ):
-            # The shift below represents +0.5/+0.5 or opposite in indexes (as done in xy2ij), but because
-            # the Y axis is inverted, a minus signs is added to shift the coordinate (even if the unit is in pixel)
+            # The shift below represents +0.5/+0.5 or opposite in indexes (as done in xy2ij)
 
             # If the new one is Point, we shift back by half a pixel
             if new_area_or_point == "Point":
                 xoff = 0.5
-                yoff = -0.5
+                yoff = 0.5
             # Otherwise we shift forward half a pixel
             else:
                 xoff = -0.5
-                yoff = 0.5
+                yoff = -0.5
             # We perform the shift in place
             self.translate(xoff=xoff, yoff=yoff, distance_unit="pixel", inplace=True)
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -219,12 +219,8 @@ def _load_rio(
     * window : to load a cropped version
     * resampling : to set the resampling algorithm
     """
-    # If window is passed, no need to account for transform and shape
-    if kwargs.get("window") is not None:
-        window = kwargs.get("window")
-        kwargs.pop("window")
     # If out_shape is passed, no need to account for transform and shape
-    elif kwargs.get("out_shape") is not None:
+    if kwargs.get("out_shape") is not None:
         window = None
         # If multi-band raster, the out_shape needs to contain the count
         if out_count is not None and out_count > 1:
@@ -2513,52 +2509,20 @@ class Raster:
         """
         Crop raster based on pixel indices (bbox), converting them into georeferenced coordinates.
 
-        :param bbox: Bounding box based on indices of the raster array (xmin, ymin, xmax, ymax).
+        :param bbox: Bounding box based on indices of the raster array (colmin, rowmin, colmax, rowax).
         :param inplace: If True, modify the raster in place. Otherwise, return a new cropped raster.
 
         :returns: Cropped raster or None (if inplace=True).
         """
-        # Ensure bbox contains four elements (xmin, ymin, xmax, ymax)
-        if len(bbox) != 4:
-            raise ValueError("bbox must be a list or tuple of four integers: (xmin, ymin, xmax, ymax).")
-
-        # Ensure bounds are consistent with the raster
-        if bbox[0] > self.height or bbox[1] > self.width:
-            raise ValueError("The bounding box is out of raster bounds")
-        if bbox[0] > bbox[2] or bbox[1] > bbox[3]:
-            raise ValueError("The order of values in the bbox is wrong, it should be (xmin, ymin, xmax, ymax)")
+        crop_img, tfm = _crop(source_raster=self, bbox=bbox, distance_unit="pixel")
 
         if inplace:
-            newraster = self
+            self._data = crop_img
+            self.transform = tfm
+            return None
         else:
-            # Create new raster if not inplace without loading it (Raster.copy load data)
-            newraster = Raster(self)  # type: ignore
-
-        # Retrieve window parameters
-        row_off = max(bbox[0], 0)
-        col_off = max(bbox[1], 0)
-        height = min(newraster.height, bbox[2]) - row_off
-        width = min(newraster.width, bbox[3]) - col_off
-        newraster._out_shape = (height, width)
-
-        # Translate the transform to match with the crop window
-        newraster.translate(xoff=col_off, yoff=row_off, distance_unit="pixel", inplace=True)
-
-        if newraster.is_loaded:
-            # If raster is already loaded, just reduce the data to the window
-            newraster._data = newraster.data[..., row_off : height + row_off, col_off : width + col_off]
-        else:
-            # If raster is not loaded, use _load_rio with the crop window
-            with rio.open(newraster.filename) as dataset:
-                newraster.data = _load_rio(
-                    dataset,
-                    masked=newraster._masked,
-                    window=rio.windows.Window(col_off, row_off, width, height),
-                )
-
-        if not inplace:
+            newraster = self.from_array(crop_img, tfm, self.crs, self.nodata, self.area_or_point)
             return newraster
-        return None
 
     @overload
     def reproject(

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2491,7 +2491,7 @@ class Raster:
         bbox: list[int] | tuple[int, ...],
         *,
         inplace: Literal[True],
-    ) -> RasterType: ...
+    ) -> None: ...
 
     @overload
     def icrop(
@@ -2499,7 +2499,7 @@ class Raster:
         bbox: list[int] | tuple[int, ...],
         *,
         inplace: Literal[False] = False,
-    ) -> None: ...
+    ) -> RasterType: ...
 
     def icrop(
         self: RasterType,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2485,6 +2485,22 @@ class Raster:
             newraster = self.from_array(crop_img, tfm, self.crs, self.nodata, self.area_or_point)
             return newraster
 
+    @overload
+    def icrop(
+        self: RasterType,
+        bbox: list[int] | tuple[int, ...],
+        *,
+        inplace: Literal[True],
+    ) -> RasterType: ...
+
+    @overload
+    def icrop(
+        self: RasterType,
+        bbox: list[int] | tuple[int, ...],
+        *,
+        inplace: Literal[False] = False,
+    ) -> None: ...
+
     def icrop(
         self: RasterType,
         bbox: list[int] | tuple[int, ...],

--- a/tests/test_raster/test_geotransformations.py
+++ b/tests/test_raster/test_geotransformations.py
@@ -703,12 +703,22 @@ class TestMaskGeotransformations:
         assert np.array_equal(mask.data[:, rand_int:].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:, rand_int:].mask, mask_cropped.data.mask)
 
+        #  With icrop
+        bbox2_pixel = [rand_int, 0, mask.width, mask.height]
+        mask_cropped_pix = mask.icrop(bbox2_pixel)
+        assert mask_cropped.raster_equal(mask_cropped_pix)
+
         # Right
         bbox2 = [bbox[0], bbox[1], bbox[2] - rand_int * mask.res[0], bbox[3]]
         mask_cropped = mask.crop(bbox2)
         assert list(mask_cropped.bounds) == bbox2
         assert np.array_equal(mask.data[:, :-rand_int].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:, :-rand_int].mask, mask_cropped.data.mask)
+
+        #  With icrop
+        bbox2_pixel = [0, 0, mask.width - rand_int, mask.height]
+        mask_cropped_pix = mask.icrop(bbox2_pixel)
+        assert mask_cropped.raster_equal(mask_cropped_pix)
 
         # Bottom
         bbox2 = [bbox[0], bbox[1] + rand_int * abs(mask.res[1]), bbox[2], bbox[3]]
@@ -717,6 +727,11 @@ class TestMaskGeotransformations:
         assert np.array_equal(mask.data[:-rand_int, :].data, mask_cropped.data.data, equal_nan=True)
         assert np.array_equal(mask.data[:-rand_int, :].mask, mask_cropped.data.mask)
 
+        #  With icrop
+        bbox2_pixel = [0, 0, mask.width, mask.height - rand_int]
+        mask_cropped_pix = mask.icrop(bbox2_pixel)
+        assert mask_cropped.raster_equal(mask_cropped_pix)
+
         # Top
         bbox2 = [bbox[0], bbox[1], bbox[2], bbox[3] - rand_int * abs(mask.res[1])]
         mask_cropped = mask.crop(bbox2)
@@ -724,12 +739,22 @@ class TestMaskGeotransformations:
         assert np.array_equal(mask.data[rand_int:, :].data, mask_cropped.data, equal_nan=True)
         assert np.array_equal(mask.data[rand_int:, :].mask, mask_cropped.data.mask)
 
+        #  With icrop
+        bbox2_pixel = [0, rand_int, mask.width, mask.height]
+        mask_cropped_pix = mask.icrop(bbox2_pixel)
+        assert mask_cropped.raster_equal(mask_cropped_pix)
+
         # Test inplace
         mask_orig = mask.copy()
         mask_orig.crop(bbox2, inplace=True)
         assert list(mask_orig.bounds) == bbox2
         assert np.array_equal(mask.data[rand_int:, :].data, mask_orig.data, equal_nan=True)
         assert np.array_equal(mask.data[rand_int:, :].mask, mask_orig.data.mask)
+
+        # With icrop
+        mask_orig_pix = mask.copy()
+        mask_orig_pix.icrop(bbox2_pixel, inplace=True)
+        assert mask_orig.raster_equal(mask_orig_pix)
 
         # Run with match_extent, check that inplace or not yields the same result
 

--- a/tests/test_raster/test_geotransformations.py
+++ b/tests/test_raster/test_geotransformations.py
@@ -305,14 +305,14 @@ class TestRasterGeotransformations:
 
         # Only bounds should change
         assert orig_transform.c + 1 * orig_res[0] == r.transform.c
-        assert orig_transform.f + 1 * orig_res[1] == r.transform.f
+        assert orig_transform.f - 1 * orig_res[1] == r.transform.f
         for attr in ["a", "b", "d", "e"]:
             assert getattr(orig_transform, attr) == getattr(r.transform, attr)
 
         assert orig_bounds.left + 1 * orig_res[0] == r.bounds.left
         assert orig_bounds.right + 1 * orig_res[0] == r.bounds.right
-        assert orig_bounds.bottom + 1 * orig_res[1] == r.bounds.bottom
-        assert orig_bounds.top + 1 * orig_res[1] == r.bounds.top
+        assert orig_bounds.bottom - 1 * orig_res[1] == r.bounds.bottom
+        assert orig_bounds.top - 1 * orig_res[1] == r.bounds.top
 
         # Check that an error is raised for a wrong distance_unit
         with pytest.raises(ValueError, match="Argument 'distance_unit' should be either 'pixel' or 'georeferenced'."):


### PR DESCRIPTION
Resolves #659 

## Description
- Changes order of `icrop` bounding box to match with Rasterio.BoundingBox.
- Adds a parameter `distance_unit: Literal["georeferenced", "pixel"] = "georeferenced"` in `georeferencing._crop` to match with the use of `icrop`.

## Tests
- Updates crop tests.

## Doc
-  Updates crop section in `raster_class.md`.