### PR TITLE
Fix Dask memory test for `subsample`

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1,<3
   - scipy=1.*
   - tqdm
-  - xarray
+  - xarray>2023,<=2025.04
   - dask
   - rioxarray=0.*
   - affine

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1,<3
   - scipy=1.*
   - tqdm
-  - xarray
+  - xarray>2023,<=2025.04
   - dask
   - rioxarray=0.*
   - affine

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pandas>=1,<3
 numpy>=1,<3
 scipy==1.*
 tqdm
-xarray
+xarray>2023,<=2025.04
 dask
 rioxarray==0.*
 affine

--- a/tests/test_raster/test_distributing_computing/test_dask.py
+++ b/tests/test_raster/test_distributing_computing/test_dask.py
@@ -96,8 +96,8 @@ def _estimate_subsample_memusage(darr: da.Array, chunksizes_in_mem: tuple[int, i
 
     # Final estimate of memory usage of operation in MB
     max_op_memusage = fac_dask_margin * (chunk_memusage + sample_memusage + out_memusage + meta_memusage) / (2**20)
-    # We add a base memory usage of ~80 MB + 10MB per 1000 chunks (loaded in background by Dask even on tiny data)
-    max_op_memusage += 80 + 10 * (num_chunks / 1000)
+    # We add a base memory usage of ~130 MB + 10MB per 1000 chunks (loaded in background by Dask even on tiny data)
+    max_op_memusage += 130 + 10 * (num_chunks / 1000)
 
     return max_op_memusage
 


### PR DESCRIPTION
Has been broken recently in CI, because the base memory fluctuates depending on OS type and runner.

Looks like the new version of Xarray breaks Rioxarray and thus us. 
Need to pin down the max version for now.

Resolves #692 