### PR TITLE
Add profile to raster metadata and use fork for multiprocessing  

### DIFF
--- a/geoutils/raster/distributed_computing/cluster.py
+++ b/geoutils/raster/distributed_computing/cluster.py
@@ -109,7 +109,7 @@ class MpCluster(AbstractCluster):
         if conf is not None:
             nb_workers = conf.get("nb_workers", 1)
         # Using the 'forkserver' context for more controlled process handling
-        ctx_in_main = multiprocessing.get_context("forkserver")
+        ctx_in_main = multiprocessing.get_context("fork")
         # Create a pool of workers with max 10 tasks per child process
         self.pool = ctx_in_main.Pool(processes=nb_workers, maxtasksperchild=10)
 

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -181,6 +181,7 @@ _default_rio_attrs = [
     "shape",
     "transform",
     "width",
+    "profile",
 ]
 
 
@@ -409,6 +410,7 @@ class Raster:
         self._disk_transform: affine.Affine | None = None
         self._downsample: int | float = 1
         self._area_or_point: Literal["Area", "Point"] | None = None
+        self._profile: dict[str, Any] | None = None
 
         # This is for Raster.from_array to work.
         if isinstance(filename_or_dataset, dict):
@@ -468,6 +470,7 @@ class Raster:
                 self._name = ds.name
                 self._driver = ds.driver
                 self._tags.update(ds.tags())
+                self._profile = ds.profile
 
                 # For tags saved from sensor metadata, convert from string to practical type (datetime, etc)
                 converted_tags = decode_sensor_metadata(self.tags)
@@ -660,6 +663,13 @@ class Raster:
     def name(self) -> str | None:
         """Name of the file on disk, if it exists."""
         return self._name
+
+    @property
+    def profile(self) -> dict[str, Any] | None:
+        """Basic metadata and creation options of this dataset.
+        May be passed as keyword arguments to rasterio.open()
+        to create a clone of this dataset."""
+        return self._profile
 
     def set_area_or_point(
         self, new_area_or_point: Literal["Area", "Point"] | None, shift_area_or_point: bool | None = None

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -351,7 +351,7 @@ class TestRaster:
         assert isinstance(rio_ds, rio.io.DatasetReader)
 
         # Check that all attributes are equal
-        rio_attrs_conserved = [attr for attr in _default_rio_attrs if attr not in ["name", "driver"]]
+        rio_attrs_conserved = [attr for attr in _default_rio_attrs if attr not in ["name", "driver", "profile"]]
         for attr in rio_attrs_conserved:
             assert rst.__getattribute__(attr) == rio_ds.__getattribute__(attr)
 
@@ -986,9 +986,9 @@ class TestRaster:
         # Check a temporary memory file different than original disk file was created
         assert r2.name != r.name
 
-        # Check all attributes except name and driver
+        # Check all attributes except name, driver and profile
         default_attrs = _default_rio_attrs.copy()
-        for attr in ["name", "driver"]:
+        for attr in ["name", "driver", "profile"]:
             default_attrs.remove(attr)
         attrs = default_attrs
         for attr in attrs:


### PR DESCRIPTION
# Small improvements 

- Adding the profile option to the raster metadata
- "fork" seems to be more widely usable than forkserver (especially on the CNES cluster)