### PR TITLE
Add stats argument to `PointCloud.info()` to match that of `Raster`

### DIFF
--- a/geoutils/pointcloud/pointcloud.py
+++ b/geoutils/pointcloud/pointcloud.py
@@ -1360,6 +1360,44 @@ class PointCloud(Vector):  # type: ignore[misc]
         )
 
     @overload
+    def info(self, verbose: Literal[True] = ..., stats: bool = False) -> None: ...
+
+    @overload
+    def info(self, verbose: Literal[False], stats: bool = False) -> str: ...
+
+    def info(self, verbose: bool = True, stats: bool = False) -> None | str:
+        """
+        Print summary information about the DEM.
+
+        :param stats: Add statistics for each band of the dataset (max, min, median, mean, std. dev.). Default is to
+            not calculate statistics.
+        :param verbose: If set to True (default) will directly print to screen and return None
+
+        :returns: Summary string or None.
+        """
+
+        # Get raster.info()
+        as_str = super().info(verbose=False)  # type: ignore
+        as_str_split = as_str.split("\n")
+
+        if stats:
+            as_str_split.append("\nStatistics:")
+            statistics = self.get_stats()
+
+            # Determine the maximum length of the stat names for alignment
+            max_len = max(len(name) for name in statistics.keys())
+
+            # Format the stats with aligned names
+            for name, value in statistics.items():
+                as_str_split.append(f"{name.ljust(max_len)}: {value:.2f}")
+
+        if verbose:
+            print("\n".join(as_str_split))
+            return None
+        else:
+            return "\n".join(as_str_split)
+
+    @overload
     def get_stats(
         self,
         stats_name: str | Callable[[NDArrayNum], np.floating[Any]],

--- a/geoutils/pointcloud/pointcloud.py
+++ b/geoutils/pointcloud/pointcloud.py
@@ -1367,7 +1367,7 @@ class PointCloud(Vector):  # type: ignore[misc]
 
     def info(self, verbose: bool = True, stats: bool = False) -> None | str:
         """
-        Print summary information about the DEM.
+        Print summary information about the point cloud.
 
         :param stats: Add statistics for each band of the dataset (max, min, median, mean, std. dev.). Default is to
             not calculate statistics.
@@ -1376,9 +1376,8 @@ class PointCloud(Vector):  # type: ignore[misc]
         :returns: Summary string or None.
         """
 
-        # Get raster.info()
-        as_str = super().info(verbose=False)  # type: ignore
-        as_str_split = as_str.split("\n")
+        # Get vector.info()
+        as_str_split = super().info(verbose=False).split("\n")  # type: ignore
 
         if stats:
             as_str_split.append("\nStatistics:")

--- a/geoutils/raster/base.py
+++ b/geoutils/raster/base.py
@@ -630,22 +630,22 @@ class RasterBase(ABC):
         :returns: Summary string or None.
         """
         as_str = [
-            f"Driver:               {self.driver} \n",
-            f"Filename:             {self.name} \n",
-            f"Loaded?               {self.is_loaded} \n",
-            f"Grid size:            {self.width}, {self.height}\n",
-            f"Number of bands:      {self.count:d}\n",
-            f"Data types:           {self.dtype}\n",
-            f"Coordinate system:    {[self.crs.to_string() if self.crs is not None else None]}\n",
-            f"Nodata value:         {self.nodata}\n",
-            f"Pixel interpretation: {self.area_or_point}\n",
-            "Pixel size:           {}, {}\n".format(*self.res),
-            f"Upper left corner:    {self.bounds.left}, {self.bounds.top}\n",
-            f"Lower right corner:   {self.bounds.right}, {self.bounds.bottom}\n",
+            f"Driver:               {self.driver}",
+            f"Filename:             {self.name}",
+            f"Loaded?               {self.is_loaded}",
+            f"Grid size:            {self.width}, {self.height}",
+            f"Number of bands:      {self.count}",
+            f"Data types:           {self.dtype}",
+            f"Coordinate system:    {[self.crs.to_string() if self.crs is not None else None]}",
+            f"Nodata value:         {self.nodata}",
+            f"Pixel interpretation: {self.area_or_point}",
+            "Pixel size:           {}, {}".format(*self.res),
+            f"Upper left corner:    {self.bounds.left}, {self.bounds.top}",
+            f"Lower right corner:   {self.bounds.right}, {self.bounds.bottom}",
         ]
 
         if stats:
-            as_str.append("\nStatistics:\n")
+            as_str.append("\nStatistics:")
             if not self.is_loaded:
                 self.load()
 
@@ -657,22 +657,22 @@ class RasterBase(ABC):
 
                 # Format the stats with aligned names
                 for name, value in statistics.items():
-                    as_str.append(f"{name.ljust(max_len)}: {value:.2f}\n")
+                    as_str.append(f"{name.ljust(max_len)}: {value:.2f}")
             else:
                 for b in range(self.count):
                     # try to keep with rasterio convention.
-                    as_str.append(f"Band {b + 1}:\n")
+                    as_str.append(f"Band {b + 1}:")
                     statistics = self.get_stats(band=b)
                     if isinstance(statistics, dict):
                         max_len = max(len(name) for name in statistics.keys())
                         for name, value in statistics.items():
-                            as_str.append(f"{name.ljust(max_len)}: {value:.2f}\n")
+                            as_str.append(f"{name.ljust(max_len)}: {value:.2f}")
 
         if verbose:
-            print("".join(as_str))
+            print("\n".join(as_str))
             return None
         else:
-            return "".join(as_str)
+            return "\n".join(as_str)
 
     @overload
     def get_stats(

--- a/tests/test_pointcloud/test_pointcloud.py
+++ b/tests/test_pointcloud/test_pointcloud.py
@@ -526,6 +526,34 @@ class TestArithmetic:
 
     pc1_wrong_coords = gu.PointCloud.from_array(arr_wrong_coord, crs=crs)
 
+    def test_info(self) -> None:
+        """Test that the information summary is consistent"""
+        fn_las = gu.examples.get_path_test("coromandel_lidar")
+        pc = gu.PointCloud(fn_las)
+
+        # Check default runs without error (prints to screen)
+        output = pc.info()
+        assert output is None
+
+        # Otherwise returns info
+        output2 = pc.info(verbose=False)
+        assert isinstance(output2, str)
+        list_prints = ["Filename", "Coordinate system", "Extent", "Number of features", "Attributes"]
+        assert all(p in output2 for p in list_prints)
+
+        # Test stats param
+        nb_lines = len(output2.split("\n"))
+        output_with_stats = pc.info(stats=True, verbose=False)
+        output_with_stats_split = output_with_stats.split("\n")
+        stats = pc.get_stats()
+        nb_lines_with_stats = len(output_with_stats_split)
+        assert nb_lines + len(stats) + 2 == nb_lines_with_stats
+
+        assert output_with_stats.split("\n")[nb_lines + 1] == "Statistics:"
+        for s, stat in enumerate(stats.keys()):
+            assert output_with_stats_split[nb_lines + 2 + s].startswith(stat)
+            assert f"{stats[stat]:.2f}" in output_with_stats_split[nb_lines + 2 + s]
+
     def test_pointcloud_equal(self) -> None:
         """
         Test that pointcloud_equal() works as expected.
@@ -568,6 +596,7 @@ class TestArithmetic:
         assert pc1.georeferenced_coords_equal(pc2)
 
         # Change dtype
+        pc2 = pc1.copy()
         pc2 = pc1.copy()
         pc2 = pc2.astype("float32")
         assert pc1.georeferenced_coords_equal(pc2)

--- a/tests/test_pointcloud/test_pointcloud.py
+++ b/tests/test_pointcloud/test_pointcloud.py
@@ -528,8 +528,9 @@ class TestArithmetic:
 
     def test_info(self) -> None:
         """Test that the information summary is consistent"""
-        fn_las = gu.examples.get_path_test("coromandel_lidar")
-        pc = gu.PointCloud(fn_las)
+        path = gu.examples.get_path_test("everest_landsat_b4")
+        raster = gu.Raster(path)
+        pc = raster.to_pointcloud()
 
         # Check default runs without error (prints to screen)
         output = pc.info()
@@ -541,18 +542,15 @@ class TestArithmetic:
         list_prints = ["Filename", "Coordinate system", "Extent", "Number of features", "Attributes"]
         assert all(p in output2 for p in list_prints)
 
-        # Test stats param
-        nb_lines = len(output2.split("\n"))
-        output_with_stats = pc.info(stats=True, verbose=False)
-        output_with_stats_split = output_with_stats.split("\n")
-        stats = pc.get_stats()
-        nb_lines_with_stats = len(output_with_stats_split)
-        assert nb_lines + len(stats) + 2 == nb_lines_with_stats
+        # Test stats param (raster vs pc)
+        pc_with_stats_split = pc.info(stats=True, verbose=False).split("\n")
+        start_stats_pc = pc_with_stats_split.index("Statistics:")
+        raster_with_stats_split = raster.info(stats=True, verbose=False).split("\n")
+        start_stats_raster = raster_with_stats_split.index("Statistics:")
 
-        assert output_with_stats.split("\n")[nb_lines + 1] == "Statistics:"
-        for s, stat in enumerate(stats.keys()):
-            assert output_with_stats_split[nb_lines + 2 + s].startswith(stat)
-            assert f"{stats[stat]:.2f}" in output_with_stats_split[nb_lines + 2 + s]
+        pc_stats_split = pc_with_stats_split[start_stats_pc:]
+        raster_stats_split = raster_with_stats_split[start_stats_raster:]
+        assert pc_stats_split == raster_stats_split
 
     def test_pointcloud_equal(self) -> None:
         """
@@ -596,7 +594,6 @@ class TestArithmetic:
         assert pc1.georeferenced_coords_equal(pc2)
 
         # Change dtype
-        pc2 = pc1.copy()
         pc2 = pc1.copy()
         pc2 = pc2.astype("float32")
         assert pc1.georeferenced_coords_equal(pc2)


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/geoutils/issues/798

`PointCloud.get_stats()` now mirrors `Raster.get_stats()` with its `stats` parameters : 

```
fn_las = gu.examples.get_path_test("coromandel_lidar")
pc = gu.PointCloud(fn_las)
pc.info()

  Filename:           /home/mbouchet/Documents/xDem_project/geoutils/geoutils/example_data/Coromandel_Lidar/points_test.laz 
  Coordinate system:  EPSG:None
  Extent:             [1838890.815, 5887910.595, 1838937.06, 5887968.602] 
  Number of features: 10000 
  Attributes:         ['Z', 'geometry']
```
And 

```pc.info(stats=True)

  Filename:           /home/mbouchet/Documents/xDem_project/geoutils/geoutils/example_data/Coromandel_Lidar/points_test.laz 
  Coordinate system:  EPSG:None
  Extent:             [1838890.815, 5887910.595, 1838937.06, 5887968.602] 
  Number of features: 10000 
  Attributes:         ['Z', 'geometry']
  
  Statistics:
  Mean                   : 790.60
  Median                 : 789.04
  Max                    : 811.24
  Min                    : 777.11
  Sum                    : 7906031.38
  Sum of squares         : 6251073481.97
  90th percentile        : 801.25
  LE90                   : 23.35
  IQR                    : 11.49
  NMAD                   : 7.64
  RMSE                   : 790.64
  Standard deviation     : 7.35
  Valid count            : 10000.00
  Total count            : 10000.00
  Percentage valid points: 100.00
```