### PR TITLE
Update PyPI publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,11 +1,12 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package when a release is created
+# See reference: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-name: Upload package to PyPI
+name: Publish to PyPI
 
 on:
   release:
     types: [created]
+
   workflow_dispatch:
      inputs:
         reason:
@@ -14,28 +15,45 @@ on:
           default: 'testing'
 
 jobs:
-  deploy:
-
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools setuptools_scm wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      # Build package, test pip install works, then upload to PyPI with twine
-      run: |
-        python setup.py sdist bdist_wheel
-        pip install dist/*.tar.gz
-        twine upload dist/*
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish distribution to PyPI
+    # if: startsWith(github.ref, 'refs/tags/')  # Only publish to PyPI on tag pushes, required depending on trigger at the top
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/geoutils  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 version_file = "geoutils/_version.py"
 fallback_version = "0.0.1"
+# Use no-local-version by default for CI builds
+local_scheme = "no-local-version"
 
 [tool.black]
 target_version = ['py310']


### PR DESCRIPTION
This PR updates PyPI publishing to the latest recommended workflow: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
And combines it with the recommended setup by `setuptools-scm` for versioning: https://setuptools-scm.readthedocs.io/en/latest/integrations/#alternative-approaches

Mirrors https://github.com/GlacioHack/xdem/pull/807, https://github.com/GlacioHack/xdem/pull/808, https://github.com/GlacioHack/xdem/pull/809 and https://github.com/GlacioHack/xdem/pull/810

It also relies on the setup of a new "Trusted Publisher" in PyPI/GeoUtils.