### PR TITLE
Bug: initialise Raster with user-provided nodata value

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -468,7 +468,11 @@ class Raster:
 
                 self._transform = ds.transform
                 self._crs = ds.crs
-                self._nodata = ds.nodata
+                # Allow user to manually override the nodata value which may be specified in the file.
+                if nodata != None:
+                    self._nodata = nodata
+                else:
+                    self._nodata = ds.nodata
                 self._name = ds.name
                 self._driver = ds.driver
                 self._tags.update(ds.tags())

--- a/tests/test_raster/test_raster.py
+++ b/tests/test_raster/test_raster.py
@@ -100,6 +100,10 @@ class TestRaster:
         ):
             gu.Raster(1)  # type: ignore
 
+        # Test that user-provided nodata value gets set
+        r6 = gu.Raster(example, nodata=255)
+        assert r6._nodata == 255
+
     @pytest.mark.parametrize("example", [landsat_b4_path, landsat_rgb_path, aster_dem_path])  # type: ignore
     def test_repr_str(self, example: str) -> None:
         """Test the representation of a raster works"""


### PR DESCRIPTION
Resolves #727 .

In addition to the test that `self._nodata` gets set, I also visually verified that the masking with the user-provided nodata value works as expected:

```python
im = gu.Raster(gu.examples.get_path('everest_landsat_b4'), nodata=255)
im.plot()
```
All high mountain tops (e.g., snow-covered) get masked.
