### PR TITLE
Improve get_stats with stats name no more (case) sensitive 

### DIFF
--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,13 +2161,16 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        if cmap is None:
-            cmap = plt.get_cmap(plt.rcParams["image.cmap"])
-        elif isinstance(cmap, str):
+        print ("cmap =", cmap)
+        print ("type bands =",  type(bands))
+        print ("default cmap", plt.rcParams["image.cmap"])
+        #if cmap is None:
+        #    cmap = plt.get_cmap(plt.rcParams["image.cmap"])
+        if isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         elif isinstance(cmap, matplotlib.colors.Colormap):
             pass
-
+        cmap = None
         # Set colorbar min/max values (needed for ScalarMappable)
         if vmin is None:
             vmin = float(np.nanmin(data))

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,16 +2161,13 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        print ("cmap =", cmap)
-        print ("type bands =",  type(bands))
-        print ("default cmap", plt.rcParams["image.cmap"])
-        #if cmap is None:
-        #    cmap = plt.get_cmap(plt.rcParams["image.cmap"])
-        if isinstance(cmap, str):
+        if cmap is None:
+            cmap = plt.get_cmap(plt.rcParams["image.cmap"])
+        elif isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         elif isinstance(cmap, matplotlib.colors.Colormap):
             pass
-        cmap = None
+
         # Set colorbar min/max values (needed for ScalarMappable)
         if vmin is None:
             vmin = float(np.nanmin(data))

--- a/geoutils/stats/stats.py
+++ b/geoutils/stats/stats.py
@@ -240,8 +240,11 @@ def _statistics(
 
         res_dict = {
             stat_name: (
-                stats_dict[get_stat_common_name(stat_name)]
-                if (get_stat_common_name(stat_name) and not callable(stats_dict[get_stat_common_name(stat_name)]))
+                stats_dict[get_stat_common_name(stat_name)]  # type: ignore
+                if (
+                    get_stat_common_name(stat_name) is not None
+                    and not callable(stats_dict[get_stat_common_name(stat_name)])  # type: ignore
+                )
                 else np.nan
             )
             for stat_name in stat_data_valid

--- a/geoutils/stats/stats.py
+++ b/geoutils/stats/stats.py
@@ -97,6 +97,8 @@ _ALIAS_STATS_LIST_MASK = {
     "percentage_inlier_points": "Percentage inlier points",
 }
 
+_ALIAS_STATS = _STATS_ALIASES | _ALIAS_STATS_LIST_MASK
+
 
 @profiler.profile("geoutils.stats.stats._statistics", memprof=True)
 def _statistics(
@@ -213,29 +215,42 @@ def _statistics(
         }
     )
 
+    if counts is not None:
+        stats_dict.update(
+            {
+                "Valid inlier count": final_count_nonzero,
+                "Total inlier count": counts[1],
+                "Percentage inlier points": (final_count_nonzero / counts[0]) * 100,
+                "Percentage valid inlier points": (final_count_nonzero / counts[1]) * 100 if counts[1] != 0 else 0,
+            }
+        )
+
+    def get_stat_common_name(stat_name):
+        if stat_name in stats_dict.keys():
+            return stat_name
+        elif "".join(stat_name.lower().split()) in _ALIAS_STATS.keys():
+            return _ALIAS_STATS["".join(stat_name.lower().split())]
+        else:
+            return None
+
     # If there are no valid data points, set all statistics to NaN
     if final_count_nonzero == 0:
         warnings.warn("Empty raster, returns Nan for all stats", category=UserWarning)
         if stats_name is None:
             stat_data_valid = STATS_LIST  # type: ignore
+            if counts is not None:
+                stat_data_valid = stat_data_valid + STATS_LIST_MASK
         else:
             stat_data_valid = stats_name  # type: ignore
+
         res_dict = {
             stat_name: (
-                stats_dict[stat_name] if (stat_name in STATS_LIST and not callable(stats_dict[stat_name])) else np.nan
+                stats_dict[get_stat_common_name(stat_name)]
+                if (get_stat_common_name(stat_name) and not callable(stats_dict[get_stat_common_name(stat_name)]))
+                else np.nan
             )
             for stat_name in stat_data_valid
         }  # type: ignore
-
-        if stats_name is not None:
-            stat_with_alias = set(stats_name).intersection(list(_STATS_ALIASES.keys()))  # type: ignore
-            if stat_with_alias:
-                for stat_name in stat_with_alias:
-                    alias = _STATS_ALIASES[stat_name]  # type: ignore
-                    if callable(stats_dict[alias]):
-                        res_dict[stat_name] = np.nan  # type: ignore
-                    else:
-                        res_dict[stat_name] = stats_dict[alias]  # type: ignore
 
     else:
         if stats_name is None:
@@ -248,17 +263,17 @@ def _statistics(
             res_dict = {}  # type: ignore
             for stat_name in stats_name:
                 # Compute stat if in stats_dict keys
-                if isinstance(stat_name, str) and stat_name in stats_dict.keys():
-                    if callable(stats_dict[stat_name]):
-                        res_dict[stat_name] = stats_dict[stat_name](data)  # type: ignore
+                if isinstance(stat_name, str):
+                    stat_common_name = get_stat_common_name(stat_name)
+                    if stat_common_name:
+                        if callable(stats_dict[stat_common_name]):
+                            res_dict[stat_name] = stats_dict[stat_common_name](data)  # type: ignore
+                        else:
+                            res_dict[stat_name] = stats_dict[stat_common_name]  # type: ignore
                     else:
-                        res_dict[stat_name] = stats_dict[stat_name]  # type: ignore
-                # Compute stat if in _STATS_ALIASES keys
-                elif isinstance(stat_name, str) and stat_name in _STATS_ALIASES.keys():
-                    if callable(stats_dict[_STATS_ALIASES[stat_name]]):
-                        res_dict[stat_name] = stats_dict[_STATS_ALIASES[stat_name]](data)  # type: ignore
-                    else:
-                        res_dict[stat_name] = stats_dict[_STATS_ALIASES[stat_name]]  # type: ignore
+                        warnings.warn("Statistic name " + stat_name + " is not recognized", category=UserWarning)
+                        res_dict[stat_name] = np.float32(np.nan)  # type: ignore
+
                 # Compute stat if callable
                 elif callable(stat_name):
                     res_dict[stat_name.__name__] = stat_name(data)  # type: ignore
@@ -269,31 +284,4 @@ def _statistics(
                         warnings.warn("Statistic name " + stat_name + " is not recognized", category=UserWarning)
                         res_dict[stat_name] = np.float32(np.nan)  # type: ignore
 
-    # If inlier mask parameter given before in get_stats() and if one of these stats is wanted
-    if counts is not None and (
-        stats_name is None
-        or list(
-            set(STATS_LIST_MASK).intersection(stats_name) or list(set(_ALIAS_STATS_LIST_MASK).intersection(stats_name))
-        )
-    ):
-        dict_c = {
-            "Valid inlier count": final_count_nonzero,
-            "Total inlier count": counts[1],
-            "Percentage inlier points": (final_count_nonzero / counts[0]) * 100,
-            "Percentage valid inlier points": (final_count_nonzero / counts[1]) * 100 if counts[1] != 0 else 0,
-        }
-
-        if stats_name is None:
-            # Add all stats
-            res_dict.update(dict_c)
-        else:
-            # Add all stats if the name is on the list
-            res_dict.update({k: dict_c[k] for k in list(set(STATS_LIST_MASK).intersection(stats_name))})
-            # and the stats from alias stats
-            res_dict.update(
-                {
-                    k: dict_c[_ALIAS_STATS_LIST_MASK[k]]
-                    for k in list(set(_ALIAS_STATS_LIST_MASK).intersection(stats_name))
-                }
-            )
     return res_dict  # type: ignore

--- a/geoutils/stats/stats.py
+++ b/geoutils/stats/stats.py
@@ -52,13 +52,9 @@ _STATS_ALIASES = {
     "rms": "RMSE",
     "std": "Standard deviation",
     "standarddeviation": "Standard deviation",
-    "standard_deviation": "Standard deviation",
     "validcount": "Valid count",
-    "valid_count": "Valid count",
     "totalcount": "Total count",
-    "total_count": "Total count",
     "percentagevalidpoints": "Percentage valid points",
-    "percentage_valid_points": "Percentage valid points",
 }  # type: ignore
 
 STATS_LIST = [
@@ -88,13 +84,9 @@ STATS_LIST_MASK = [
 
 _ALIAS_STATS_LIST_MASK = {
     "validinliercount": "Valid inlier count",
-    "valid_inlier_count": "Valid inlier count",
     "totalinliercount": "Total inlier count",
-    "total_inlier_count": "Total inlier count",
     "percentagevalidinlierpoints": "Percentage valid inlier points",
-    "percentage_valid_inlier_points": "Percentage valid inlier points",
     "percentageinlierpoints": "Percentage inlier points",
-    "percentage_inlier_points": "Percentage inlier points",
 }
 
 _ALIAS_STATS = _STATS_ALIASES | _ALIAS_STATS_LIST_MASK
@@ -152,7 +144,7 @@ def _statistics(
             Accepted names include:
             `mean`, `median`, `max`, `min`, `sum`, `sum of squares`, `90th percentile`, `iqr`, `LE90`, `nmad`, `rmse`,
             `std`, `valid count`, `total count`, `percentage valid points` and if an inlier mask is passed :
-            `valid inlier count`, `total inlier count`, `percentage inlier point`, `percentage valid inlier points`.
+            `valid inlier count`, `total inlier count`, `percentage inlier points`, `percentage valid inlier points`.
             Custom callables can also be provided.
     :param counts: Tuple with number of finite data points in array and number of valid points in inlier_mask.
 
@@ -225,11 +217,14 @@ def _statistics(
             }
         )
 
-    def get_stat_common_name(stat_name):
+    def get_stat_common_name(stat_name: str) -> str | None:
+        print(stat_name)
         if stat_name in stats_dict.keys():
             return stat_name
         elif "".join(stat_name.lower().split()) in _ALIAS_STATS.keys():
             return _ALIAS_STATS["".join(stat_name.lower().split())]
+        elif "".join(stat_name.lower().split("_")) in _ALIAS_STATS.keys():
+            return _ALIAS_STATS["".join(stat_name.lower().split("_"))]
         else:
             return None
 

--- a/tests/test_stats/test_stats.py
+++ b/tests/test_stats/test_stats.py
@@ -69,6 +69,7 @@ class TestStats:
         # Full stats
         stats = raster.get_stats()
         assert len(stats) == len(expected_stats + expected_stats_count)
+
         for name in expected_stats + expected_stats_count:
             assert name in stats
             assert isinstance(stats.get(name), stat_types)
@@ -81,6 +82,11 @@ class TestStats:
             assert name in stats_masked
             stats_masked.pop(name)
         assert stats_masked == stats
+
+        stats_masked = raster.get_stats(inlier_mask=inlier_mask)
+        for name in expected_stats + expected_stats_count + expected_stats_mask:
+            assert stats_masked[name] == raster.get_stats(stats_name=name.lower(), inlier_mask=inlier_mask)
+            assert stats_masked[name] == raster.get_stats(stats_name="".join(name.split()), inlier_mask=inlier_mask)
 
         # Empty mask (=False)
         empty_mask = np.zeros_like(inlier_mask)
@@ -109,8 +115,10 @@ class TestStats:
         assert stats_masked == 0
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning, message="Empty raster")
-            stats_masked = raster.get_stats(inlier_mask=empty_mask, stats_name="validinliercount")
-        assert stats_masked == 0
+            stats_masked = raster.get_stats(inlier_mask=inlier_mask)
+            for name in expected_stats + expected_stats_count + expected_stats_mask:
+                assert stats_masked[name] == raster.get_stats(stats_name=name.lower(), inlier_mask=inlier_mask)
+                assert stats_masked[name] == raster.get_stats(stats_name="".join(name.split()), inlier_mask=inlier_mask)
 
         # Empty DEM
         dem_empty = gu.Raster.from_array(
@@ -438,11 +446,6 @@ class TestStats:
             warnings.filterwarnings("ignore", category=UserWarning, message="New nodata.*")
             rast_crop.set_nodata(255)  # Needs to be defined for reprojection
         rast_crop_proj = rast_crop.reproject(rast, resampling=rio.warp.Resampling.nearest)
-        for data in [rast_crop_proj, rast_crop, rast]:
-            print(
-                "# data shape:", data.shape, data.shape[0] * rast_crop.shape[1], "->", len(data.to_pointcloud()["b1"])
-            )
-            print("    ", data.to_pointcloud()["b1"].min(), "to", data.to_pointcloud()["b1"].max())
         rast_crop_proj_pc = rast_crop_proj.to_pointcloud()
 
         rast_stats_crop_proj_pc = {

--- a/tests/test_stats/test_stats.py
+++ b/tests/test_stats/test_stats.py
@@ -83,10 +83,18 @@ class TestStats:
             stats_masked.pop(name)
         assert stats_masked == stats
 
+        # Test case sensitive + space/underscore possibilities
         stats_masked = raster.get_stats(inlier_mask=inlier_mask)
         for name in expected_stats + expected_stats_count + expected_stats_mask:
             assert stats_masked[name] == raster.get_stats(stats_name=name.lower(), inlier_mask=inlier_mask)
             assert stats_masked[name] == raster.get_stats(stats_name="".join(name.split()), inlier_mask=inlier_mask)
+            assert stats_masked[name] == raster.get_stats(
+                stats_name="".join(name.lower().split()), inlier_mask=inlier_mask
+            )
+            assert stats_masked[name] == raster.get_stats(stats_name="_".join(name.split()), inlier_mask=inlier_mask)
+            assert stats_masked[name] == raster.get_stats(
+                stats_name="_".join(name.lower().split()), inlier_mask=inlier_mask
+            )
 
         # Empty mask (=False)
         empty_mask = np.zeros_like(inlier_mask)


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/geoutils/issues/885 the statistic names allowed in the get_stats() method were too case-sensitives and did not match the list in the [documentation](https://geoutils.readthedocs.io/en/latest/gen_modules/geoutils.Raster.get_stats.html#geoutils.Raster.get_stats)

After a bit of cleanup in the code, we now accept all (main) possible writing of each statistics. 
For example, "Percentage inlier points" can be compute with :
- percentage inlier points (no matter the cases)
- Percentageinlierpoints, percentageinlierpoints...  (no space, no matter the cases)
- Percentage_inlier_points, percentage_inlier_points... (underscore for each space, no matter the cases)

Plus, an "s" was forgotten in the "percentage inlier points" name, in the function docstring. Now, every stat name works : 

```
list_stat_in_the_doc = ["mean", "median", "max", "min", "sum", "sum of squares", "90th percentile", "iqr", "LE90", "nmad", "rmse", "std", "valid count", "total count","percentage valid points", "valid inlier count", "total inlier count", "percentage inlier points", "percentage valid inlier points"]

raster = gu.Raster(examples.get_path_test("everest_landsat_b4"))
inlier_mask = ~raster.get_mask()

for stat in list_stat_in_the_doc :
    raster.get_stats(stats_name=stat, inlier_mask=inlier_mask))
```


