### PR TITLE
Move `filter.py` from xDEM to GeoUtils and integrate into `raster` class

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -96,6 +96,7 @@ documentation.
     Raster.proximity
     Raster.interp_points
     Raster.reduce_points
+    Raster.filter
 ```
 
 ### Plotting

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -370,6 +370,32 @@ Both {func}`~geoutils.Raster.reduce_points` and {func}`~geoutils.Raster.interp_p
 {class}`list` of coordinates.
 ```
 
+## Filter
+Filtering a {class}`~geoutils.Raster` is done through the {func}`~geoutils.Raster.filter` function.
+The following filters are available:
+
+| Filter Name | Description                                                                             | Typical Effect                                                  |
+|:------------|:----------------------------------------------------------------------------------------|:----------------------------------------------------------------|
+| `gaussian`  | Applies a Gaussian (blur) filter with a specified sigma.                                | Smooths the image, reduces noise while slightly blurring edges. |
+| `median`    | Applies a median filter over a sliding window.                                          | Reduces noise while preserving edges better than Gaussian.      |
+| `mean`      | Applies a mean (average) filter with a specified kernel size.                           | Smooths the image uniformly, reduces high-frequency noise.      |
+| `max`       | Applies a maximum filter over a sliding window.                                         | Enhances bright regions, expands high-intensity areas.          |
+| `min`       | Applies a minimum filter over a sliding window. | Suppresses bright regions, expands dark regions. |
+| `distance`  | Removes pixels that deviate strongly from local neighborhood average (within a radius). | Removes outliers and anomalous values based on local context.   |
+
+You can also pass a hand-made filter function for numpy arrays
+
+```{code-cell} ipython3
+# Filter the raster with a gaussian kernel
+rast_filtered = rast.filter("gaussian", sigma=5)
+
+# Filter the raster with a hand-made filter
+def double_filter(arr: np.ndarray) -> np.ndarray:
+    return arr * 2
+
+rast_double = rast.filter(double_filter)
+```
+
 ## Export
 
 A {class}`~geoutils.Raster` can be exported to different formats, to facilitate inter-compatibility with different packages and code versions.

--- a/geoutils/__init__.py
+++ b/geoutils/__init__.py
@@ -20,7 +20,15 @@
 GeoUtils is a Python package for the analysis of geospatial data.
 """
 
-from geoutils import examples, pointcloud, projtools, raster, stats, vector  # noqa
+from geoutils import (  # noqa
+    examples,
+    filters,
+    pointcloud,
+    projtools,
+    raster,
+    stats,
+    vector,
+)
 from geoutils._config import config  # noqa
 from geoutils.raster import Mask, Raster  # noqa
 from geoutils.vector import Vector  # noqa

--- a/geoutils/filters.py
+++ b/geoutils/filters.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2025 GeoUtils developers
+# Copyright (c) 2025 Centre National d'Etudes Spatiales (CNES)
+#
+# This file is part of the GeoUtils project:
+# https://github.com/glaciohack/geoutils
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Filters to remove outliers and reduce noise in rasters."""
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import scipy
+
+from geoutils._typing import NDArrayNum
+
+
+def _filter(array: NDArrayNum, method: str | Callable[..., NDArrayNum], **kwargs: dict[str, Any]) -> NDArrayNum:
+    """
+    Apply a filter to the array. See description of raster.filter.
+    """
+    if isinstance(method, str):
+        filter_map: dict[str, Callable[..., NDArrayNum]] = {
+            "gaussian": gaussian_filter,
+            "median": median_filter,
+            "mean": mean_filter,
+            "max": max_filter,
+            "min": min_filter,
+            "distance": distance_filter,
+        }
+
+        if method not in filter_map:
+            raise ValueError(f"Unsupported filter method '{method}'. " f"Available methods: {list(filter_map.keys())}")
+
+        filter_func = filter_map[method]
+
+    elif callable(method):
+        filter_func = method
+    else:
+        raise TypeError("`method` must be a string or a callable.")
+
+    # Apply filter
+    filtered_data = filter_func(array, **kwargs)
+    return filtered_data
+
+
+def _nan_safe_filter(array: NDArrayNum, filter_func: Callable[..., NDArrayNum], **kwargs: Any) -> NDArrayNum:
+    """Apply a NaN-safe filter using a weighting trick."""
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    # In case array does not contain NaNs, use scipy's gaussian filter directly
+    if not np.isnan(array).any():
+        return filter_func(array, **kwargs)
+
+    # If array contain NaNs, need a more sophisticated approach
+    # Inspired by https://stackoverflow.com/a/36307291
+    # Run filter on the array with NaNs set to 0
+    array_filled = np.nan_to_num(array, nan=0.0)
+    weights = (~np.isnan(array)).astype(array_filled.dtype)
+
+    filtered_array_filled = filter_func(array_filled, **kwargs)
+    del array_filled
+
+    weight_sum = filter_func(weights, **kwargs)
+    del weights
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="invalid value encountered")
+        filtered_array = filtered_array_filled / weight_sum
+
+    return filtered_array
+
+
+def gaussian_filter(array: NDArrayNum, sigma: float) -> NDArrayNum:
+    """
+    Apply a Gaussian filter to a raster that may contain NaNs, using scipy's implementation.
+    gaussian_filter_cv is recommended as it is usually faster, but this depends on the value of sigma.
+
+    N.B: kernel_size is set automatically based on sigma.
+
+    :param array: the input array to be filtered.
+    :param sigma: the sigma of the Gaussian kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    return _nan_safe_filter(array, scipy.ndimage.gaussian_filter, sigma=sigma)
+
+
+def median_filter(array: NDArrayNum, **kwargs: Any) -> NDArrayNum:
+    """
+    Apply a median filter to a raster that may contain NaNs, using scipy's implementation.
+
+    :param array: the input array to be filtered.
+
+    :returns: the filtered array (same shape as input).
+    """
+    return _nan_safe_filter(array, scipy.ndimage.median_filter, **kwargs)
+
+
+def mean_filter(array: NDArrayNum, kernel_size: int, **kwargs: Any) -> NDArrayNum:
+    """
+    Apply a mean filter to a raster that may contain NaNs.
+
+    :param array: the input array to be filtered.
+    :param kernel_size: the size of the kernel.
+
+    :returns: the filtered array (same shape as input).
+    """
+    # Check that array dimension is 2
+    if np.ndim(array) not in [2]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D array.")
+    kernel = np.ones((kernel_size, kernel_size)) / kernel_size**2
+    return _nan_safe_filter(array, scipy.ndimage.convolve, weights=kernel, **kwargs)
+
+
+def min_filter(array: NDArrayNum, **kwargs: Any) -> NDArrayNum:
+    """
+    Apply a minimum filter to a raster that may contain NaNs, using scipy's implementation.
+
+    :param array: the input array to be filtered.
+
+    :returns: the filtered array (same shape as input).
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by infinite values during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, np.inf, array)
+    array_nans_replaced_f = scipy.ndimage.minimum_filter(array_nans_replaced, **kwargs)
+    # In the end we want the filtered array without infinite values, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
+
+
+def max_filter(array: NDArrayNum, **kwargs: Any) -> NDArrayNum:
+    """
+    Apply a maximum filter to a raster that may contain NaNs, using scipy's implementation.
+
+    :param array: the input array to be filtered.
+
+    :returns: the filtered array (same shape as input).
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by negative infinite values during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, -np.inf, array)
+    array_nans_replaced_f = scipy.ndimage.maximum_filter(array_nans_replaced, **kwargs)
+    # In the end we want the filtered array without negative infinite values, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
+
+
+def distance_filter(array: NDArrayNum, radius: float, outlier_threshold: float) -> NDArrayNum:
+    """
+    Filter out pixels whose value is distant more than a set threshold from the average value of all neighbor \
+pixels within a given radius.
+    Filtered pixels are set to NaN.
+
+    TO DO: Add an option on how the "average" value should be calculated, i.e. using a Gaussian, median etc filter.
+
+    :param array: the input array to be filtered.
+    :param radius: the radius in which the average value is calculated (for Gaussian filter, this is sigma).
+    :param outlier_threshold: the minimum difference abs(array - mean) for a pixel to be considered an outlier.
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Calculate the average value within the radius
+    smooth = gaussian_filter(array, sigma=radius)
+
+    # Filter outliers
+    outliers = (np.abs(array - smooth)) > outlier_threshold
+    out_array = np.copy(array)
+    out_array[outliers] = np.nan
+
+    return out_array
+
+
+def generic_filter(
+    array: NDArrayNum, filter_function: Callable[..., NDArrayNum], **kwargs: dict[Any, Any]
+) -> NDArrayNum:
+    """
+    Apply a filter from a function.
+
+    :param array: the input array to be filtered.
+    :param filter_function: the function of the filter.
+
+    :returns: the filtered array (same shape as input).
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    return scipy.ndimage.generic_filter(array, filter_function, **kwargs)

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -3560,7 +3560,7 @@ class Raster:
         """
         Apply a filter to the array.
 
-        :param method: The filter to apply. Can be a string ("gaussian", "median", "mean", "max", "distance")
+        :param method: The filter to apply. Can be a string ("gaussian", "median", "mean", "max", "min", "distance")
                        for built-in filters, or a custom callable that takes a 2D ndarray and returns one.
         :param inplace: Whether to modify the raster in-place.
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,187 @@
+"""Functions to test the filtering tools."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+import geoutils as gu
+from geoutils._typing import NDArrayNum
+from geoutils.raster import get_array_and_mask
+
+
+class TestFilters:
+    """Test cases for the filter functions."""
+
+    # Load example data.
+    landsat_dem = gu.Raster(gu.examples.get_path("everest_landsat_b4")).astype(np.float32)
+    aster_dem_path = gu.examples.get_path("exploradores_aster_dem")
+
+    def test_gauss(self) -> None:
+        """Test applying the various Gaussian filters on rasters with/without NaNs"""
+
+        # Test applying scipy's Gaussian filter
+        # smoothing should not yield values below.above original DEM
+        raster_array = get_array_and_mask(self.landsat_dem)[0]
+        raster_sm = gu.filters.gaussian_filter(raster_array, sigma=5)
+        assert np.min(raster_array) <= np.min(raster_sm)
+        assert np.max(raster_array) >= np.max(raster_sm)
+        assert raster_array.shape == raster_sm.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.landsat_dem.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.landsat_dem.height - 1, size=nan_count, dtype=int)
+        raster_with_nans = np.copy(self.landsat_dem.data).squeeze()
+        raster_with_nans[rows, cols] = np.nan
+
+        raster_sm = gu.filters.gaussian_filter(raster_with_nans, sigma=10)
+        assert np.nanmin(raster_with_nans) <= np.min(raster_sm)
+        assert np.nanmax(raster_with_nans) >= np.max(raster_sm)
+
+        # Test that it works with 3D arrays
+        array_3d = np.vstack((raster_array[np.newaxis, :], raster_array[np.newaxis, :]))
+        raster_sm = gu.filters.gaussian_filter(array_3d, sigma=5)
+        assert array_3d.shape == raster_sm.shape
+
+        # Tests that it fails with 1D arrays with appropriate error
+        data = raster_array[:, 0]
+        pytest.raises(ValueError, gu.filters.gaussian_filter, data, sigma=5)
+
+    def test_dist_filter(self) -> None:
+        """Test that distance_filter works"""
+
+        # Calculate dDEM
+        ddem = self.landsat_dem.copy()
+
+        # Add random outliers
+        count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.landsat_dem.width - 1, size=count, dtype=int)
+        rows = rng.integers(0, high=self.landsat_dem.height - 1, size=count, dtype=int)
+        ddem.data[rows, cols] = 5000
+
+        # Filter gross outliers
+        filtered_ddem = gu.filters.distance_filter(ddem.data, radius=20, outlier_threshold=50)
+
+        # Check that all outliers were properly filtered
+        assert np.all(np.isnan(filtered_ddem[rows, cols]))
+
+        # Assert that non filtered pixels remain the same
+        assert ddem.data.shape == filtered_ddem.shape
+        assert np.all(ddem.data[np.isfinite(filtered_ddem)] == filtered_ddem[np.isfinite(filtered_ddem)])
+
+        # Check that it works with NaNs too
+        ddem.data[rows[:500], cols[:500]] = np.nan
+        filtered_ddem = gu.filters.distance_filter(ddem.data, radius=20, outlier_threshold=50)
+        assert np.all(np.isnan(filtered_ddem[rows, cols]))
+
+    @pytest.mark.parametrize(
+        "name, filter_func",
+        [
+            ("median", lambda arr: gu.filters.median_filter(arr, **{"size": 5})),  # type:ignore
+            ("mean", lambda arr: gu.filters.mean_filter(arr, kernel_size=5)),  # type:ignore
+            ("min", lambda arr: gu.filters.min_filter(arr, **{"size": 5})),  # type:ignore
+            ("max", lambda arr: gu.filters.max_filter(arr, **{"size": 5})),  # type:ignore
+        ],
+    )
+    def test_filters(self, name: str, filter_func: Callable[[NDArrayNum], NDArrayNum]) -> None:
+        """Test that all the filters applied on rasters with/without NaNs, work"""
+        raster_array = get_array_and_mask(self.landsat_dem)[0]
+        raster_filtered = filter_func(raster_array)
+
+        if name in ("median", "mean"):
+            assert np.min(raster_array) <= np.min(raster_filtered)
+            assert np.max(raster_array) >= np.max(raster_filtered)
+        elif name == "min":
+            assert np.min(raster_array) == np.min(raster_filtered)
+            assert np.max(raster_array) >= np.max(raster_filtered)
+        elif name == "max":
+            assert np.min(raster_array) <= np.min(raster_filtered)
+            assert np.max(raster_array) == np.max(raster_filtered)
+
+        assert raster_array.shape == raster_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.landsat_dem.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.landsat_dem.height - 1, size=nan_count, dtype=int)
+        raster_with_nans = np.copy(raster_array).squeeze()
+        raster_with_nans[rows, cols] = np.nan
+
+        raster_with_nans_filtered = filter_func(raster_with_nans)
+        if name in ("median", "mean"):
+            # smoothing should not yield values below.above original DEM
+            assert np.nanmin(raster_with_nans) <= np.nanmin(raster_with_nans_filtered)
+            # assert np.nanmax(raster_with_nans) >= np.nanmax(raster_with_nans_filtered)
+            assert np.min(raster_filtered) == np.nanmin(raster_with_nans_filtered)
+            # assert np.max(raster_filtered) == np.nanmax(raster_with_nans_filtered)
+        elif name == "min":
+            assert np.nanmin(raster_with_nans) == np.nanmin(raster_with_nans_filtered)
+            assert np.min(raster_filtered) == np.nanmin(raster_with_nans_filtered)
+            assert np.nanmax(raster_with_nans) >= np.nanmax(raster_with_nans_filtered)
+        elif name == "max":
+            assert np.nanmin(raster_with_nans) <= np.nanmin(raster_with_nans_filtered)
+            assert np.nanmax(raster_with_nans) == np.nanmax(raster_with_nans_filtered)
+            assert np.max(raster_filtered) == np.nanmax(raster_with_nans_filtered)
+
+        # Test that it works with 3D arrays
+        if name != "mean":
+            array_3d = np.vstack((raster_array[np.newaxis, :], raster_array[np.newaxis, :]))
+            raster_filtered = filter_func(array_3d)
+            assert array_3d.shape == raster_filtered.shape
+
+            # Tests that it fails with 1D arrays with appropriate error
+            data = raster_array[:, 0]
+            pytest.raises(ValueError, filter_func, data)
+
+    def test_generic_filter(self) -> None:
+        """Test that the generic filter applied on rasters works"""
+
+        raster_array = get_array_and_mask(self.landsat_dem)[0]
+        raster_filtered = gu.filters.generic_filter(raster_array, np.nanmin, **{"size": 5})  # type:ignore
+
+        assert np.nansum(raster_array) != np.nansum(raster_filtered)
+
+    @pytest.mark.parametrize(  # type: ignore
+        "method, kwargs",
+        [
+            ("gaussian", {"sigma": 1}),
+            ("median", {"size": 3}),
+            ("mean", {"kernel_size": 3}),
+            ("max", {"size": 3}),
+            ("min", {"size": 3}),
+        ],
+    )
+    def test_raster_filter(self, method: str, kwargs: dict[str, int]) -> None:
+        raster = gu.Raster(self.aster_dem_path)
+        filtered_raster = raster.filter(method, inplace=False, **kwargs)
+        assert isinstance(filtered_raster, gu.Raster)
+        assert filtered_raster.shape == raster.shape
+
+    def test_raster_filter_callable(self) -> None:
+        def double_filter(arr: NDArrayNum) -> NDArrayNum:
+            return arr * 2
+
+        raster = gu.Raster(self.aster_dem_path)
+        filtered = raster.filter(double_filter, inplace=False)
+        expected_raster = raster.copy()
+        expected_raster.data *= 2
+        assert filtered.raster_equal(expected_raster)
+
+    def test_raster_filter_inplace(self) -> None:
+        raster = gu.Raster(self.aster_dem_path)
+        filtered_raster = raster.copy()
+        filtered_raster.filter("gaussian", sigma=0, inplace=True)
+        assert raster.raster_equal(filtered_raster)
+
+    def test_raster_filter_invalid(self) -> None:
+        raster = gu.Raster(self.aster_dem_path)
+        with pytest.raises(ValueError, match="Unsupported filter method"):
+            raster.filter("unknown_filter")
+        with pytest.raises(TypeError, match="`method` must be a string or a callable"):
+            raster.filter(12345, inplace=False)


### PR DESCRIPTION
Resolves #690.

## Context

The current `filter.py` module in **xDEM** provides a collection of filters that are highly useful for digital elevation models (DEMs). However, these filtering utilities are not intrinsically tied to elevation data—they are generally applicable to any geospatial raster data. Given this, it makes more architectural sense for them to live in **GeoUtils**.

## Changes
- Moved the `filter.py` module from `xdem/` to `geoutils/filters.py`.
- Removed `gaussian_filter_cv` to avoid dependence on opencv.
- Moved `tests/test_filter.py` in xDEM to `tests/test_filters.py` in GeoUtils.
- Added a new function `_nan_safe_filter` common for gaussian, mean and median filter, to deal with arrays containing nan values.
- Added a generic `_filter` function mapping the available filters.
- Added the `Raster.filter` method that extracts the array with Nans, uses the `_filter` function, and rebuild the Raster data.

 ## Tests
- Added new tests for the `Raster.filter` method.

## Documentation
- Added a `filter` section in `raster_class.md`.

## Note
When this ticket is approved, a linked PR to remove filters in xDEM will be opened.