### PR TITLE
Add COG format

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -477,7 +477,7 @@ class Raster:
                 converted_tags = decode_sensor_metadata(self.tags)
                 self._tags.update(converted_tags)
                 # Add image structure in tags
-                self._tags.update(ds.tags(ns='IMAGE_STRUCTURE'))
+                self._tags.update(ds.tags(ns="IMAGE_STRUCTURE"))
 
                 self._area_or_point = self.tags.get("AREA_OR_POINT", None)
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -476,6 +476,8 @@ class Raster:
                 # For tags saved from sensor metadata, convert from string to practical type (datetime, etc)
                 converted_tags = decode_sensor_metadata(self.tags)
                 self._tags.update(converted_tags)
+                # Add image structure in tags
+                self._tags.update(ds.tags(ns='IMAGE_STRUCTURE'))
 
                 self._area_or_point = self.tags.get("AREA_OR_POINT", None)
 

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1771,10 +1771,10 @@ class TestRaster:
         assert saved.tags["Type"] == "test"
 
         # Test saving file in COG format
-        img.save(temp_file, driver='COG')
+        img.save(temp_file, driver="COG")
         saved = gu.Raster(temp_file)
         assert img.raster_equal(saved)
-        assert saved.tags['LAYOUT'] == 'COG'
+        assert saved.tags["LAYOUT"] == "COG"
         
         # Test that nodata value is enforced when masking - since value 0 is not used, data should be unchanged
         img.save(temp_file, nodata=0)

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1770,6 +1770,12 @@ class TestRaster:
         assert img.raster_equal(saved)
         assert saved.tags["Type"] == "test"
 
+        # Test saving file in COG format
+        img.save(temp_file, driver='COG')
+        saved = gu.Raster(temp_file)
+        assert img.raster_equal(saved)
+        assert saved.tags['LAYOUT'] == 'COG'
+        
         # Test that nodata value is enforced when masking - since value 0 is not used, data should be unchanged
         img.save(temp_file, nodata=0)
         saved = gu.Raster(temp_file)

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1775,7 +1775,7 @@ class TestRaster:
         saved = gu.Raster(temp_file)
         assert img.raster_equal(saved)
         assert saved.tags["LAYOUT"] == "COG"
-        
+
         # Test that nodata value is enforced when masking - since value 0 is not used, data should be unchanged
         img.save(temp_file, nodata=0)
         saved = gu.Raster(temp_file)

--- a/tests/test_raster/test_satimg.py
+++ b/tests/test_raster/test_satimg.py
@@ -83,8 +83,12 @@ class TestSatImg:
         temp_file = os.path.join(temp_dir.name, "test.tif")
         rast.save(temp_file)
         saved = gu.Raster(temp_file)
-
-        assert saved.tags == rast.tags
+        saved_tags = saved.tags
+        rast_tags = rast.tags
+        # Do not check COMPRESSION tags 
+        saved_tags.pop("COMPRESSION", None)
+        rast_tags.pop("COMPRESSION", None)
+        assert saved_tags == rast_tags
 
     def test_filename_parsing(self) -> None:
         """Test metadata parsing from filenames"""

--- a/tests/test_raster/test_satimg.py
+++ b/tests/test_raster/test_satimg.py
@@ -85,7 +85,7 @@ class TestSatImg:
         saved = gu.Raster(temp_file)
         saved_tags = saved.tags
         rast_tags = rast.tags
-        # Do not check COMPRESSION tags 
+        # Do not check COMPRESSION tags
         saved_tags.pop("COMPRESSION", None)
         rast_tags.pop("COMPRESSION", None)
         assert saved_tags == rast_tags

--- a/tests/test_raster/test_satimg.py
+++ b/tests/test_raster/test_satimg.py
@@ -86,6 +86,8 @@ class TestSatImg:
         saved_tags = saved.tags
         rast_tags = rast.tags
         # Do not check COMPRESSION tags
+        # The file "saved" is just read, it has no compression by default (no COMPRESSION tag)
+        # The file "rast" is saved, therefore a compression is applied (COMPRESSION tag)
         saved_tags.pop("COMPRESSION", None)
         rast_tags.pop("COMPRESSION", None)
         assert saved_tags == rast_tags


### PR DESCRIPTION
- Add image structure in tags (`geoutils/geoutils/raster/raster.py`)
- Add tests to save a file in COG format (`tests/test_raster/test_raster.py`) 


Do not check COMPRESSION tags for the following reasons:
The tags of rast and the tags of saved are compared. The file saved has no compression by default (the image is already saved). The tag COMPRESSION is not present in IMAGE_STRUCTURE. The file rast is saved during the test, therefore a compression is applied. The tag COMPRESSION is present in IMAGE_STRUCTURE. Therefore, it is not possible to compare the tag COMPRESSION for both files.