### PR TITLE
Correct CI for python3_10 troubles

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         pkgs_conda_dev=`python -c "import geoutils; geoutils.misc.diff_environment_yml('environment.yml', 'dev-environment.yml', 'conda')"`
         pkgs_pip_dev=`python -c "import geoutils; geoutils.misc.diff_environment_yml('environment.yml', 'dev-environment.yml', 'pip')"`
-        mamba install $pkgs_conda_dev --freeze-installed
+        mamba install $pkgs_conda_dev
         if [[ "$pkgs_pip_dev" != "None" ]]; then
           pip install --user $pkgs_pip_dev
         fi


### PR DESCRIPTION
All of our PRs are blocked because of an incompatibility between Python 3.10 and Conda. I tried something that seems to work, but I don’t think it’s a good solution.

@rhugonnet what do you think ? 
