### PR TITLE
fix: messy inlier mask True/False signification

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -1992,7 +1992,8 @@ class Raster:
             Custom callables can also be provided.
         :param inlier_mask: A boolean mask to filter values for statistical calculations.
         :param band: The index of the band for which to compute statistics. Default is 1.
-        :param counts: (number of finite data points in the array, number of valid points in inlier_mask). DO NOT USE.
+        :param counts: (number of finite data points in the array, number of valid points (=True, to keep)
+            in inlier_mask). DO NOT USE.
         :returns: The requested statistic or a dictionary of statistics if multiple or all are requested.
         """
         if not self.is_loaded:
@@ -2000,11 +2001,11 @@ class Raster:
         if inlier_mask is not None:
             valid_points = np.count_nonzero(~self.get_mask())
             if isinstance(inlier_mask, Mask):
-                inlier_points = np.count_nonzero(~inlier_mask.data)
+                inlier_points = np.count_nonzero(inlier_mask.data)
             else:
-                inlier_points = np.count_nonzero(~inlier_mask)
+                inlier_points = np.count_nonzero(inlier_mask)
             dem_masked = self.copy()
-            dem_masked.set_mask(inlier_mask)
+            dem_masked.set_mask(~inlier_mask)
             return dem_masked.get_stats(stats_name=stats_name, band=band, counts=(valid_points, inlier_points))
         stats_dict = self._statistics(band=band, counts=counts)
         if stats_name is None:

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -1984,7 +1984,7 @@ class TestRaster:
             assert isinstance(stats.get(name), stat_types)
 
         # With mask
-        inlier_mask = raster.get_mask()
+        inlier_mask = ~raster.get_mask()
         stats_masked = raster.get_stats(inlier_mask=inlier_mask)
         for name in expected_stats_mask:
             assert name in stats_masked
@@ -1993,7 +1993,7 @@ class TestRaster:
         assert stats_masked == stats
 
         # Empty mask
-        empty_mask = np.ones_like(inlier_mask)
+        empty_mask = np.zeros_like(inlier_mask)
         with caplog.at_level(logging.WARNING):
             stats_masked = raster.get_stats(inlier_mask=empty_mask)
         assert "Empty raster, returns Nan for all stats" in caplog.text


### PR DESCRIPTION
Resolves #710 

inlier_mask usage in [Raster.get_stats()](https://github.com/GlacioHack/geoutils/blob/main/geoutils/raster/raster.py#L1976) seems a bit confusing. 

# Problem 

Currently : 

```
#  (A) Mask = True 
Mean: nan
Total inlier count: nan/9

#  (B) Mask = False 
Mean: 0.4444444444444444
Total inlier count: 9/9

# (V) Random Maks 
Array: [[102 220 225]
		[ 95 179  61]
		[234 203  92]]
Mask: [[False  True  True]
	   [ True False False]
	   [False False  True]]
Number of true Values in the mask: 4/9
Mean: 155.8
Total inlier count: 5/9
```

If we set True for pixels that are used for calculating the statistics: 

In case (A), the mask is fully set to True, so ALL the pixels need to be keep : 
- [ ] Valid/Total inlier count = 9
- [ ] Mean != null 

In case (B), the mask is fully set to False, so ZERO pixels need to be keep :
- [ ] Valid/Total inlier count = 0 
- [ ] Mean = null 

In case (C), the mask has 4 True values, so 4 pixels need to be keep :
- [ ] Valid/Total inlier count = 4
- [ ] Mean = (220 + 225 + 95 + 92)/4 = 158.0

# Correction

To correct "Valid/Total inlier count": 
`inlier_points = np.count_nonzero(~inlier_mask.data)` change to `inlier_points = np.count_nonzero(inlier_mask.data)` to compute all 1/True values

To correct the pixels to mask before statitistics computation : 
`dem_masked.set_mask(inlier_mask)` change to `dem_masked.set_mask(~inlier_mask)` to mask all pixels where the mask = False

# Tests

To adapt the signification inversion of True/False values in the mask, two lines needed a change in the tests : 
- an empty mask is a mask full of zeros       [L1996](https://github.com/marinebcht/geoutils/blob/aa4432665c5399ea2ce9f62d6ac1498e9f73a5c3/tests/test_raster/test_raster.py#L1996)
- inversion of the mask raster.get_mask() to list pixels with data to True [L1987](https://github.com/marinebcht/geoutils/blob/aa4432665c5399ea2ce9f62d6ac1498e9f73a5c3/tests/test_raster/test_raster.py#L1987)
