### PR TITLE
Use automatic `packages.find` listing to avoid forgetting `setuptools` modules

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -26,12 +26,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install project
-        run: |
-          outputs=$(python -m pip install -e . -vv 2>&1)
-          echo $outputs
-          
+        run: python -m pip install -e . -vv | tee pip.txt
+
       - name: Check no package is missing in setup.cfg
-        run: if [[ $output == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
+        run: |
+          outputs = $(cat pip.txt)
+          if [[  == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -33,10 +33,6 @@ jobs:
       - name: Check no package is missing in setup.cfg
         run: if [[ $output == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
 
-        uses: actions/github-script@v7
-        with:
-          script: core.setFailed('Missing packages not declared in setup.cfg!')
-
       # Check import works
       - name: Check import works with base environment
         run: python -c "import geoutils"

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check no package is missing in setup.cfg
         run: |
           outputs=$(cat pip.txt)
-          if [[  == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
+          if [[ $outputs == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check no package is missing in setup.cfg
         run: |
-          outputs = $(cat pip.txt)
+          outputs=$(cat pip.txt)
           if [[  == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
 
       # Check import works

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           outputs=$(python -m pip install -e . -vv 2>&1)
           echo $outputs
-          if [[ $output == *"Package would be ignored"* ]]; then echo "::error title=Package-ignored::See pip warning"; fi;
+          if [[ $outputs == *"Package would be ignored"* ]]; then echo "::error title=Missing-package-in-setup-cfg::See pip warning"; fi;
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -32,12 +32,12 @@ jobs:
           outputs=$(python -m pip install -e . -vv 2>&1)
           echo $outputs
           
-      - name: Check not package is ignored
-        if: $outputs == *"Package would be ignored"*
-        uses: actions/github-script@v3
+      - name: Check no package is missing in setup.cfg
+        run: if [[ $output == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
+
+        uses: actions/github-script@v7
         with:
-          script: |
-            core.setFailed('Missing packages not declared in setup.cfg!')
+          script: core.setFailed('Missing packages not declared in setup.cfg!')
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -26,12 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install project
-        run: python -m pip install -e . -vv | tee pip.txt
-
-      - name: Check no package is missing in setup.cfg
-        run: |
-          outputs=$(cat pip.txt)
-          if [[ $outputs == *"Package would be ignored"* ]]; then echo "::error title=MISSING-PACKAGES::Missing packages in setup.cfg"; exit 1; fi;
+        run: python -m pip install . -vv
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -31,7 +31,13 @@ jobs:
         run: |
           outputs=$(python -m pip install -e . -vv 2>&1)
           echo $outputs
-          if [[ $outputs == *"Package would be ignored"* ]]; then echo "::error title=Missing-package-in-setup-cfg::See pip warning"; fi;
+          
+      - name: Check not package is ignored
+        if: $outputs == *"Package would be ignored"*
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Missing packages not declared in setup.cfg!')
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -26,8 +26,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # Use pip install
+      # Raise error if pip warns incomplete package list in setup.cfg is ignored to avoid failure in the conda feedstock
       - name: Install project
-        run: python -m pip install -e .
+        run: |
+          outputs=$(python -m pip install -e . -vv 2>&1)
+          echo $outputs
+          if [[ $output == *"Package would be ignored"* ]]; then echo "::error title=Package-ignored::See pip warning"; fi;
 
       # Check import works
       - name: Check import works with base environment

--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Use pip install
-      # Raise error if pip warns incomplete package list in setup.cfg is ignored to avoid failure in the conda feedstock
       - name: Install project
         run: |
           outputs=$(python -m pip install -e . -vv 2>&1)

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -49,7 +49,7 @@ jobs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ env.cache_date }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
       env:
-        CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 1 # Increase this value to reset cache if environment.yml has not changed
       id: cache
 
     # The trick below is necessary because the generic environment file does not specify a Python version, and ONLY

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -49,7 +49,7 @@ jobs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ env.cache_date }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
       env:
-        CACHE_NUMBER: 1 # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
       id: cache
 
     # The trick below is necessary because the generic environment file does not specify a Python version, and ONLY
@@ -96,7 +96,7 @@ jobs:
         conda list
 
     - name: Test with pytest
-      run: pytest -ra --cov=geoutils/
+      run: python -m pytest -ra --cov=geoutils/
 
     - name: Converting coverage to LCOV format
       run: coveragepy-lcov --data_file_path .coverage --output_file_path coverage.info

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -96,7 +96,7 @@ jobs:
         conda list
 
     - name: Test with pytest
-      run: python -m pytest -ra --cov=geoutils/
+      run: pytest -ra --cov=geoutils/
 
     - name: Converting coverage to LCOV format
       run: coveragepy-lcov --data_file_path .coverage --output_file_path coverage.info

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,6 @@ download_url = https://pypi.org/project/geoutils/
 
 [options]
 packages = find:
-package_dir =
-    =geoutils
 scripts = bin/geoviewer.py
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
@@ -46,8 +44,9 @@ geoutils =
     py.typed
 
 [options.packages.find]
-where = geoutils
-include = *
+include =
+    geoutils
+    geoutils.*
 
 [options.extras_require]
 opt =

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description = Analysis and handling of georeferenced rasters and vectors
 keywords = raster, vector, geospatial, gis, xarray
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = Apache 2.0
+license = Apache-2.0
 license_files = LICENSE
 platform = any
 classifiers =
@@ -14,7 +14,6 @@ classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     Natural Language :: English
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: GIS
     Topic :: Scientific/Engineering :: Image Processing
@@ -31,6 +30,8 @@ download_url = https://pypi.org/project/geoutils/
 
 [options]
 packages = find:
+package_dir =
+    =geoutils
 scripts = bin/geoviewer.py
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
@@ -45,12 +46,8 @@ geoutils =
     py.typed
 
 [options.packages.find]
-include =
-    geoutils
-    geoutils.raster
-    geoutils.vector
-    geoutils.interface
-    geoutils.pointcloud
+where = geoutils
+include = *
 
 [options.extras_require]
 opt =


### PR DESCRIPTION
It's impossible to flag the warning from pip in CI, so the best solution was to simply automatize the finding of packages, given that anything we have under `geoutils/` is always a package meant to be distributed.

Additionally, `setuptools` was raising a `DeprecationWarning` for using a classifier for the license, saying to remove it and correct the license code with the SPDX identifier: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

Resolves #686 