### PR TITLE
Temporarily pin GDAL 3.13.3 and below for COG writing issue

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,7 @@ jobs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-level }}-${{ env.cache_date }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
       env:
-        CACHE_NUMBER: 1 # Increase this value to reset cache if environment.yml has not changed
+        CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
       id: cache
 
     # The trick below is necessary because the generic environment file does not specify a Python version, and ONLY

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -59,7 +59,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         mamba install pyyaml python=${{ matrix.python-version }}
-        python .github/scripts/generate_yml_env_fixed_py.py --pyv ${{ matrix.python-version }} --add "gdal" "environment.yml"
+        python .github/scripts/generate_yml_env_fixed_py.py --pyv ${{ matrix.python-version }} --add "gdal<3.13.3" "environment.yml"
         mamba env update -n geoutils-dev -f environment-ci-py${{ matrix.python-version }}.yml
 
     # If/else equivalent to install base environment, or base+optional

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - dask # For out-of-memory operations
 
   # Test dependencies
-  - gdal  # To test functionalities against GDAL
+  - gdal<3.13.3  # To test functionalities against GDAL
   - pytest=7.*
   - pytest-xdist
   - pytest-lazy-fixtures


### PR DESCRIPTION
Follows https://github.com/GlacioHack/geoutils/pull/904

Restores working CI.
Opening #910 to remember to unpin