### PR TITLE
Fix interp_points returning NaN for valid points on non-square rasters

### DIFF
--- a/geoutils/interface/interpolation.py
+++ b/geoutils/interface/interpolation.py
@@ -718,12 +718,8 @@ def _interp_points(
 
         i, j = _xy2ij(x, y, transform=transform, area_or_point=area_or_point, shift_area_or_point=shift_area_or_point)
 
-        # Get index of points outside of bounds
-        ind_outofbounds: NDArrayBool = np.vectorize(
-            lambda k1, k2: _outside_bounds(
-                k1, k2, transform=transform, area_or_point=area_or_point, shape=shape, index=True
-            )
-        )(j, i)
+        # Get index of points outside of bounds (i = row index vs shape[0], j = column index vs shape[1])
+        ind_outofbounds: NDArrayBool = (i < 0) | (j < 0) | (i >= shape[0]) | (j >= shape[1])
 
         # If all points fell outside of bounds
         if np.count_nonzero(~ind_outofbounds) == 0:

--- a/tests/test_interface/test_interpolation.py
+++ b/tests/test_interface/test_interpolation.py
@@ -249,6 +249,36 @@ class TestInterpolate:
             assert all(~np.isfinite(raster_points_mapcoords_edge))
             assert all(~np.isfinite(raster_points_interpn_edge))
 
+    @pytest.mark.parametrize("shape", [(3, 7), (7, 3)])  # landscape and portrait exercise different bounds axes
+    def test_interp_points__nonsquare(self, shape: tuple[int, int]) -> None:
+        """
+        Regression test: interp_points must not drop valid points on a non-square raster.
+
+        The buggy out-of-bounds mask compared the row index against the number of columns and the column
+        index against the number of rows (axes swapped), so points whose index exceeded the smaller raster
+        dimension were wrongly flagged as out-of-bounds and returned as NaN. Square rasters hide this, so we
+        test both a landscape (rows < cols) and a portrait (rows > cols) raster, which exercise the two axes
+        independently.
+        """
+        nrows, ncols = shape
+        # Unique value per pixel so nearest-neighbour sampling is an exact ground-truth check
+        arr = (np.arange(nrows)[:, None] * ncols + np.arange(ncols)[None, :]).astype("float32")
+        transform = rio.transform.from_bounds(0, 0, ncols, nrows, ncols, nrows)
+        raster = gu.Raster.from_array(data=arr, transform=transform, crs=None, nodata=-9999)
+        raster.set_area_or_point("Area", shift_area_or_point=False)
+
+        # Sample every pixel centre, plus one clearly out-of-bounds point, in the same call.
+        index_i, index_j = np.meshgrid(np.arange(nrows), np.arange(ncols), indexing="ij")
+        x, y = raster.ij2xy(i=index_i.ravel(), j=index_j.ravel(), shift_area_or_point=True)
+        x = np.append(x, -5.0)
+        y = np.append(y, -5.0)
+        vals = raster.interp_points((x, y), method="nearest", shift_area_or_point=True, as_array=True)
+
+        # Every valid pixel centre is finite and equals its pixel value; the out-of-bounds point stays NaN
+        assert np.all(np.isfinite(vals[:-1]))
+        np.testing.assert_allclose(vals[:-1], raster.get_nanarray()[index_i.ravel(), index_j.ravel()])
+        assert not np.isfinite(vals[-1])
+
     @pytest.mark.parametrize("example", [landsat_b4_path, aster_dem_path])
     @pytest.mark.parametrize(
         "method", ["nearest", "linear", "cubic", "quintic", "slinear", "pchip", "splinef2d"]


### PR DESCRIPTION
## Bug
`Raster.interp_points` silently returns NaN for valid interior points on any non-square raster. The
out-of-bounds mask compared the **row** index against the number of **columns** and the **column** index
against the number of **rows** (axes swapped), so points whose index exceeds the smaller raster dimension
were wrongly discarded. Square rasters are unaffected, which is why existing tests didn't catch it.

Reproduce (prints `67%` on `main`, `0%` on released 0.2.5):
```python
import numpy as np, geoutils as gu, rasterio as rio
nrows, ncols = 20, 60  # non-square (more columns than rows)
r = gu.Raster.from_array(
    np.ones((nrows, ncols), "float32"),
    transform=rio.transform.from_bounds(0, 0, ncols, nrows, ncols, nrows),
    crs=None, nodata=-9999,
)
r.set_area_or_point("Area", shift_area_or_point=False)
i, j = np.meshgrid(np.arange(nrows), np.arange(ncols), indexing="ij")
x, y = r.ij2xy(i=i.ravel(), j=j.ravel(), shift_area_or_point=True)
v = np.asarray(r.interp_points((x, y), as_array=True), float)
print(f"{np.mean(~np.isfinite(v)):.0%} of valid interior points are NaN")
```

## Cause
Regression from the interface restructure (#862): `_outside_bounds` changed its internal `(xi, yj)` →
`(row, col)` convention, but the `_interp_points` call site kept passing `(j, i)`, producing the swap.
Present on `main` only (released 0.2.5 is correct), so it is caught before shipping. The mask is computed
once pre-dispatch, so the in-memory, Dask and Multiprocessing backends were affected alike.

## Fix
Compute the mask with the correct axes as a vectorized comparison (which also removes a per-point
`np.vectorize` lambda — a minor speedup on large point sets):
```python
ind_outofbounds = (i < 0) | (j < 0) | (i >= shape[0]) | (j >= shape[1])
```
The sibling caller `reduce_points` already passes `(row, col)` correctly and is unaffected; only this one
call site had the swap.

## Tests
Adds `test_interp_points__nonsquare`, parametrized over landscape (rows < cols) and portrait (rows > cols)
so each raster axis is exercised; asserts every pixel centre is finite and correct, and an out-of-bounds
point stays NaN. Fails on the pre-fix code (both orientations), passes after.

---
*Disclosure: investigation and tests were assisted by an AI coding tool; all changes were reviewed and
validated by me.*
