### PR TITLE
Generic Multiprocessing Functions for Raster Processing

### DIFF
--- a/doc/source/multiprocessing.md
+++ b/doc/source/multiprocessing.md
@@ -1,0 +1,127 @@
+---
+file_format: mystnb
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: geoutils-env
+  language: python
+  name: geoutils
+---
+(multiprocessing)=
+
+# Multiprocessing
+
+## Overview
+
+Processing large raster datasets can be **computationally expensive and memory-intensive**. To optimize performance and enable **out-of-memory processing**, GeoUtils provides **multiprocessing utilities** that allow users to process raster data in parallel by splitting it into tiles.
+
+GeoUtils offers two functions for out-of-memory multiprocessing:
+
+- {func}`~geoutils.raster.distributed_computing.map_overlap_multiproc_save`: Applies a function to raster tiles and **saves the output** as a {class}`geoutils.Raster`.
+- {func}`~geoutils.raster.distributed_computing.map_multiproc_collect`: Applies a function and **collects extracted data** from raster tiles into a list.
+
+Both functions require a **multiprocessing configuration** defined with {class}`~geoutils.raster.distributed_computing.MultiprocConfig`.
+
+---
+
+## Using {class}`~geoutils.raster.distributed_computing.MultiprocConfig`
+
+{class}`~geoutils.raster.distributed_computing.MultiprocConfig` defines tiling and processing settings, such as chunk size, output file, and computing cluster. It ensures that computations are performed **without loading the entire raster into memory**.
+
+### Example: creating a {class}`~geoutils.raster.distributed_computing.MultiprocConfig` object
+```{code-cell} ipython3
+from geoutils.raster.distributed_computing import ClusterGenerator
+from geoutils.raster.distributed_computing import MultiprocConfig
+
+# Create a configuration without multiprocessing cluster (tasks will be processed sequentially)
+config_basic = MultiprocConfig(chunk_size=200, outfile="output.tif", cluster=None)
+
+# Create a configuration with a multiprocessing cluster
+config_np = config_basic.copy()
+config_np.cluster = ClusterGenerator("multi", nb_workers=4)
+```
+- **`chunk_size=200`**: The raster is divided into 200x200 pixel tiles.
+- **`outfile="output.tif"`**: Required when saving results.
+- **`cluster=ClusterGenerator("multi", nb_workers=4)`**: Enables parallel processing.
+
+---
+
+## {func}`~geoutils.raster.distributed_computing.map_overlap_multiproc_save`: process and save large rasters
+
+This function applies a user-defined function to raster tiles and **saves the output** to a file. The entire raster is **never loaded into memory at once**, making it suitable for processing large datasets.
+
+### When to use
+- When the function **returns a Raster**.
+- When the result should be **saved as a new raster**.
+- When working with large rasters that do not fit into memory.
+
+### Example: applying a raster filter
+```{code-cell} ipython3
+import geoutils as gu
+import scipy
+import numpy as np
+from geoutils.raster import RasterType
+from geoutils.raster.distributed_computing import map_overlap_multiproc_save
+
+filename_rast = gu.examples.get_path("exploradores_aster_dem")
+
+def filter(raster: RasterType, size: int) -> RasterType:
+    new_data = scipy.ndimage.maximum_filter(raster.data, size)
+    if raster.nodata is not None:
+        new_data = np.ma.masked_equal(new_data, raster.nodata)
+    raster.data = new_data
+    return raster
+
+size = 1
+map_overlap_multiproc_save(filter, filename_rast, config_basic, size, depth=size+1)
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+import os
+os.remove(config_basic.outfile)
+```
+
+---
+
+## {func}`~geoutils.raster.distributed_computing.map_multiproc_collect`: extract and collect data from large rasters
+
+This function applies a function to raster tiles and **returns a list** of extracted data, without saving a new raster file. The process runs in **out-of-memory mode**, ensuring efficient handling of large datasets.
+
+### When to use
+- When the function **does not return a Raster**.
+- When extracting **summary statistics, features, or analysis results**.
+- When processing large rasters that cannot fit into memory.
+
+### Example: extracting elevation statistics
+```{code-cell} ipython3
+from geoutils.raster.distributed_computing import map_multiproc_collect
+from typing import Any
+
+# Compute mean
+
+def compute_statistics(raster: gu.Raster) -> dict[str, np.floating[Any]]:
+    return raster.get_stats(stats_name=["mean", "valid_count"])
+
+stats_results = map_multiproc_collect(compute_statistics, filename_rast, config_basic)
+total_count = sum([stats["valid_count"] for stats in stats_results])
+total_mean = sum([stats["mean"] * stats["valid_count"] for stats in stats_results]) / total_count
+print("Mean: ", total_mean)
+```
+
+```{Note}
+To include tile location (col_min, col_max, row_min, row_max) in the results, set `return_tile=True`.
+```
+
+---
+
+## Choosing the right function
+
+| Use case                                      | Function |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------|
+| Apply processing and save results as a raster | {func}`~geoutils.raster.distributed_computing.map_overlap_multiproc_save` |
+| Extract statistics or features into a list    | {func}`~geoutils.raster.distributed_computing.map_multiproc_collect` |
+| Track tile locations with extracted data      | {func}`~geoutils.raster.distributed_computing.map_multiproc_collect` with `return_tile=True` |

--- a/geoutils/raster/distributed_computing/__init__.py
+++ b/geoutils/raster/distributed_computing/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from geoutils.raster.distributed_computing.cluster import *  # noqa
+from geoutils.raster.distributed_computing.multiproc import *  # noqa

--- a/geoutils/raster/distributed_computing/__init__.py
+++ b/geoutils/raster/distributed_computing/__init__.py
@@ -17,4 +17,8 @@
 # limitations under the License.
 
 from geoutils.raster.distributed_computing.cluster import *  # noqa
-from geoutils.raster.distributed_computing.multiproc import *  # noqa
+from geoutils.raster.distributed_computing.multiproc import (  # noqa
+    MultiprocConfig,
+    map_multiproc_collect,
+    map_overlap_multiproc_save,
+)

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -72,9 +72,9 @@ def load_raster_tile(raster_unload: RasterType, tile: NDArrayNum) -> RasterType:
     :param tile: The bounding box of the tile as [xmin, xmax, ymin, ymax].
     :return: The extracted raster tile.
     """
-    xmin, xmax, ymin, ymax = tile
+    rowmin, rowmax, colmin, colmax = tile
     # Crop the raster to extract the tile based on the bounding box coordinates
-    raster_tile = raster_unload.icrop(bbox=(xmin, ymin, xmax, ymax))
+    raster_tile = raster_unload.icrop(bbox=(colmin, rowmin, colmax, rowmax))
     return raster_tile
 
 
@@ -84,28 +84,28 @@ def remove_tile_padding(raster_shape: tuple[int, int], raster_tile: RasterType, 
 
     :param raster_shape: The shape (height, width) of the raster from which tiles are extracted.
     :param raster_tile: The raster tile with possible padding that needs removal.
-    :param tile: The bounding box of the tile as [xmin, xmax, ymin, ymax].
+    :param tile: The bounding box of the tile as [rowmin, rowmax, colmin, colmax].
     :param padding: The padding size to be removed from each side of the tile.
     """
     # New bounding box dimensions after removing padding
-    xmin, xmax, ymin, ymax = 0, raster_tile.height, 0, raster_tile.width
+    colmin, rowmin, colmax, rowmax = 0, 0, raster_tile.width, raster_tile.height
 
     # Remove padding only if the tile is not at the DEM's edges
     if tile[0] != 0:
         tile[0] += padding
-        xmin += padding
+        rowmin += padding
     if tile[1] != raster_shape[0]:
         tile[1] -= padding
-        xmax -= padding
+        rowmax -= padding
     if tile[2] != 0:
         tile[2] += padding
-        ymin += padding
+        colmin += padding
     if tile[3] != raster_shape[1]:
         tile[3] -= padding
-        ymax -= padding
+        colmax -= padding
 
     # Apply the new bounding box to crop the tile and remove the padding
-    raster_tile.icrop(bbox=(xmin, ymin, xmax, ymax), inplace=True)
+    raster_tile.icrop(bbox=(colmin, rowmin, colmax, rowmax), inplace=True)
 
 
 def apply_func_block(

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -148,6 +148,7 @@ def map_overlap_multiproc(  # type: ignore
     raster_path: str | RasterType,
     config: MultiprocConfig,
     *args: Any,
+    return_tiles: bool = False,
     **kwargs: dict[str, Any],
 ) -> None: ...
 
@@ -158,6 +159,7 @@ def map_overlap_multiproc(
     raster_path: str | RasterType,
     config: MultiprocConfig,
     *args: Any,
+    return_tiles: bool = False,
     **kwargs: dict[str, Any],
 ) -> list[Any]: ...
 
@@ -167,6 +169,7 @@ def map_overlap_multiproc(
     raster_path: str | RasterType,
     config: MultiprocConfig,
     *args: Any,
+    return_tiles: bool = False,
     **kwargs: dict[str, Any],
 ) -> None | list[Any]:
     """
@@ -182,6 +185,7 @@ def map_overlap_multiproc(
     :param config: Configuration object containing chunk size, output file, depth, and optional cluster. Output file is
         needed if func returns a Raster or a tuple with a Raster.
     :param args: Additional arguments to pass to the function being applied.
+    :param return_tiles: True to return the tiles coordinates for each tile in the list
     """
     # Load DEM metadata if raster_path is a filepath, otherwise use the Raster object
     if not isinstance(raster_path, Raster):
@@ -263,8 +267,11 @@ def map_overlap_multiproc(
     else:
         # Handle non-raster results
         for results in tasks:
-            result_tile, _ = config.cluster.get_res(results)
-            result_list.append(result_tile)
+            result_tile, dst_tile = config.cluster.get_res(results)
+            if return_tiles:
+                result_list.append((result_tile, dst_tile))
+            else:
+                result_list.append(result_tile)
 
     # Return the result list if there are non-raster results
     if result_list:

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -242,7 +242,11 @@ def map_overlap_multiproc(
 
                     # If result_tile is a tuple, append the non-raster part to result_list
                     if isinstance(result_tile, tuple):
-                        result_list.append(result_tile[1:])  # Add non-raster parts to result_list
+                        # Add non-raster parts to result_list
+                        if return_tiles:
+                            result_list.append((*result_tile[1:], dst_tile))
+                        else:
+                            result_list.append(*result_tile[1:])
                         result_tile = result_tile[0]  # Extract the raster part
 
                     # Define the window in the output file where the tile should be written
@@ -269,7 +273,10 @@ def map_overlap_multiproc(
         for results in tasks:
             result_tile, dst_tile = config.cluster.get_res(results)
             if return_tiles:
-                result_list.append((result_tile, dst_tile))
+                if isinstance(result_tile, tuple):
+                    result_list.append((*result_tile, dst_tile))
+                else:
+                    result_list.append((result_tile, dst_tile))
             else:
                 result_list.append(result_tile)
 

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -74,7 +74,9 @@ def load_raster_tile(raster_unload: RasterType, tile: NDArrayNum) -> RasterType:
     return raster_tile
 
 
-def remove_tile_padding(raster_shape: tuple[int, int], raster_tile: RasterType, tile: NDArrayNum, padding: int) -> None:
+def _remove_tile_padding(
+    raster_shape: tuple[int, int], raster_tile: RasterType, tile: NDArrayNum, padding: int
+) -> None:
     """
     Removes the padding added around tiles during terrain attribute computation to prevent edge effects.
 
@@ -104,7 +106,7 @@ def remove_tile_padding(raster_shape: tuple[int, int], raster_tile: RasterType, 
     raster_tile.icrop(bbox=(colmin, rowmin, colmax, rowmax), inplace=True)
 
 
-def apply_func_block(
+def _apply_func_block(
     func: Callable[..., Any],
     raster: RasterType,
     tile: NDArrayNum,
@@ -131,9 +133,9 @@ def apply_func_block(
 
     # Remove padding
     if isinstance(result_tile, Raster):
-        remove_tile_padding((raster.height, raster.width), result_tile, tile, depth)
+        _remove_tile_padding((raster.height, raster.width), result_tile, tile, depth)
     elif isinstance(result_tile, tuple) and isinstance(result_tile[0], Raster):
-        remove_tile_padding((raster.height, raster.width), result_tile[0], tile, depth)
+        _remove_tile_padding((raster.height, raster.width), result_tile[0], tile, depth)
 
     return result_tile, tile
 
@@ -182,7 +184,7 @@ def map_overlap_multiproc_save(
             tile = tiling_grid[row, col]
             # Launch the task on the cluster to process each tile
             tasks.append(
-                config.cluster.launch_task(fun=apply_func_block, args=[func, raster, tile, depth, *args], **kwargs)
+                config.cluster.launch_task(fun=_apply_func_block, args=[func, raster, tile, depth, *args], **kwargs)
             )
 
     # get first tile to retrieve dtype and nodata
@@ -306,7 +308,7 @@ def map_multiproc_collect(
             tile = tiling_grid[row, col]
             # Launch the task on the cluster to process each tile
             tasks.append(
-                config.cluster.launch_task(fun=apply_func_block, args=[func, raster, tile, depth, *args], **kwargs)
+                config.cluster.launch_task(fun=_apply_func_block, args=[func, raster, tile, depth, *args], **kwargs)
             )
 
     try:

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process out-of-memory calculations"""
+from typing import Any, Callable
+
+import numpy as np
+import rasterio as rio
+
+from geoutils import Raster
+from geoutils._typing import NDArrayNum
+from geoutils.raster import RasterType, compute_tiling
+from geoutils.raster.distributed_computing.cluster import (
+    AbstractCluster,
+    ClusterGenerator,
+)
+
+
+def load_raster_tile(raster_unload: RasterType, tile: NDArrayNum) -> RasterType:
+    """
+    Extracts a specific tile (spatial subset) from the raster based on the provided tile coordinates.
+
+    :param raster_unload: The input raster from which the tile is to be extracted.
+    :param tile: The bounding box of the tile as [xmin, xmax, ymin, ymax].
+    :return: The extracted raster tile.
+    """
+    xmin, xmax, ymin, ymax = tile
+    # Crop the raster to extract the tile based on the bounding box coordinates
+    raster_tile = raster_unload.icrop(bbox=(xmin, ymin, xmax, ymax))
+    return raster_tile
+
+
+def remove_tile_padding(raster: RasterType, raster_tile: RasterType, tile: NDArrayNum, padding: int) -> None:
+    """
+    Removes the padding added around tiles during terrain attribute computation to prevent edge effects.
+
+    :param raster: The full DEM object from which tiles are extracted.
+    :param raster_tile: The raster tile with possible padding that needs removal.
+    :param tile: The bounding box of the tile as [xmin, xmax, ymin, ymax].
+    :param padding: The padding size to be removed from each side of the tile.
+    """
+    # New bounding box dimensions after removing padding
+    xmin, xmax, ymin, ymax = 0, raster_tile.height, 0, raster_tile.width
+
+    # Remove padding only if the tile is not at the DEM's edges
+    if tile[0] != 0:
+        tile[0] += padding
+        xmin += padding
+    if tile[1] != raster.height:
+        tile[1] -= padding
+        xmax -= padding
+    if tile[2] != 0:
+        tile[2] += padding
+        ymin += padding
+    if tile[3] != raster.width:
+        tile[3] -= padding
+        ymax -= padding
+
+    # Apply the new bounding box to crop the tile and remove the padding
+    raster_tile.icrop(bbox=(xmin, ymin, xmax, ymax), inplace=True)
+
+
+def map_block(
+    func: Callable[..., Any],
+    raster: RasterType,
+    tile: NDArrayNum,
+    depth: int,
+    *args: tuple[Any, ...],
+    **kwargs: dict[str, Any],
+) -> tuple[Any, NDArrayNum]:
+    """
+    Apply a function to a specific tile of a raster, handling loading and padding.
+
+    :param func: The function to apply to each tile.
+    :param raster: The input raster.
+    :param tile: The bounding box of the tile as [xmin, xmax, ymin, ymax].
+    :param depth: The padding size used to overlap tiles.
+    :param args: Additional arguments to pass to the function being applied.
+
+    :return: The processed tile and its bounding box.
+    """
+    # Load raster tile
+    raster_tile = load_raster_tile(raster, tile)
+
+    # Apply user-defined function to the tile
+    result_tile = func(raster_tile, *args, **kwargs)
+
+    # Remove padding
+    remove_tile_padding(raster, result_tile, tile, depth)
+
+    return result_tile, tile
+
+
+def map_multiproc(
+    func: Callable[..., Any],
+    raster_path: str | RasterType,
+    tile_size: int,
+    outfile: str,
+    *args: tuple[Any, ...],
+    depth: int = 0,
+    cluster: AbstractCluster | None = None,
+    **kwargs: dict[str, Any],
+) -> None:
+    """
+    Multiprocessing function for applying out_of_memory operations on raster.
+
+    This function divides the input raster into tiles, processes them in parallel using multiprocessing, and
+    writes the output to a new raster file. It handles the overlap between tiles (depth) to avoid edge effects.
+
+    :param func: The function to apply to each tile.
+    :param raster_path: Path to the input raster or the Raster object itself.
+    :param tile_size: The size of each tile to divide the raster into.
+    :param outfile: The path where the resulting output raster will be saved.
+    :param args: Additional arguments to pass to the function being applied.
+    :param depth: The padding size for overlapping tiles (default is 0).
+    :param cluster: An optional multiprocessing cluster to use for task distribution.
+    """
+    if cluster is None:
+        # Initialize a basic multiprocessing cluster if none is provided
+        cluster = ClusterGenerator("basic")  # type: ignore
+    assert cluster is not None  # for mypy
+
+    # Load DEM metadata if raster_path is a filepath, otherwise use the Raster object
+    if not isinstance(raster_path, Raster):
+        raster = Raster(raster_path)
+    else:
+        raster = raster_path
+
+    # Generate tiling grid
+    tiling_grid = compute_tiling(tile_size, raster.shape, raster.shape, overlap=depth)
+
+    # Create tasks for multiprocessing
+    tasks = []
+    for row in range(tiling_grid.shape[0]):
+        for col in range(tiling_grid.shape[1]):
+            tile = tiling_grid[row, col]
+            # Launch the task on the cluster to process each tile
+            tasks.append(cluster.launch_task(fun=map_block, args=[func, raster, tile, depth, *args], **kwargs))
+
+    # get first tile to retrieve dtype and nodata
+    attr_tile0, _ = cluster.get_res(tasks[0])
+
+    if isinstance(attr_tile0, Raster):
+        # Create a new raster file to save the processed results
+        with rio.open(
+            outfile,
+            "w",
+            driver="GTiff",
+            height=raster.height,
+            width=raster.width,
+            count=raster.count,
+            dtype=attr_tile0.dtype,
+            crs=raster.crs,
+            transform=raster.transform,
+            nodata=attr_tile0.nodata,
+        ) as dst:
+            try:
+                # Iterate over the tasks and retrieve the processed tiles
+                for results in tasks:
+                    attr_tile, dst_tile = cluster.get_res(results)
+
+                    # Define the window in the output file where the tile should be written
+                    dst_window = rio.windows.Window(
+                        col_off=dst_tile[2],
+                        row_off=dst_tile[0],
+                        width=dst_tile[3] - dst_tile[2],
+                        height=dst_tile[1] - dst_tile[0],
+                    )
+
+                    # Cast to 3D before saving if single band
+                    if attr_tile.count == 1:
+                        data = attr_tile[np.newaxis, :, :]
+                    else:
+                        data = attr_tile.data
+
+                    # Write the processed tile to the appropriate location in the output file
+                    dst.write(data, window=dst_window)
+            except Exception as e:
+                raise RuntimeError(f"Error retrieving terrain attribute from multiprocessing tasks: {e}")

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -226,6 +226,7 @@ def map_overlap_multiproc_save(
 
                 # Write the processed tile to the appropriate location in the output file
                 dst.write(data, window=dst_window)
+            print(f"Raster saved under {config.outfile}")
         except Exception as e:
             raise RuntimeError(f"Error retrieving terrain attribute from multiprocessing tasks: {e}")
 

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -12,6 +12,7 @@ from geoutils import Raster, examples
 from geoutils.raster import RasterType
 from geoutils.raster.distributed_computing import (
     ClusterGenerator,
+    MultiprocConfig,
     apply_func_block,
     load_raster_tile,
     map_overlap_multiproc,
@@ -98,11 +99,13 @@ class TestMultiproc:
         """
         raster = Raster(example)
         output_file = "output.tif"
+        depth = 10
+        config = MultiprocConfig(tile_size, output_file, depth, cluster)
 
         addition = 5
         factor = 0.5
         # Apply the multiproc map function
-        map_overlap_multiproc(_custom_func, raster, tile_size, output_file, addition, factor, depth=10, cluster=cluster)
+        map_overlap_multiproc(_custom_func, raster, config, addition, factor)
 
         # Ensure raster has not been loading during process
         assert not raster.is_loaded

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -17,7 +17,8 @@ from geoutils.raster.distributed_computing import (
     MultiprocConfig,
     apply_func_block,
     load_raster_tile,
-    map_overlap_multiproc,
+    map_multiproc_collect,
+    map_overlap_multiproc_save,
     remove_tile_padding,
 )
 
@@ -39,13 +40,6 @@ def _custom_func(raster: RasterType, addition: float, factor: float) -> RasterTy
 # Define a simple function which do not return a Raster
 def _custom_func_stats(raster: RasterType) -> dict[str, floating[Any]]:
     return raster.get_stats(stats_name=["mean", "valid_count"])
-
-
-# Define a simple function which return a tuple containing a Raster
-def _custom_func_fusion(
-    raster: RasterType, addition: float, factor: float
-) -> tuple[RasterType, dict[str, floating[Any]]]:
-    return _custom_func(raster, addition, factor), _custom_func_stats(raster)
 
 
 class TestMultiproc:
@@ -107,19 +101,19 @@ class TestMultiproc:
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
     @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
     @pytest.mark.parametrize("cluster", [None, ClusterGenerator("multi", 4)])
-    def test_map_overlap_multiproc1(self, example, tile_size, cluster):
+    def test_map_overlap_multiproc_save(self, example, tile_size, cluster):
         """
         Test the multiprocessing map function with a simple operation returning a raster.
         """
         raster = Raster(example)
         output_file = "output.tif"
         depth = 10
-        config = MultiprocConfig(tile_size, output_file, depth, cluster)
+        config = MultiprocConfig(tile_size, output_file, cluster)
 
         addition = 5
         factor = 0.5
         # Apply the multiproc map function
-        map_overlap_multiproc(_custom_func, raster, config, addition, factor)
+        map_overlap_multiproc_save(_custom_func, raster, config, addition, factor, depth=depth)
 
         # Ensure raster has not been loading during process
         assert not raster.is_loaded
@@ -138,7 +132,7 @@ class TestMultiproc:
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
     @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
     @pytest.mark.parametrize("cluster", [None, ClusterGenerator("multi", 4)])
-    def test_map_overlap_multiproc2(self, example, tile_size, cluster):
+    def test_map_multiproc_collect(self, example, tile_size, cluster):
         """
         Test the multiprocessing map function with a simple operation returning not a raster.
         """
@@ -146,58 +140,10 @@ class TestMultiproc:
         config = MultiprocConfig(tile_size, cluster=cluster)
 
         # Apply the multiproc map function
-        list_stats = map_overlap_multiproc(_custom_func_stats, raster, config)
+        list_stats = map_multiproc_collect(_custom_func_stats, raster, config)
 
         # Ensure raster has not been loading during process
         assert not raster.is_loaded
-
-        # Compare tiled_stats with the stats on full raster
-        total_stats = _custom_func_stats(raster)
-
-        tiled_count = sum([stats["valid_count"] for stats in list_stats])
-        tiled_mean = sum([stats["mean"] * stats["valid_count"] for stats in list_stats]) / tiled_count
-        assert abs(total_stats["mean"] - tiled_mean) < tiled_mean * 1e-5
-        assert total_stats["valid_count"] == tiled_count
-
-    @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
-    @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
-    @pytest.mark.parametrize("cluster", [ClusterGenerator("multi", 4)])  # type: ignore
-    @pytest.mark.parametrize("return_tiles", [False, True])  # type: ignore
-    def test_map_overlap_multiproc3(self, example, tile_size, cluster, return_tiles):
-        """
-        Test the multiprocessing map function with a simple operation returning a tuple with a raster.
-        """
-        raster = Raster(example)
-        output_file = "output.tif"
-        config = MultiprocConfig(tile_size, output_file, cluster=cluster)
-
-        addition = 5
-        factor = 0.5
-        # Apply the multiproc map function
-        result_list = map_overlap_multiproc(
-            _custom_func_fusion, raster, config, addition, factor, return_tiles=return_tiles
-        )
-
-        if return_tiles:
-            list_stats = [result[0] for result in result_list]
-            list_tiles = [result[1] for result in result_list]
-            assert np.array_equal(list_tiles[0], np.array([0, tile_size, 0, tile_size]))
-        else:
-            list_stats = result_list
-
-        # Ensure raster has not been loading during process
-        assert not raster.is_loaded
-
-        # Ensure the output file is created and valid
-        assert os.path.exists(output_file)
-
-        # Open the output file and compare with the operation on full raster
-        output_raster = Raster(output_file)
-        new_raster = _custom_func(raster, addition, factor)
-        assert output_raster.raster_equal(new_raster)
-
-        # Remove output file
-        os.remove(output_file)
 
         # Compare tiled_stats with the stats on full raster
         total_stats = _custom_func_stats(raster)

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -161,8 +161,9 @@ class TestMultiproc:
 
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
     @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
-    @pytest.mark.parametrize("cluster", [None, ClusterGenerator("multi", 4)])
-    def test_map_overlap_multiproc3(self, example, tile_size, cluster):
+    @pytest.mark.parametrize("cluster", [ClusterGenerator("multi", 4)])  # type: ignore
+    @pytest.mark.parametrize("return_tiles", [False, True])  # type: ignore
+    def test_map_overlap_multiproc3(self, example, tile_size, cluster, return_tiles):
         """
         Test the multiprocessing map function with a simple operation returning a tuple with a raster.
         """
@@ -173,8 +174,16 @@ class TestMultiproc:
         addition = 5
         factor = 0.5
         # Apply the multiproc map function
-        result_list = map_overlap_multiproc(_custom_func_fusion, raster, config, addition, factor)
-        list_stats = [result[0] for result in result_list]
+        result_list = map_overlap_multiproc(
+            _custom_func_fusion, raster, config, addition, factor, return_tiles=return_tiles
+        )
+
+        if return_tiles:
+            list_stats = [result[0] for result in result_list]
+            list_tiles = [result[1] for result in result_list]
+            assert np.array_equal(list_tiles[0], np.array([0, tile_size, 0, tile_size]))
+        else:
+            list_stats = result_list
 
         # Ensure raster has not been loading during process
         assert not raster.is_loaded

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -59,7 +59,7 @@ class TestMultiproc:
         """
         raster = Raster(example)
         # Define a tile (bounding box) to load
-        tile = np.array([50, 125, 100, 200])  # [xmin, xmax, ymin, ymax]
+        tile = np.array([50, 125, 100, 200])  # [rowmin, rowmax, colmin, colmax]
 
         # Load the tile and verify dimensions
         raster_tile = load_raster_tile(raster, tile)
@@ -90,7 +90,7 @@ class TestMultiproc:
         Test applying a function to a raster tile and handling padding removal.
         """
         raster = Raster(example)
-        tile = np.array([100, 200, 100, 200])  # [xmin, xmax, ymin, ymax]
+        tile = np.array([100, 200, 100, 200])  # [rowmin, rowmax, colmin, colmax]
         size = 2
 
         # Apply map_block

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -15,11 +15,13 @@ from geoutils.raster import RasterType
 from geoutils.raster.distributed_computing import (
     ClusterGenerator,
     MultiprocConfig,
-    apply_func_block,
-    load_raster_tile,
     map_multiproc_collect,
     map_overlap_multiproc_save,
-    remove_tile_padding,
+)
+from geoutils.raster.distributed_computing.multiproc import (
+    _apply_func_block,
+    _remove_tile_padding,
+    load_raster_tile,
 )
 
 
@@ -74,7 +76,7 @@ class TestMultiproc:
         raster_tile_with_padding = load_raster_tile(raster, tile_pad)
 
         # Remove padding and ensure it's back to the original size
-        remove_tile_padding((raster.height, raster.width), raster_tile_with_padding, tile, padding)
+        _remove_tile_padding((raster.height, raster.width), raster_tile_with_padding, tile, padding)
         assert raster_tile_with_padding.raster_equal(raster_tile)
 
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
@@ -88,7 +90,7 @@ class TestMultiproc:
         size = 2
 
         # Apply map_block
-        result_tile, _ = apply_func_block(_custom_func_overlap, raster, tile, padding, size)
+        result_tile, _ = _apply_func_block(_custom_func_overlap, raster, tile, padding, size)
 
         raster = _custom_func_overlap(raster, size)
         # If padding >=1, The result should be the equal to the original tile filtered

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -132,7 +132,8 @@ class TestMultiproc:
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
     @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
     @pytest.mark.parametrize("cluster", [None, ClusterGenerator("multi", 4)])
-    def test_map_multiproc_collect(self, example, tile_size, cluster):
+    @pytest.mark.parametrize("return_tile", [False, True])
+    def test_map_multiproc_collect(self, example, tile_size, cluster, return_tile):
         """
         Test the multiprocessing map function with a simple operation returning not a raster.
         """
@@ -140,7 +141,11 @@ class TestMultiproc:
         config = MultiprocConfig(tile_size, cluster=cluster)
 
         # Apply the multiproc map function
-        list_stats = map_multiproc_collect(_custom_func_stats, raster, config)
+        results = map_multiproc_collect(_custom_func_stats, raster, config, return_tile=return_tile)
+        if return_tile:
+            list_stats = [result[0] for result in results]
+        else:
+            list_stats = results
 
         # Ensure raster has not been loading during process
         assert not raster.is_loaded

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -1,0 +1,103 @@
+"""
+Tests for multiprocessing functions
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from geoutils import Raster, examples
+from geoutils.raster import RasterType
+from geoutils.raster.distributed_computing import (
+    ClusterGenerator,
+    load_raster_tile,
+    map_block,
+    map_multiproc,
+    remove_tile_padding,
+)
+
+
+# Define a simple function (copy the raster)
+def _copy_func(r: RasterType, cast_nodata: bool) -> RasterType:
+    return r.copy(cast_nodata=cast_nodata)
+
+
+class TestMultiproc:
+    aster_dem_path = examples.get_path("exploradores_aster_dem")
+    landsat_rgb_path = examples.get_path("everest_landsat_rgb")
+
+    @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
+    def test_load_raster_tile(self, example) -> None:
+        """
+        Test loading a specific tile (spatial subset) from the raster.
+        """
+        raster = Raster(example)
+        # Define a tile (bounding box) to load
+        tile = np.array([50, 125, 100, 200])  # [xmin, xmax, ymin, ymax]
+
+        # Load the tile and verify dimensions
+        raster_tile = load_raster_tile(raster, tile)
+        assert np.array_equal(raster_tile.data, raster.data[..., tile[0] : tile[1], tile[2] : tile[3]])
+
+    @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
+    @pytest.mark.parametrize("padding", [0, 1, 10])  # type: ignore
+    def test_remove_tile_padding(self, example, padding) -> None:
+        """
+        Test removing padding from a raster tile after processing.
+        """
+        raster = Raster(example)
+        # Extract a tile with padding
+        tile = np.array([0, 100, 50, 150])
+        tile_pad = tile + np.array([-1, 1, -1, 1]) * padding
+
+        raster_tile = load_raster_tile(raster, tile)
+        raster_tile_with_padding = load_raster_tile(raster, tile_pad)
+
+        # Remove padding and ensure it's back to the original size
+        remove_tile_padding(raster, raster_tile_with_padding, tile, padding)
+        assert raster_tile_with_padding.raster_equal(raster_tile)
+
+    @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
+    def test_map_block(self, example):
+        """
+        Test applying a function to a raster tile and handling padding removal.
+        """
+        raster = Raster(example)
+        tile = np.array([100, 200, 100, 200])  # [xmin, xmax, ymin, ymax]
+        padding = 10
+
+        cast_nodata = True
+        # Apply map_block
+        result_tile, _ = map_block(_copy_func, raster, tile, padding, (cast_nodata,))
+
+        # Check if the result is the same as the original tile
+        original_tile = load_raster_tile(raster, tile)
+        assert result_tile.raster_equal(original_tile)
+
+    @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
+    @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore
+    @pytest.mark.parametrize("cluster", [None, ClusterGenerator("multi", 4)])
+    def test_map_multiproc(self, example, tile_size, cluster):
+        """
+        Test the multiprocessing map function with a simple copy operation.
+        """
+        raster = Raster(example)
+        output_file = "output.tif"
+
+        cast_nodata = True
+        # Apply the multiproc map function
+        map_multiproc(_copy_func, raster, tile_size, output_file, (cast_nodata,), depth=10, cluster=cluster)
+
+        # Ensure raster has not been loading during process
+        assert not raster.is_loaded
+
+        # Ensure the output file is created and valid
+        assert os.path.exists(output_file)
+
+        # Open the output file and compare with the original raster
+        output_raster = Raster(output_file)
+        assert output_raster.raster_equal(raster)
+
+        # Remove output file
+        os.remove(output_file)


### PR DESCRIPTION
Resolves #670.

## Context

To enable efficient raster processing on large datasets without exceeding memory limits, this PR introduces generic multiprocessing functions within `geoutils`. These functions allow users to apply any processing function to raster data using a tiling approach with overlap handling. The approach minimizes memory usage by processing tiles separately and writing results directly to disk.

## Features

This PR introduces the following key functions:

- `map_overlap_multiproc_save`: This function divides the input raster into overlapping tiles, processes them in parallel using
    multiprocessing, and writes the processed results to an output raster file.
- `map_multiproc_collect`: This function splits an input raster into overlapping tiles, processes them in parallel, and returns the results as a list. It is intended for cases where `func` does *not* return a `Raster`, but instead returns arbitrary values (e.g., numerical statistics, feature extractions, etc.).
- `apply_func_block`: A helper function that loads a specific raster tile, applies the provided function, and removes padding to avoid edge effects.
- `load_raster_tile`: Loads a specific tile from a raster based on given bounding box coordinates.
- `remove_tile_padding`: Removes extra padding from tiles after processing to mitigate edge artifacts.
- `MultiprocConfig`: Configuration class for handling multiprocessing parameters.

These functions are designed to be generic and reusable for various raster-processing tasks.

## Tests

To ensure the correctness of these functions, tests have been implemented:
- Running `map_multiproc` with a simple function (Raster.copy()) to verify that tiles are processed correctly and raster is not loaded during processing.
- Verifying that `load_raster_tile` load the right tile.
- Verifying that padding removal correctly restores tile boundaries without artifacts.
- Ensuring that multiprocessing runs correctly across different tile sizes and clusters.

## Documentation
A documentation page has been written to explain how to use these generic multiprocessing functions, and they have been added to the API.

## Example Usage

A basic example demonstrating the usage of `map_overlap_multiproc_save` with a simple function (`Raster.copy()`):

```{code-cell} ipython3
# Input raster path
input_raster_path = "path/to/large_raster.tif"

# Define function to apply to the raster
cast_nodata=True
def copy_func(r: RasterType, cast_nodata: bool) -> RasterType:
    return r.copy(cast_nodata=cast_nodata)

# Define config for multiprocessing:
config = MultiprocConfig(
    chunk_size=200, 
    outfile = "path/to/output_raster.tif", 
    cluster=ClusterGenerator("multi", nb_workers=4)
)

# Run multiprocessing with the copy function
map_overlap_multiproc_save(
    copy_func, 
    raster_path, 
    config,
    cast_nodata,
    depth=0
)
```