### PR TITLE
Add IQR stat  + pytest correction with lazy_fixtures

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,20 +22,20 @@ This file keeps track of authors contributions.
 
 ## Contributors
 
-- **Marine Bouchet** [@marinebcht](https://github.com/marinebcht)
-
 ---
 
 - **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
 - **Eli Schwat** [@elischwat](https://github.com/elischwat)
-- **Valentin Schaffner** [@vschaffn](https://github/vschaffn) <valentin.schaffner@cs-soprasteria.com>
+- **Valentin Schaffner** [@vschaffn](https://github/vschaffn)
 - **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
+- **Marine Bouchet** [@marinebcht](https://github.com/marinebcht)
 - **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
 - **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
 - **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
 - **Adrien Wehrlé** [@AdrienWehrle](https://github.com/AdrienWehrle)
 - **Fabien Maussion** [@fmaussion](https://github.com/fmaussion)
 - **Johannes Landmann** [@jlandmann](https://github/jlandmann)
+
 
 Update here with new contributors.
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,9 +19,10 @@ This file keeps track of authors contributions.
 - **Amaury Dehecq** [@adehecq](https://github/adehecq)
 - **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
 - **Andrew Tedstone** [@atedstone](https://github/atedstone)
-- **Marine Bouchet** [@marinebcht](https://github/marinebcht)
 
 ## Contributors
+
+- **Marine Bouchet** [@marinebcht](https://github.com/marinebcht)
 
 ---
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@ This file keeps track of authors contributions.
 - **Amaury Dehecq** [@adehecq](https://github/adehecq)
 - **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
 - **Andrew Tedstone** [@atedstone](https://github/atedstone)
+- **Marine Bouchet** [@marinebcht](https://github/marinebcht)
 
 ## Contributors
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,7 +25,7 @@ dependencies:
 
   # Test dependencies
   - gdal  # To test functionalities against GDAL
-  - pytest
+  - pytest=7.*
   - pytest-xdist
   - pytest-lazy-fixtures
   - pyyaml

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - gdal  # To test functionalities against GDAL
   - pytest=7.*
   - pytest-xdist
-  - pytest-lazy-fixture
+  - pytest-lazy-fixtures
   - pyyaml
   - flake8
   - pylint

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,7 +25,7 @@ dependencies:
 
   # Test dependencies
   - gdal  # To test functionalities against GDAL
-  - pytest=7.*
+  - pytest
   - pytest-xdist
   - pytest-lazy-fixtures
   - pyyaml

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -404,7 +404,8 @@ Supported statistics are :
 - **Sum:** sum of all data, ignoring masked values.
 - **Sum of squares:** sum of the squares of all data, ignoring masked values.
 - **90th percentile:** point below which 90% of the data falls, ignoring masked values.
-- **LE90 (Linear Error with 90% confidence):** Difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
+- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset.
+- **LE90 (Linear Error with 90% confidence):** difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
 - **Std (Standard deviation):** measures the spread or dispersion of the data around the mean, ignoring masked values.

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -404,7 +404,7 @@ Supported statistics are :
 - **Sum:** sum of all data, ignoring masked values.
 - **Sum of squares:** sum of the squares of all data, ignoring masked values.
 - **90th percentile:** point below which 90% of the data falls, ignoring masked values.
-- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset.
+- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset, ignoring masked values.
 - **LE90 (Linear Error with 90% confidence):** difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1926,7 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
-            "IQR": stats.iqr(mdata, nan_policy="omit"), # ignore masked value (nan)
+            "IQR": stats.iqr(mdata, nan_policy="omit"),  # ignore masked value (nan)
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1926,7 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
-            "IQR": stats.iqr(mdata, nan_policy="omit"),
+            "IQR": stats.iqr(mdata, nan_policy="omit"), # ignore masked value (nan)
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -47,6 +47,7 @@ from packaging.version import Version
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.plot import show as rshow
+from scipy import stats
 
 from geoutils._config import config
 from geoutils._typing import (
@@ -1925,6 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
+            "IQR": stats.iqr(mdata, nan_policy="omit"),
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),
@@ -1986,7 +1988,7 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
             Accepted names include:
-            `mean`, `median`, `max`, `min`, `sum`, `sum of squares`, `90th percentile`, `LE90`, `nmad`, `rmse`,
+            `mean`, `median`, `max`, `min`, `sum`, `sum of squares`, `90th percentile`, `iqr`, `LE90`, `nmad`, `rmse`,
             `std`, `valid count`, `total count`, `percentage valid points` and if an inlier mask is passed :
             `valid inlier count`, `total inlier count`, `percentage inlier point`, `percentage valid inlier points`.
             Custom callables can also be provided.
@@ -2023,6 +2025,7 @@ class Raster:
             "sum2": "Sum of squares",
             "90thpercentile": "90th percentile",
             "90percentile": "90th percentile",
+            "iqr": "IQR",
             "le90": "LE90",
             "nmad": "NMAD",
             "rmse": "RMSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8",
+    "setuptools_scm[toml]>=8,<9.2",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8,<9.2",
+    "setuptools_scm[toml]>=8,<9.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ test =
     gdal
     pytest
     pytest-xdist
-    pytest-lazy-fixture
+    pytest-lazy-fixtures
     pyyaml
     flake8
     pylint

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -11,6 +11,7 @@ import numpy as np
 import pyproj
 import pytest
 import rasterio as rio
+from pytest_lazy_fixtures import lf as lazy_fixtures
 
 import geoutils as gu
 from geoutils import examples
@@ -158,10 +159,10 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_different_crs"),
-            pytest.lazy_fixture("images_3d"),
-            pytest.lazy_fixture("images_nodata_zero"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_different_crs"),
+            lazy_fixtures("images_3d"),
+            lazy_fixtures("images_nodata_zero"),
         ],
     )  # type: ignore
     def test_stack_rasters(self, rasters) -> None:  # type: ignore
@@ -252,9 +253,9 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_3d"),
-            pytest.lazy_fixture("images_different_crs"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_3d"),
+            lazy_fixtures("images_different_crs"),
         ],
     )  # type: ignore
     def test_merge_rasters(self, rasters) -> None:  # type: ignore
@@ -311,8 +312,8 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_3d"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_3d"),
         ],
     )  # type: ignore
     def test_merge_rasters__errors(self, rasters) -> None:

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1959,6 +1959,7 @@ class TestRaster:
             "Sum",
             "Sum of squares",
             "90th percentile",
+            "IQR",
             "LE90",
             "NMAD",
             "RMSE",

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2032,6 +2032,7 @@ class TestRaster:
         mdata = np.ma.filled(raster.data.astype(float), np.nan)
         assert raster.get_stats(stats_name="iqr") == np.nanpercentile(mdata, 75) - np.nanpercentile(mdata, 25)
 
+
 class TestMask:
     # Paths to example data
     landsat_b4_path = examples.get_path("everest_landsat_b4")

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2028,6 +2028,9 @@ class TestRaster:
             assert isnan(stat)
         assert "Statistic name '80 percentile' is not recognized" in caplog.text
 
+        # IQR (scipy) validation with numpy
+        mdata = np.ma.filled(raster.data.astype(float), np.nan)
+        assert raster.get_stats(stats_name="iqr") == np.nanpercentile(mdata, 75) - np.nanpercentile(mdata, 25)
 
 class TestMask:
     # Paths to example data


### PR DESCRIPTION
This PR proposes to add the IQR (Interquartile Range) to the statistical information (dict) of a raster.

1. SciPy was choosen over Numpy :

- IQR function is already implemented in scipy.stats ([here](https://docs.scipy.org/doc/scipy-1.16.0/reference/generated/scipy.stats.iqr.html))
- This function is faster than recompute it with Numpy 

 ```
# Raster exploradores_aster_dem
Numpy) 0.011367651999535155 sec
iqr = 530.6628723144531
Scipy) 0.0081036680003308 sec
iqr = 530.6628723144531 

# List 1M values
Numpy) 0.14357674500024586 sec
iqr = 499999.5
Scipy) 0.07437301699974341 sec
iqr = 499999.5 
```
2. The computation no need to be outsourced in another fonction (like others np metrics or rmse at worst).

By the way, it replaces the obsolete pytest-lazyfixture with the new (working with Pytest > 8.0.0 and maintained) variant pytest-lazy-fixtures.

 - [x] Resolves #716 
 - [x] Tests: tests/test_raster/test_multiraster.py passes now + iqr test (with scipy) and the presence of the new stat in test_raster.py:test_stats
 - [x] Docs: add IQR to the stats list in raster_class.md
 - [x] Deps: pytest-lazyfixture replaced by pytest-lazyfixtures in `dev-environment.yml` and `setup.cfg`

