### PR TITLE
Add option to Raster.coords to provide reprojected coordinates

### DIFF
--- a/geoutils/raster/base.py
+++ b/geoutils/raster/base.py
@@ -1448,7 +1448,7 @@ class RasterBase(ABC):
         grid: bool = True,
         shift_area_or_point: bool | None = None,
         force_offset: str | None = None,
-        dst_crs: CRS | int | None = None,
+        crs: CRS | int | None = None,
     ) -> tuple[NDArrayNum, NDArrayNum]:
         """
         Get coordinates (x,y) of all pixels in the raster.
@@ -1459,14 +1459,15 @@ class RasterBase(ABC):
             Defaults to True. Can be configured with the global setting geoutils.config["shift_area_or_point"].
         :param force_offset: Ignore pixel interpretation and force coordinate to a certain offset: "center" of pixel, or
             any corner (upper-left "ul", "ur", "ll", lr"). Default coordinate of a raster is upper-left.
-        :param dst_crs: Coordinate reference system of the coordinates wanted.
+        :param crs: Coordinate reference system in which the coordinates are provided. Defaults to CRS of
+            the input raster.
 
         :returns x,y: Arrays of the (x,y) coordinates.
         """
         dst_transform = self.transform
-        if dst_crs:
+        if crs:
             _, dst_transform, _ = _check_match_grid(
-                src=self, crs=dst_crs, ref=None, res=None, shape=None, bounds=None, coords=None
+                src=self, crs=crs, ref=None, res=None, shape=None, bounds=None, coords=None
             )
 
         return _coords(

--- a/geoutils/raster/base.py
+++ b/geoutils/raster/base.py
@@ -47,6 +47,7 @@ from rasterio.enums import Resampling
 
 from geoutils import profiler
 from geoutils._config import config
+from geoutils._dispatch import _check_match_grid
 from geoutils._misc import deprecate
 from geoutils._typing import (
     ArrayLike,
@@ -1443,7 +1444,11 @@ class RasterBase(ABC):
         )
 
     def coords(
-        self, grid: bool = True, shift_area_or_point: bool | None = None, force_offset: str | None = None
+        self,
+        grid: bool = True,
+        shift_area_or_point: bool | None = None,
+        force_offset: str | None = None,
+        dst_crs: CRS | int | None = None,
     ) -> tuple[NDArrayNum, NDArrayNum]:
         """
         Get coordinates (x,y) of all pixels in the raster.
@@ -1454,12 +1459,18 @@ class RasterBase(ABC):
             Defaults to True. Can be configured with the global setting geoutils.config["shift_area_or_point"].
         :param force_offset: Ignore pixel interpretation and force coordinate to a certain offset: "center" of pixel, or
             any corner (upper-left "ul", "ur", "ll", lr"). Default coordinate of a raster is upper-left.
+        :param dst_crs: Coordinate reference system of the coordinates wanted.
 
         :returns x,y: Arrays of the (x,y) coordinates.
         """
+        dst_transform = self.transform
+        if dst_crs:
+            _, dst_transform, _ = _check_match_grid(
+                src=self, crs=dst_crs, ref=None, res=None, shape=None, bounds=None, coords=None
+            )
 
         return _coords(
-            transform=self.transform,
+            transform=dst_transform,
             shape=self.shape,
             area_or_point=self.area_or_point,
             grid=grid,

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,13 +2161,16 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        if cmap is None:
-            cmap = plt.get_cmap(plt.rcParams["image.cmap"])
-        elif isinstance(cmap, str):
+        print ("cmap =", cmap)
+        print ("type bands =",  type(bands))
+        print ("default cmap", plt.rcParams["image.cmap"])
+        #if cmap is None:
+        #    cmap = plt.get_cmap(plt.rcParams["image.cmap"])
+        if isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         elif isinstance(cmap, matplotlib.colors.Colormap):
             pass
-
+        cmap = None
         # Set colorbar min/max values (needed for ScalarMappable)
         if vmin is None:
             vmin = float(np.nanmin(data))

--- a/geoutils/raster/raster.py
+++ b/geoutils/raster/raster.py
@@ -2161,16 +2161,13 @@ class Raster(RasterBase):
 
         # Create colorbar
         # Use rcParam default
-        print ("cmap =", cmap)
-        print ("type bands =",  type(bands))
-        print ("default cmap", plt.rcParams["image.cmap"])
-        #if cmap is None:
-        #    cmap = plt.get_cmap(plt.rcParams["image.cmap"])
-        if isinstance(cmap, str):
+        if cmap is None:
+            cmap = plt.get_cmap(plt.rcParams["image.cmap"])
+        elif isinstance(cmap, str):
             cmap = plt.get_cmap(cmap)
         elif isinstance(cmap, matplotlib.colors.Colormap):
             pass
-        cmap = None
+
         # Set colorbar min/max values (needed for ScalarMappable)
         if vmin is None:
             vmin = float(np.nanmin(data))

--- a/tests/test_raster/test_base.py
+++ b/tests/test_raster/test_base.py
@@ -14,7 +14,7 @@ from packaging.version import Version
 from pandas.testing import assert_frame_equal
 from pyproj import CRS
 
-from geoutils import Raster, Vector, open_raster
+from geoutils import Raster, Vector, examples, open_raster
 from geoutils.raster import MultiprocConfig
 from geoutils.raster.base import RasterBase
 from geoutils.raster.xr_accessor import RasterAccessor
@@ -77,6 +77,17 @@ def should_be_loaded(method: str, args: dict[str, Any], noload: list[str], noloa
         should_output_be_loaded = any_different
 
     return should_output_be_loaded
+
+
+def test_coords_crs() -> None:
+    """Test coords functions with a target crs"""
+    dem = Raster(examples.get_path_test("everest_landsat_b4"))
+    print(dem.nodata)
+    dem.set_nodata(0)
+    dem_4326 = dem.reproject(crs=4326)
+    coords_proj_4326 = dem.coords(grid=True, shift_area_or_point=None, force_offset=None, dst_crs=4326)
+    coords_4326 = dem_4326.coords(grid=True, shift_area_or_point=None, force_offset=None)
+    assert np.array_equal(coords_4326, coords_proj_4326)
 
 
 class NeedsTestError(ValueError):

--- a/tests/test_raster/test_base.py
+++ b/tests/test_raster/test_base.py
@@ -82,10 +82,9 @@ def should_be_loaded(method: str, args: dict[str, Any], noload: list[str], noloa
 def test_coords_crs() -> None:
     """Test coords functions with a target crs"""
     dem = Raster(examples.get_path_test("everest_landsat_b4"))
-    print(dem.nodata)
     dem.set_nodata(0)
     dem_4326 = dem.reproject(crs=4326)
-    coords_proj_4326 = dem.coords(grid=True, shift_area_or_point=None, force_offset=None, dst_crs=4326)
+    coords_proj_4326 = dem.coords(grid=True, shift_area_or_point=None, force_offset=None, crs=4326)
     coords_4326 = dem_4326.coords(grid=True, shift_area_or_point=None, force_offset=None)
     assert np.array_equal(coords_4326, coords_proj_4326)
 


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/geoutils/issues/886

I added the possibility to define an other target CRS `dst_crs` when you want to get coordinates (x,y) of all pixels in the raster using `Raster.coords()` function.

So now, here the function signature : 

<img width="926" height="535" alt="image" src="https://github.com/user-attachments/assets/7827c490-eaf1-47d9-a128-cbd069802730" />



