### PR TITLE
Fix `Raster.get_stats` when an empty `inlier_mask` is passed

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1918,7 +1918,7 @@ class Raster:
             "90th percentile": np.nanpercentile(mdata, 90),
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
-            "RMSE": np.sum(np.sqrt(np.ma.mean(np.square(data)))),
+            "RMSE": np.sqrt(np.ma.mean(np.square(data))),
             "Standard deviation": np.ma.std(data),
             "Valid count": valid_count,
             "Total count": data.size,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1918,7 +1918,7 @@ class Raster:
             "90th percentile": np.nanpercentile(mdata, 90),
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
-            "RMSE": np.sqrt(np.ma.mean(np.square(data))),
+            "RMSE": np.sum(np.sqrt(np.ma.mean(np.square(data)))),
             "Standard deviation": np.ma.std(data),
             "Valid count": valid_count,
             "Total count": data.size,
@@ -1932,7 +1932,7 @@ class Raster:
                     "Valid inlier count": valid_inlier_count,
                     "Total inlier count": counts[1],
                     "Percentage inlier points": (valid_inlier_count / counts[0]) * 100,
-                    "Percentage valid inlier points": (valid_inlier_count / counts[1]) * 100,
+                    "Percentage valid inlier points": (valid_inlier_count / counts[1]) * 100 if counts[1] != 0 else 0,
                 }
             )
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1936,6 +1936,12 @@ class Raster:
                 }
             )
 
+        # If there are no valid data points, set all statistics to NaN
+        if np.count_nonzero(~self.get_mask()) == 0:
+            logging.warning("Empty raster, returns Nan for all stats")
+            for key in stats_dict:
+                stats_dict[key] = np.nan
+
         return stats_dict
 
     @overload

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2002,11 +2002,13 @@ class TestRaster:
             "Percentage valid points",
         ]
 
+        stat_types = (int, float, np.integer, np.floating)
+
         # Full stats
         stats = raster.get_stats()
         for name in expected_stats:
             assert name in stats
-            assert stats.get(name) is not None
+            assert isinstance(stats.get(name), stat_types)
 
         # With mask
         inlier_mask = raster.get_mask()
@@ -2018,9 +2020,20 @@ class TestRaster:
             "Percentage valid inlier points",
         ]:
             assert name in stats_masked
-            assert stats_masked.get(name) is not None
+            assert isinstance(stats_masked.get(name), stat_types)
             stats_masked.pop(name)
         assert stats_masked == stats
+
+        # Empty mask
+        empty_mask = np.ones_like(inlier_mask)
+        stats_masked = raster.get_stats(inlier_mask=empty_mask)
+        for name in [
+            "Valid inlier count",
+            "Total inlier count",
+            "Percentage inlier points",
+            "Percentage valid inlier points",
+        ]:
+            assert stats_masked.get(name) == 0
 
         # Single stat
         for name in expected_stats:


### PR DESCRIPTION
Resolves #662.

## Changes
- Adds robustness in `Percentage_valid_inlier_ points` when `total_inlier_counts` is 0 to avoid divided by 0.
- Sets all stats to `NaN` when the raster or inlier mask is empty and add a warning in logging.
- Fixes `rmse` (the sum was missing).

## Tests
- Adds a test with an empty inlier mask, ensure returned stats are `NaN`
- Adds a check to ensure that value types in stats are `int` or `float`.
