### PR TITLE
Add handling of failure case for `merge_rasters()` `algo` check

### DIFF
--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -312,7 +312,10 @@ def merge_rasters(
             merged_data.append(algo(raster_stack.data, axis=0))
         # If that doesn't work, use the slower np.apply_along_axis approach.
         except TypeError as exception:
-            if not ("'axis' is an invalid keyword" in str(exception) or "got an unexpected keyword argument 'axis'" in str(exception)):
+            if not (
+                "'axis' is an invalid keyword" in str(exception)
+                or "got an unexpected keyword argument 'axis'" in str(exception)
+            ):
                 raise exception
             merged_data.append(np.apply_along_axis(algo, axis=0, arr=raster_stack.data))
 

--- a/geoutils/raster/multiraster.py
+++ b/geoutils/raster/multiraster.py
@@ -312,7 +312,7 @@ def merge_rasters(
             merged_data.append(algo(raster_stack.data, axis=0))
         # If that doesn't work, use the slower np.apply_along_axis approach.
         except TypeError as exception:
-            if "'axis' is an invalid keyword" not in str(exception):
+            if not ("'axis' is an invalid keyword" in str(exception) or "got an unexpected keyword argument 'axis'" in str(exception)):
                 raise exception
             merged_data.append(np.apply_along_axis(algo, axis=0, arr=raster_stack.data))
 

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -301,6 +301,29 @@ class TestMultiRaster:
         if all(rast.crs == rasters.img.crs for rast in [rasters.img1, rasters.img2]):
             assert merged_img2 == merged_img
 
+        # For merge algo: function not supporting the axis keyword argument but raising the right "axis" type error
+        custom_func = lambda x: np.logical_and(*x)
+        gu.raster.merge_rasters([rasters.img1, rasters.img2], merge_algorithm=custom_func)
+
+    @pytest.mark.parametrize(
+        "rasters",
+        [
+            pytest.lazy_fixture("images_1d"),
+            pytest.lazy_fixture("images_3d"),
+        ],
+    )  # type: ignore
+    def test_merge_rasters__errors(self, rasters) -> None:
+        """Test errors of merge raster are properly raised."""
+
+        # For merge algo: function that raises another type error than the expect axis error
+        msg = "not the right axis message"
+
+        def custom_func(x):
+            raise TypeError(msg)
+
+        with pytest.raises(TypeError, match=msg):
+            gu.raster.merge_rasters([rasters.img1, rasters.img2], merge_algorithm=custom_func)
+
     # Group rasters for for testing `load_multiple_rasters`
     # two overlapping, single band rasters
     # two overlapping, 1 and 3 band rasters

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -14,6 +14,7 @@ import rasterio as rio
 
 import geoutils as gu
 from geoutils import examples
+from geoutils._typing import NDArrayNum
 from geoutils.raster import RasterType
 from geoutils.raster.raster import _default_nodata
 
@@ -302,7 +303,9 @@ class TestMultiRaster:
             assert merged_img2 == merged_img
 
         # For merge algo: function not supporting the axis keyword argument but raising the right "axis" type error
-        custom_func = lambda x: np.logical_and(*x)
+        def custom_func(x: NDArrayNum) -> NDArrayNum:
+            return np.logical_and(*x)
+
         gu.raster.merge_rasters([rasters.img1, rasters.img2], merge_algorithm=custom_func)
 
     @pytest.mark.parametrize(
@@ -318,7 +321,7 @@ class TestMultiRaster:
         # For merge algo: function that raises another type error than the expect axis error
         msg = "not the right axis message"
 
-        def custom_func(x):
+        def custom_func(x: NDArrayNum) -> None:
             raise TypeError(msg)
 
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
**Bug found with Python 3.12.7**

When a call to `raster/multiraster.merge_rasters()` uses a lambda function as `merge_algorithm` like this:
`merge_algorithm=lambda x: np.logical_and(*x)`
the `TypeError` on unexpected kwarg `axis` is not handled because the error message is different from the hardcoded expected error message structure.

Adds support for this error message structure.

```
  File "/home/ehusby/miniforge3/envs/dem-slice/lib/python3.12/site-packages/geoutils/raster/multiraster.py", line 312, in merge_rasters
    merged_data.append(algo(raster_stack.data, axis=0))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: my_calling_func.<locals>.<lambda>() got an unexpected keyword argument 'axis'
```