### PR TITLE
Handle Masks in `map_overlap_multiproc_save`

### DIFF
--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -19,6 +19,7 @@
 """Process out-of-memory calculations"""
 from __future__ import annotations
 
+import logging
 import tempfile
 from typing import Any, Callable, Literal, overload
 
@@ -252,12 +253,12 @@ def _write_multiproc_result(
 
                 # Write the processed tile to the appropriate location in the output file
                 dst.write(data, window=dst_window)
-            print(f"Raster saved under {config.outfile}")
-            if is_mask:
-                return gu.Mask(config.outfile)
-            return gu.Raster(config.outfile)
+            logging.warning(f"Raster saved under {config.outfile}")
         except Exception as e:
             raise RuntimeError(f"Error retrieving terrain attribute from multiprocessing tasks: {e}")
+    if is_mask:
+        return gu.Mask(config.outfile)
+    return gu.Raster(config.outfile)
 
 
 @overload

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -234,6 +234,7 @@ def _write_multiproc_result(
             # Iterate over the tasks and retrieve the processed tiles
             for results in tasks:
                 result_tile, dst_tile = config.cluster.get_res(results)
+                is_mask = isinstance(result_tile, gu.Mask)
 
                 # Define the window in the output file where the tile should be written
                 dst_window = rio.windows.Window(
@@ -252,6 +253,8 @@ def _write_multiproc_result(
                 # Write the processed tile to the appropriate location in the output file
                 dst.write(data, window=dst_window)
             print(f"Raster saved under {config.outfile}")
+            if is_mask:
+                return gu.Mask(config.outfile)
             return gu.Raster(config.outfile)
         except Exception as e:
             raise RuntimeError(f"Error retrieving terrain attribute from multiprocessing tasks: {e}")

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -152,6 +152,7 @@ def _apply_func_block(
     elif isinstance(result_tile, tuple) and isinstance(result_tile[0], gu.Raster):
         _remove_tile_padding((raster.height, raster.width), result_tile[0], tile, depth)
 
+    # If the raster is a mask, convert to uint8 before saving and force nodata to 255
     if isinstance(result_tile, gu.Mask):
         result_tile.astype("uint8", inplace=True)
         result_tile.set_nodata(255)

--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -152,6 +152,10 @@ def _apply_func_block(
     elif isinstance(result_tile, tuple) and isinstance(result_tile[0], gu.Raster):
         _remove_tile_padding((raster.height, raster.width), result_tile[0], tile, depth)
 
+    if isinstance(result_tile, gu.Mask):
+        result_tile.astype("uint8", inplace=True)
+        result_tile.set_nodata(255)
+
     return result_tile, tile
 
 
@@ -220,12 +224,10 @@ def map_overlap_multiproc_save(
 def _write_multiproc_result(
     tasks: list[Any],
     config: MultiprocConfig,
-    file_metadata: dict[str, Any] | None = None,
+    file_metadata: dict[str, Any],
 ) -> gu.Raster:
 
     # Create a new raster file to save the processed results
-    if file_metadata is None:
-        file_metadata = {}
     with rio.open(config.outfile, "w", driver=config.driver, **file_metadata) as dst:
         try:
             # Iterate over the tasks and retrieve the processed tiles

--- a/tests/test_raster/test_distributing_computing/test_multiproc.py
+++ b/tests/test_raster/test_distributing_computing/test_multiproc.py
@@ -46,6 +46,12 @@ def _custom_func_stats(raster: RasterType) -> dict[str, floating[Any]]:
     return raster.get_stats(stats_name=["mean", "valid_count"])
 
 
+# Define a simple function which return a Mask
+def _custom_func_mask(raster: RasterType) -> gu.Mask:
+    mask_array = raster.get_mask()
+    return gu.Mask.from_array(mask_array, raster.transform, raster.crs)
+
+
 class TestMultiproc:
     aster_dem_path = examples.get_path("exploradores_aster_dem")
     landsat_rgb_path = examples.get_path("everest_landsat_rgb")
@@ -141,6 +147,11 @@ class TestMultiproc:
         output_raster = map_overlap_multiproc_save(_custom_func, raster, config, addition, factor, depth=depth)
         output_raster_saved = Raster(config.outfile)
         assert output_raster_saved.raster_equal(output_raster)
+
+        if raster.count == 1:
+            # With a wrapper returning a Mask
+            output_mask = map_overlap_multiproc_save(_custom_func_mask, raster, config, depth=depth)
+            assert np.array_equal(raster.get_mask(), output_mask.data)
 
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])  # type: ignore
     @pytest.mark.parametrize("tile_size", [100, 200])  # type: ignore


### PR DESCRIPTION
When the output of `map_overlap_multiproc_save` is a `Mask`, it is converted to uint8, with a nodata of 255 so that it can be saved via rasterio.