### PR TITLE
Add input checks for tiling

### DIFF
--- a/geoutils/raster/distributed_computing/multiproc.py
+++ b/geoutils/raster/distributed_computing/multiproc.py
@@ -255,7 +255,7 @@ def _write_multiproc_result(
                 dst.write(data, window=dst_window)
             logging.warning(f"Raster saved under {config.outfile}")
         except Exception as e:
-            raise RuntimeError(f"Error retrieving terrain attribute from multiprocessing tasks: {e}")
+            raise RuntimeError(f"Error retrieving raster tiles from multiprocessing tasks: {e}")
     if is_mask:
         return gu.Mask(config.outfile)
     return gu.Raster(config.outfile)

--- a/geoutils/raster/tiling.py
+++ b/geoutils/raster/tiling.py
@@ -155,6 +155,11 @@ def _generate_tiling_grid(
     :return: A numpy array grid with splits in two dimensions (0: row, 1: column),
              where each cell contains [row_min, row_max, col_min, col_max].
     """
+    if overlap < 0:
+        raise ValueError(f"Overlap negative : {overlap}, must be positive")
+    if not isinstance(overlap, int):
+        raise TypeError(f"Overlap : {overlap}, must be an integer")
+
     # Calculate the total range of rows and columns
     col_range = col_max - col_min
     row_range = row_max - row_min
@@ -203,6 +208,9 @@ def compute_tiling(
     :param ref_shape: The shape of another raster to coregister, use to validate the shape.
     :param overlap: Size of overlap between tiles (optional).
     :return: tiling_grid (array of tile boundaries).
+
+    :raises ValueError: if overlap is negative.
+    :raises TypeError: if overlap is not an integer.
     """
     if raster_shape != ref_shape:
         raise Exception("Reference and secondary rasters do not have the same shape")

--- a/tests/test_raster/test_tiling.py
+++ b/tests/test_raster/test_tiling.py
@@ -105,3 +105,9 @@ class TestTiling:
 
         for col in range(nb_col_tiles - 1):
             assert tiling_grid[0, col + 1, 2] == tiling_grid[0, col, 3] - 2 * overlap
+
+    def test_tiling_overlap_errors(self) -> None:
+        with pytest.raises(ValueError):
+            _generate_tiling_grid(0, 0, 100, 100, 50, 50, -1)
+        with pytest.raises(TypeError):
+            _generate_tiling_grid(0, 0, 100, 100, 50, 50, 0.5)  # type: ignore


### PR DESCRIPTION
- Added error message if the overlap in the tiling is negative/not an integer, added tests.
- Fix error message in `_write_multiproc_result`.
