### PR TITLE
Small updates to example data path and CI

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install project with documentation dependencies
-        run: python -m pip install .[doc,opt] -vv
+        run: python -m pip install -e .[doc,opt] -vv
       - name: Sphinx build
         run: |
           cd doc
-          sphinx-build -b html source/ build/
+          sphinx-build -T -b html source/ build/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -76,12 +76,6 @@ jobs:
     - name: Check import works
       run: python -c "import geoutils"
 
-      # Stop the build if there are Python syntax errors or undefined names
-    - name: Lint with flake8
-      run: |
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
     - name: Print conda environment (for debugging)
       run: |
         conda info

--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,7 @@ doc/source/analysis_examples/
 doc/source/gen_modules/
 
 # Directories where example data is downloaded
-examples/data/
+geoutils/example_data/
 
 # Directory where myst_nb executes jupyter code
 doc/jupyter_execute/

--- a/geoutils/examples.py
+++ b/geoutils/examples.py
@@ -23,26 +23,29 @@ import shutil
 import tarfile
 import tempfile
 import urllib.request
+from importlib.resources import as_file, files
 
-# Define the location of the data in the example directory
-_EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples/data"))
+# This directory needs to be created within xdem/ so that it works for an installed package as well
+# importlib.resources.files helps take care of the relative path, no matter if package is dev-local or installed
+_EXAMPLES_DIRECTORY = files("geoutils").joinpath("example_data")
 
 # Absolute filepaths to the example files.
-_FILEPATHS_DATA = {
-    "everest_landsat_rgb": os.path.join(_EXAMPLES_DIRECTORY, "Everest_Landsat", "LE71400412000304SGS00_RGB.tif"),
-    "everest_landsat_b4": os.path.join(_EXAMPLES_DIRECTORY, "Everest_Landsat", "LE71400412000304SGS00_B4.tif"),
-    "everest_landsat_b4_cropped": os.path.join(
-        _EXAMPLES_DIRECTORY, "Everest_Landsat", "LE71400412000304SGS00_B4_cropped.tif"
-    ),
-    "everest_rgi_outlines": os.path.join(_EXAMPLES_DIRECTORY, "Everest_Landsat", "15_rgi60_glacier_outlines.gpkg"),
-    "exploradores_aster_dem": os.path.join(
-        _EXAMPLES_DIRECTORY, "Exploradores_ASTER", "AST_L1A_00303182012144228_Z.tif"
-    ),
-    "exploradores_rgi_outlines": os.path.join(
-        _EXAMPLES_DIRECTORY, "Exploradores_ASTER", "17_rgi60_glacier_outlines.gpkg"
-    ),
-    "coromandel_lidar": os.path.join(_EXAMPLES_DIRECTORY, "Coromandel_Lidar", "points.laz"),
-}
+with as_file(_EXAMPLES_DIRECTORY) as examples_directory:
+    _FILEPATHS_DATA = {
+        "everest_landsat_rgb": os.path.join(examples_directory, "Everest_Landsat", "LE71400412000304SGS00_RGB.tif"),
+        "everest_landsat_b4": os.path.join(examples_directory, "Everest_Landsat", "LE71400412000304SGS00_B4.tif"),
+        "everest_landsat_b4_cropped": os.path.join(
+            examples_directory, "Everest_Landsat", "LE71400412000304SGS00_B4_cropped.tif"
+        ),
+        "everest_rgi_outlines": os.path.join(examples_directory, "Everest_Landsat", "15_rgi60_glacier_outlines.gpkg"),
+        "exploradores_aster_dem": os.path.join(
+            examples_directory, "Exploradores_ASTER", "AST_L1A_00303182012144228_Z.tif"
+        ),
+        "exploradores_rgi_outlines": os.path.join(
+            examples_directory, "Exploradores_ASTER", "17_rgi60_glacier_outlines.gpkg"
+        ),
+        "coromandel_lidar": os.path.join(examples_directory, "Coromandel_Lidar", "points.laz"),
+    }
 
 _FILEPATHS_TEST = {
     k: os.path.join(
@@ -97,7 +100,8 @@ def download_examples(overwrite: bool = False) -> None:
             )
 
             # Copy the temporary extracted data to the example directory.
-            shutil.copytree(tmp_dir_name, os.path.join(_EXAMPLES_DIRECTORY, dir_name), dirs_exist_ok=True)
+            with as_file(_EXAMPLES_DIRECTORY) as ed:
+                shutil.copytree(tmp_dir_name, os.path.join(ed, dir_name), dirs_exist_ok=True)
 
 
 def get_path(name: str) -> str:


### PR DESCRIPTION
Mirroring updates and good practices that were required in https://github.com/GlacioHack/xdem/pull/852

This PR:
- Adds full traceback on Sphinx build, and makes the package editable during doc build to facilitate relative paths,
- Moves example data from `examples/data` to `geoutils/example_data` using `importlib.resources` for robust relative path instead of `__file__`,
- Removes duplicate `flake8` call during CI tests, as this is already covered during CI pre-commit.