### PR TITLE
Remove geom_almost_equal from Geopandas

### DIFF
--- a/geoutils/vector/vector.py
+++ b/geoutils/vector/vector.py
@@ -494,10 +494,6 @@ class Vector:
         return self._override_gdf_output(self.ds.geom_equals(other=other.ds, align=align))
 
     @copy_doc(gpd.GeoSeries, "Vector", replace_return_series_statement=True)
-    def geom_almost_equals(self, other: Vector, decimal: int = 6, align: bool = True) -> pd.Series:
-        return self._override_gdf_output(self.ds.geom_almost_equals(other=other.ds, decimal=decimal, align=align))
-
-    @copy_doc(gpd.GeoSeries, "Vector", replace_return_series_statement=True)
     def geom_equals_exact(
         self,
         other: Vector,

--- a/tests/test_vector/test_vector.py
+++ b/tests/test_vector/test_vector.py
@@ -162,7 +162,6 @@ class TestGeoPandasMethods:
     nongeo_methods = [
         "contains",
         "geom_equals",
-        "geom_almost_equals",
         "geom_equals_exact",
         "crosses",
         "disjoint",


### PR DESCRIPTION
I remove the wrapper for geom_almost_equal because this function doesn't exist anymore in geopandas

Resolves #700