### PR TITLE
Update authors, code of conduct and add governance

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,39 +11,47 @@ contributions are subject to the project's copyright under the terms of the
 
 This file keeps track of authors contributions.
 
-## Development Lead
+
+## Maintainers / Steering committee
 
 ---
 
-- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
-- **Amaury Dehecq** [@adehecq](https://github/adehecq)
-- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
-- **Andrew Tedstone** [@atedstone](https://github/atedstone)
+| Full name                        | GitHub                                     | Affiliation                    | Email                                   |
+|----------------------------------|--------------------------------------------|--------------------------------|-----------------------------------------|
+| **Romain Hugonnet**              | [@rhugonnet](https://github.com/rhugonnet) | University of Alaska Fairbanks | [📧](mailto:romain.hugonnet@gmail.com)  |
+| **Amaury Dehecq**                | [@adehecq](https://github.com/adehecq)     | Université Grenoble Alpes, IRD | N/A                                     |
+| **Andrew Tedstone**              | [@atedstone](https://github/atedstone)   | University of Lausanne      | [📧](mailto:alice.de-bardonneche-richard@cs-soprasteria.com) |
+| **Valentine Bellet**             | [@belletva](https://github.com/belletva)   | CNES (French Space Agency)     | [📧](mailto:valentine.bellet@cnes.fr)   |
+| **Alice de Bardonnèche-Richard** | [@adebardo](https://github.com/adebardo)   | CS Group                       | [📧](mailto:alice.de-bardonneche-richard@cs-soprasteria.com) |
+
+## Emeritus maintainers
+
+---
+
+| Full name                  | GitHub | Affiliation                | Email                                                        |
+|----------------------------|------|----------------------------|--------------------------------------------------------------|
+| **Erik Schytt Mannerfelt** | [@erikmannerfelt](https://github.com/erikmannerfelt) | University of Oslo         | N/A                                                          |
+| **Emmanuel Dubois**        | [@duboise-cnes](https://github.com/duboise-cnes) | CNES (French Space Agency) | [📧](mailto:emmanuel.dubois@cnes.fr)                         |
 
 ## Contributors
 
 ---
 
+- **Valentin Schaffner** [@vschaffn](https://github/vschaffn)
 - **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
 - **Eli Schwat** [@elischwat](https://github.com/elischwat)
-- **Valentin Schaffner** [@vschaffn](https://github/vschaffn)
-- **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
 - **Marine Bouchet** [@marinebcht](https://github.com/marinebcht)
-- **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
 - **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
 - **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
 - **Adrien Wehrlé** [@AdrienWehrle](https://github.com/AdrienWehrle)
 - **Fabien Maussion** [@fmaussion](https://github.com/fmaussion)
 - **Johannes Landmann** [@jlandmann](https://github/jlandmann)
 
-
-Update here with new contributors.
-
-## Original Developers/Designers/Supporters
+## Original creators
 
 ---
 
-- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet)
 - **Amaury Dehecq** [@adehecq](https://github/adehecq)
 - **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
 - **Andrew Tedstone** [@atedstone](https://github/atedstone)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -22,17 +22,17 @@ community include:
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
@@ -59,8 +59,9 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders. Please contact any or all of the repository administrators,
-either through GitHub or via their personal email addresses.
+reported to the community leaders responsible, please refer to the "Steering
+Comittee" section in [AUTHORS.md](AUTHORS.md).
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -82,15 +83,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -106,23 +107,27 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Governance Policy
+
+This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project polices,
+including the [code of conduct](./CODE_OF_CONDUCT.md) and by adding their name to the [AUTHORS.md file](./AUTHORS.md).
+
+## 1. Roles.
+
+This project may include the following roles. Additional roles may be adopted and documented by the Project.
+
+**1.1. Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating
+the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with
+the approval of the current Maintainers. All past Maintainers will be listed as an Emeritus maintainer, and may rejoin
+at any time.
+
+**1.2. Contributors**. Contributors are those that have made contributions to the Project.
+
+## 2. Decisions.
+
+**2.1. Consensus-Based Decision Making**. Projects make decisions through consensus of the Maintainers. While explicit
+agreement of all Maintainers is preferred, it is not required for consensus. Rather, the Maintainers will determine
+consensus based on their good faith consideration of a number of factors, including the dominant view of the
+Contributors and nature of support and objections. The Maintainers will document evidence of consensus in accordance
+with these requirements.
+
+**2.2. Appeal Process**. Decisions may be appealed by opening an issue and that appeal will be considered by the
+Maintainers in good faith, who will respond in writing within a reasonable time. If the Maintainers deny the appeal,
+the appeal may be brought before the Organization Steering Committee, who will also respond in writing in a reasonable
+time.
+
+## 3. How We Work.
+
+**3.1. Openness**. Participation is open to anyone who is directly and materially affected by the activity in question.
+There shall be no undue financial barriers to participation.
+
+**3.2. Balance**. The development process should balance the interests of Contributors and other stakeholders.
+Contributors from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.3. Coordination and Harmonization**. Good faith efforts shall be made to resolve potential conflicts or
+incompatibility between releases in this Project.
+
+**3.4. Consideration of Views and Objections**. Prompt consideration shall be given to the written views and
+objections of all Contributors.
+
+**3.5. Written procedures**. This governance document and other materials documenting this project's development
+process shall be available to any interested person.
+
+## 4. No Confidentiality.
+
+Information disclosed in connection with any Project activity, including but not limited to meetings, contributions,
+and submissions, is not confidential, regardless of any markings or statements to the contrary.
+
+## 5. Trademarks.
+
+Any names, trademarks, logos, or goodwill developed by and associated with the Project (the "Marks") are controlled by
+the Organization. Maintainers may only use these Marks in accordance with the Organization's trademark policy. If a
+Maintainer resigns or is removed, any rights the Maintainer may have in the Marks revert to the Organization.
+
+## 6. Amendments.
+
+Amendments to this governance policy may be made by affirmative vote of 2/3 of all Maintainers, with approval by the
+Organization's Steering Committee.
+
+---
+Part of MVG-0.1-beta.
+Made with love by GitHub. Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
This PR update the author file (mirroring https://github.com/GlacioHack/xdem/pull/776), adds the governance file (mirror of xDEM) and updates the code of conduct (moving from v2.0 to v2.1).