### PR TITLE
Fix pip CI checks and remove `distutils` implicit dependency

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -29,11 +29,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: |
-            **/setup.cfg
-            **/requirements*.txt
-
+          
       # Use pip install
       - name: Install project
         run: python -m pip install -e .

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/setup.cfg
+            **/requirements*.txt
 
       # Use pip install
       - name: Install project

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -26,23 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # We initiate the environment empty
-      - name: Initiate empty environment
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
-          auto-update-conda: true
-          use-mamba: true
-          mamba-version: "2.0.5"
-          channel-priority: strict
-          activate-environment: geoutils-pip
           python-version: ${{ matrix.python-version }}
 
       # Use pip install
       - name: Install project
-        run: |
-          mamba install pip
-          pip install -e .
+        run: pip install -e .
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -18,18 +18,13 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12"]
 
-    # Run all shells using bash (including Windows)
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       # Use pip install
       - name: Install project
         run: python -m pip install -e .

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Use pip install
       - name: Install project
-        run: pip install -e .
+        run: python -m pip install -e .
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -105,7 +105,7 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
-        flag-name: run-${{ matrix.test_number }}
+        flag-name: run-${{ join(matrix.*, '-') }}
         path-to-lcov: coverage.info
         parallel: true
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload to Coveralls finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -19,10 +19,10 @@
 """Utility functions to download and find example data."""
 
 import os
+import shutil
 import tarfile
 import tempfile
 import urllib.request
-import shutil
 
 # Define the location of the data in the example directory
 _EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples/data"))

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -19,10 +19,10 @@
 """Utility functions to download and find example data."""
 
 import os
-import shutil
 import tarfile
 import tempfile
 import urllib.request
+from distutils.dir_util import copy_tree
 
 # Define the location of the data in the example directory
 _EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples/data"))
@@ -87,7 +87,7 @@ def download_examples(overwrite: bool = False) -> None:
             )
 
             # Copy the temporary extracted data to the example directory.
-            shutil.copytree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
+            copy_tree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
 
 
 def get_path(name: str) -> str:

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -22,7 +22,7 @@ import os
 import tarfile
 import tempfile
 import urllib.request
-from distutils.dir_util import copy_tree
+import shutil
 
 # Define the location of the data in the example directory
 _EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples/data"))
@@ -87,7 +87,7 @@ def download_examples(overwrite: bool = False) -> None:
             )
 
             # Copy the temporary extracted data to the example directory.
-            copy_tree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
+            shutil.copytree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name))
 
 
 def get_path(name: str) -> str:


### PR DESCRIPTION
Moves environment setup to `actions/setup-python` in pip CI.
Removes `distutils` usage, replaced by `shutil`.
(Also fixes a small inconsistency in version usage and run number for Coveralls).

Resolves #674 