### PR TITLE
Prevent automatic scalar mapping when plotting RGB images

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,10 +2161,10 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        if cmap is None and len(bands) == 1:
+        if cmap is None and isinstance(bands, int):
             # ONLY set a cmap arg for single band images
             cmap = plt.get_cmap(plt.rcParams["image.cmap"])
-        elif cmap is None and len(bands) > 1:
+        elif cmap is None and isinstance(bands, tuple):
             # Leave cmap as None for multi-band image, because if a cmap
             # is passed then imshow treats this as an instruction to apply scalar
             # mapping, which is not a desirable behaviour (it can result in color-casted
@@ -2181,6 +2181,7 @@ class Raster(RasterBase):
 
         if vmax is None:
             vmax = float(np.nanmax(data))
+
 
         # Make sure they are numbers, to avoid mpl error
         try:

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2182,7 +2182,6 @@ class Raster(RasterBase):
         if vmax is None:
             vmax = float(np.nanmax(data))
 
-
         # Make sure they are numbers, to avoid mpl error
         try:
             vmin = float(vmin)

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,8 +2161,15 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        if cmap is None:
+        if cmap is None and len(bands) == 1:
+            # ONLY set a cmap arg for single band images
             cmap = plt.get_cmap(plt.rcParams["image.cmap"])
+        elif cmap is None and len(bands) > 1:
+            # Leave cmap as None for multi-band image, because if a cmap
+            # is passed then imshow treats this as an instruction to apply scalar
+            # mapping, which is not a desirable behaviour (it can result in color-casted
+            # RGB images for example).
+            pass
         elif isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         elif isinstance(cmap, matplotlib.colors.Colormap):


### PR DESCRIPTION
Relates to prep. work for #860 . I found a bug where we are passing a `cmap` value to `plt.imshow()` when using `Raster.plot()` to plot a multi-band image (e.g. RGB). This results in `imshow()` triggering some kind of scalar remapping of the supplied data. This is not a desired automatic behaviour as we are then not in control of this remapping. In my tests I found that it brings a danger of introducing a colour contrast in some extreme images (e.g. accumulation zone of the Greenland Ice Sheet).

By passing `cmap=None` we disable this behaviour.