### PR TITLE
710 inlier mask get stats

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,9 +19,10 @@ This file keeps track of authors contributions.
 - **Amaury Dehecq** [@adehecq](https://github/adehecq)
 - **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
 - **Andrew Tedstone** [@atedstone](https://github/atedstone)
-- **Marine Bouchet** [@marinebcht](https://github/marinebcht)
 
 ## Contributors
+
+- **Marine Bouchet** [@marinebcht](https://github.com/marinebcht)
 
 ---
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@ This file keeps track of authors contributions.
 - **Amaury Dehecq** [@adehecq](https://github/adehecq)
 - **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
 - **Andrew Tedstone** [@atedstone](https://github/atedstone)
+- **Marine Bouchet** [@marinebcht](https://github/marinebcht)
 
 ## Contributors
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,7 +25,7 @@ dependencies:
 
   # Test dependencies
   - gdal  # To test functionalities against GDAL
-  - pytest
+  - pytest=7.*
   - pytest-xdist
   - pytest-lazy-fixtures
   - pyyaml

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - gdal  # To test functionalities against GDAL
   - pytest=7.*
   - pytest-xdist
-  - pytest-lazy-fixture
+  - pytest-lazy-fixtures
   - pyyaml
   - flake8
   - pylint

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,7 +25,7 @@ dependencies:
 
   # Test dependencies
   - gdal  # To test functionalities against GDAL
-  - pytest=7.*
+  - pytest
   - pytest-xdist
   - pytest-lazy-fixtures
   - pyyaml

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -404,7 +404,8 @@ Supported statistics are :
 - **Sum:** sum of all data, ignoring masked values.
 - **Sum of squares:** sum of the squares of all data, ignoring masked values.
 - **90th percentile:** point below which 90% of the data falls, ignoring masked values.
-- **LE90 (Linear Error with 90% confidence):** Difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
+- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset.
+- **LE90 (Linear Error with 90% confidence):** difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.
 - **Std (Standard deviation):** measures the spread or dispersion of the data around the mean, ignoring masked values.

--- a/doc/source/raster_class.md
+++ b/doc/source/raster_class.md
@@ -404,7 +404,7 @@ Supported statistics are :
 - **Sum:** sum of all data, ignoring masked values.
 - **Sum of squares:** sum of the squares of all data, ignoring masked values.
 - **90th percentile:** point below which 90% of the data falls, ignoring masked values.
-- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset.
+- **IQR (Interquartile Range):** difference between the 75th and 25th percentile of a dataset, ignoring masked values.
 - **LE90 (Linear Error with 90% confidence):** difference between the 95th and 5th percentiles of a dataset, representing the range within which 90% of the data points lie. Ignore masked values.
 - **NMAD (Normalized Median Absolute Deviation):** robust measure of variability in the data, less sensitive to outliers compared to standard deviation. Ignore masked values.
 - **RMSE (Root Mean Square Error):** commonly used to express the magnitude of errors or variability and can give insight into the spread of the data. Only relevant when the raster represents a difference of two objects. Ignore masked values.

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1926,7 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
-            "IQR": stats.iqr(mdata, nan_policy="omit"), # ignore masked value (nan)
+            "IQR": stats.iqr(mdata, nan_policy="omit"),  # ignore masked value (nan)
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1926,7 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
-            "IQR": stats.iqr(mdata, nan_policy="omit"),
+            "IQR": stats.iqr(mdata, nan_policy="omit"), # ignore masked value (nan)
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1992,9 +1992,11 @@ class Raster:
             `std`, `valid count`, `total count`, `percentage valid points` and if an inlier mask is passed :
             `valid inlier count`, `total inlier count`, `percentage inlier point`, `percentage valid inlier points`.
             Custom callables can also be provided.
-        :param inlier_mask: A boolean mask to filter values for statistical calculations.
+        :param inlier_mask: A boolean mask to filter values for statistical calculations, with 1/True pixels used for
+            calculating the statistics
         :param band: The index of the band for which to compute statistics. Default is 1.
-        :param counts: (number of finite data points in the array, number of valid points in inlier_mask). DO NOT USE.
+        :param counts: (number of finite data points in the array, number of valid points (1/True, meaning "to keep")
+            in inlier_mask). DO NOT USE.
         :returns: The requested statistic or a dictionary of statistics if multiple or all are requested.
         """
         if not self.is_loaded:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2002,11 +2002,11 @@ class Raster:
         if inlier_mask is not None:
             valid_points = np.count_nonzero(~self.get_mask())
             if isinstance(inlier_mask, Mask):
-                inlier_points = np.count_nonzero(~inlier_mask.data)
+                inlier_points = np.count_nonzero(inlier_mask.data)
             else:
-                inlier_points = np.count_nonzero(~inlier_mask)
+                inlier_points = np.count_nonzero(inlier_mask)
             dem_masked = self.copy()
-            dem_masked.set_mask(inlier_mask)
+            dem_masked.set_mask(~inlier_mask)
             return dem_masked.get_stats(stats_name=stats_name, band=band, counts=(valid_points, inlier_points))
         stats_dict = self._statistics(band=band, counts=counts)
         if stats_name is None:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -47,6 +47,7 @@ from packaging.version import Version
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.plot import show as rshow
+from scipy import stats
 
 from geoutils._config import config
 from geoutils._typing import (
@@ -1925,6 +1926,7 @@ class Raster:
             "Sum": np.ma.sum(data),
             "Sum of squares": np.ma.sum(np.square(data)),
             "90th percentile": np.nanpercentile(mdata, 90),
+            "IQR": stats.iqr(mdata, nan_policy="omit"),
             "LE90": linear_error(mdata, interval=90),
             "NMAD": nmad(data),
             "RMSE": np.sqrt(np.ma.mean(np.square(data))),
@@ -1986,7 +1988,7 @@ class Raster:
 
         :param stats_name: Name or list of names of the statistics to retrieve. If None, all statistics are returned.
             Accepted names include:
-            `mean`, `median`, `max`, `min`, `sum`, `sum of squares`, `90th percentile`, `LE90`, `nmad`, `rmse`,
+            `mean`, `median`, `max`, `min`, `sum`, `sum of squares`, `90th percentile`, `iqr`, `LE90`, `nmad`, `rmse`,
             `std`, `valid count`, `total count`, `percentage valid points` and if an inlier mask is passed :
             `valid inlier count`, `total inlier count`, `percentage inlier point`, `percentage valid inlier points`.
             Custom callables can also be provided.
@@ -2023,6 +2025,7 @@ class Raster:
             "sum2": "Sum of squares",
             "90thpercentile": "90th percentile",
             "90percentile": "90th percentile",
+            "iqr": "IQR",
             "le90": "LE90",
             "nmad": "NMAD",
             "rmse": "RMSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8",
+    "setuptools_scm[toml]>=8,<9.2",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8,<9.2",
+    "setuptools_scm[toml]>=8,<9.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ test =
     gdal
     pytest
     pytest-xdist
-    pytest-lazy-fixture
+    pytest-lazy-fixtures
     pyyaml
     flake8
     pylint

--- a/tests/test_raster/test_multiraster.py
+++ b/tests/test_raster/test_multiraster.py
@@ -11,6 +11,7 @@ import numpy as np
 import pyproj
 import pytest
 import rasterio as rio
+from pytest_lazy_fixtures import lf as lazy_fixtures
 
 import geoutils as gu
 from geoutils import examples
@@ -158,10 +159,10 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_different_crs"),
-            pytest.lazy_fixture("images_3d"),
-            pytest.lazy_fixture("images_nodata_zero"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_different_crs"),
+            lazy_fixtures("images_3d"),
+            lazy_fixtures("images_nodata_zero"),
         ],
     )  # type: ignore
     def test_stack_rasters(self, rasters) -> None:  # type: ignore
@@ -252,9 +253,9 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_3d"),
-            pytest.lazy_fixture("images_different_crs"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_3d"),
+            lazy_fixtures("images_different_crs"),
         ],
     )  # type: ignore
     def test_merge_rasters(self, rasters) -> None:  # type: ignore
@@ -311,8 +312,8 @@ class TestMultiRaster:
     @pytest.mark.parametrize(
         "rasters",
         [
-            pytest.lazy_fixture("images_1d"),
-            pytest.lazy_fixture("images_3d"),
+            lazy_fixtures("images_1d"),
+            lazy_fixtures("images_3d"),
         ],
     )  # type: ignore
     def test_merge_rasters__errors(self, rasters) -> None:

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1959,6 +1959,7 @@ class TestRaster:
             "Sum",
             "Sum of squares",
             "90th percentile",
+            "IQR",
             "LE90",
             "NMAD",
             "RMSE",

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1985,7 +1985,7 @@ class TestRaster:
             assert isinstance(stats.get(name), stat_types)
 
         # With mask
-        inlier_mask = raster.get_mask()
+        inlier_mask = ~raster.get_mask()
         stats_masked = raster.get_stats(inlier_mask=inlier_mask)
         for name in expected_stats_mask:
             assert name in stats_masked
@@ -1994,9 +1994,10 @@ class TestRaster:
         assert stats_masked == stats
 
         # Empty mask
-        empty_mask = np.ones_like(inlier_mask)
+        empty_mask = np.zeros_like(inlier_mask)
         with caplog.at_level(logging.WARNING):
             stats_masked = raster.get_stats(inlier_mask=empty_mask)
+        print(stats_masked)
         assert "Empty raster, returns Nan for all stats" in caplog.text
         for name in expected_stats + expected_stats_mask:
             assert np.isnan(stats_masked.get(name))

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2032,6 +2032,7 @@ class TestRaster:
         mdata = np.ma.filled(raster.data.astype(float), np.nan)
         assert raster.get_stats(stats_name="iqr") == np.nanpercentile(mdata, 75) - np.nanpercentile(mdata, 25)
 
+
 class TestMask:
     # Paths to example data
     landsat_b4_path = examples.get_path("everest_landsat_b4")

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -2028,6 +2028,9 @@ class TestRaster:
             assert isnan(stat)
         assert "Statistic name '80 percentile' is not recognized" in caplog.text
 
+        # IQR (scipy) validation with numpy
+        mdata = np.ma.filled(raster.data.astype(float), np.nan)
+        assert raster.get_stats(stats_name="iqr") == np.nanpercentile(mdata, 75) - np.nanpercentile(mdata, 25)
 
 class TestMask:
     # Paths to example data


### PR DESCRIPTION
Resolves #710 

[Raster.get_stats()](https://github.com/GlacioHack/geoutils/blob/main/geoutils/raster/raster.py#L1974) and its usage seems a bit confusing. 

Currently : 

```
#  (A) Mask = True 
Mean: nan
Total inlier count: nan/9

#  (B) Mask = False 
Mean: 0.4444444444444444
Total inlier count: 9/9

# (V) Random Maks 
Array: [[102 220 225]
        [ 95 179  61]
        [234 203  92]]
Mask: [[False  True  True]
       [ True False False]
       [False False  True]]
Number of true Values in the mask: 4/9
Mean: 155.8
Total inlier count: 5/9
```

If we set True for pixels that are used for calculating the statistics: 

In case (A), the mask is fully set to True, so ALL the pixels need to be keep : 
- [ ] Total inlier count = 9
- [ ] Mean != null 

In case (B), the mask is fully set to False, so ZERO pixels need to be keep :
- [ ] Total inlier count = 0 
- [ ] Mean = null 

In case (C), the mask has 4 True values, so 4 pixels need to be keep :
- [ ] Total inlier count = 4
- [ ] Mean = (220 + 225 + 95 + 92)/4 = 158.0

#######################

To correct "Total inlier count": 
`inlier_points = np.count_nonzero(~inlier_mask.data)` change to `inlier_points = np.count_nonzero(inlier_mask.data)` to compute all 1/True values

To correct the pixels to mask before statitistics computation : 
`dem_masked.set_mask(inlier_mask)` change to `dem_masked.set_mask(~inlier_mask)` to mask all pixels where the mask = False

#######################

To adapt the inversion signification of True/False values in the mask, two lines needed a change in the tests : 
- an empty mask is the mask full of zeros (L1997)
- inversion of the mask raster.get_mask() to list pixel with data to True (L1988)

