### PR TITLE
Continue on error when coveralls.io is down

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -103,6 +103,7 @@ jobs:
 
     - name: Upload coverage to Coveralls
       uses: coverallsapp/github-action@v2
+      continue-on-error: true
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ join(matrix.*, '-') }}


### PR DESCRIPTION
Resolves #723 

Add continue-on-error for updating coveralls stage.

It should works but I don't know how to break coveralls.io

We should try to release on a friday at 4pm to test it

