### PR TITLE
Modify `nmad` to match with xDEM usage

### DIFF
--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -20,7 +20,7 @@
 GeoUtils is a Python package for the analysis of geospatial data.
 """
 
-from geoutils import examples, pointcloud, projtools, raster, vector  # noqa
+from geoutils import examples, pointcloud, projtools, raster, stats, vector  # noqa
 from geoutils._config import config  # noqa
 from geoutils.raster import Mask, Raster  # noqa
 from geoutils.vector import Vector  # noqa

--- a/geoutils/stats.py
+++ b/geoutils/stats.py
@@ -17,12 +17,12 @@
 # limitations under the License.
 
 """ Statistical tools"""
-
 from typing import Any
 
 import numpy as np
 
 from geoutils._typing import NDArrayNum
+from geoutils.raster.array import get_array_and_mask
 
 
 def nmad(data: NDArrayNum, nfact: float = 1.4826) -> np.floating[Any]:
@@ -38,8 +38,10 @@ def nmad(data: NDArrayNum, nfact: float = 1.4826) -> np.floating[Any]:
     :returns nmad: (normalized) median absolute deviation of data.
     """
     if isinstance(data, np.ma.masked_array):
-        return nfact * np.ma.median(np.abs(data - np.ma.median(data)))
-    return nfact * np.nanmedian(np.abs(data - np.nanmedian(data)))
+        data_arr = get_array_and_mask(data)[0]
+    else:
+        data_arr = np.asarray(data)
+    return nfact * np.nanmedian(np.abs(data_arr - np.nanmedian(data_arr)))
 
 
 def linear_error(data: NDArrayNum, interval: float = 90) -> np.floating[Any]:


### PR DESCRIPTION
Resolves GlacioHack/xdem#715.

- In xDEM usage, the nmad can be use on masked array where nan values are not always masked. In this cases the `np.ma.median` is not working.

- Adding `stats` in `__init__`.
