### PR TITLE
Fix Windows in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,13 +16,14 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         dep-level: ["base", "opt"]
 
     defaults:
       run:
-        shell: bash -l {0}
+        # Use PowerShell on Windows to better work with setup-miniconda
+        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash -el {0}' }}
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -81,6 +81,9 @@ jobs:
         conda list
 
     - name: Test with pytest
+      env:
+        # Render plots without a GUI backend (avoid Tcl/Tk issues on Windows)
+        MPLBACKEND: Agg
       # Module execution also collects tests from the repository-only benchmarks package
       run: python -m pytest -ra --cov=geoutils/ --cov-report=lcov
 

--- a/geoutils/multiproc/cluster.py
+++ b/geoutils/multiproc/cluster.py
@@ -19,6 +19,7 @@
 
 """This module defines the cluster configurations."""
 
+import sys
 import multiprocessing
 from multiprocessing.pool import Pool
 from typing import Any, Callable, Dict, Optional
@@ -119,7 +120,8 @@ class MpCluster(AbstractCluster):
             nb_workers = conf.get("nb_workers", 1)
             max_tasks_per_child = conf.get("max_tasks_per_child", 10)
         # Using the 'forkserver' context for more controlled process handling
-        ctx_in_main = multiprocessing.get_context("fork")
+        # Windows requires spawn, preserve existing fork behavior elsewhere
+        ctx_in_main = multiprocessing.get_context("spawn" if sys.platform == "win32" else "fork")
         # Recycling stays configurable so memory tests can distinguish it from a crash
         self.pool = ctx_in_main.Pool(processes=nb_workers, maxtasksperchild=max_tasks_per_child)
 

--- a/geoutils/multiproc/cluster.py
+++ b/geoutils/multiproc/cluster.py
@@ -19,8 +19,8 @@
 
 """This module defines the cluster configurations."""
 
-import sys
 import multiprocessing
+import sys
 from multiprocessing.pool import Pool
 from typing import Any, Callable, Dict, Optional
 

--- a/tests/test_multiproc/test_mparray.py
+++ b/tests/test_multiproc/test_mparray.py
@@ -5,7 +5,7 @@ Tests for multiprocessing functions
 import os
 import warnings
 from multiprocessing import cpu_count
-from typing import Any
+from typing import Any, Iterator
 
 import numpy as np
 import pytest
@@ -182,8 +182,14 @@ class TestMultiproc:
     aster_dem_path = examples.get_path_test("exploradores_aster_dem")
     landsat_rgb_path = examples.get_path_test("everest_landsat_rgb")
 
-    num_workers = min(2, cpu_count())  # Safer limit for CI
-    cluster = ClusterGenerator("test", nb_workers=num_workers)
+    @pytest.fixture(scope="class", params=[None, "test"])
+    def cluster(self, request: pytest.FixtureRequest) -> Iterator[AbstractCluster | None]:
+        # This is for tests to work with spawn (Windows, requires this fixture) or Fork (ubuntu, macos)
+        if request.param is None:
+            yield None
+        else:
+            with ClusterGenerator("test", nb_workers=min(2, cpu_count())) as cluster:
+                yield cluster
 
     def test_multiproc_config_rectangular_chunks(self) -> None:
         """Accept positive rectangular chunks and reject invalid dimensions."""
@@ -273,7 +279,6 @@ class TestMultiproc:
 
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])
     @pytest.mark.parametrize("tile_size", [100, 200])
-    @pytest.mark.parametrize("cluster", [None, cluster])
     def test_map_overlap(self, example: str, tile_size: int, cluster: None | AbstractCluster) -> None:
         """
         Test the multiprocessing map function with a simple operation returning a raster.
@@ -332,7 +337,6 @@ class TestMultiproc:
 
     @pytest.mark.parametrize("example", [aster_dem_path, landsat_rgb_path])
     @pytest.mark.parametrize("tile_size", [10, 20])
-    @pytest.mark.parametrize("cluster", [None, cluster])
     @pytest.mark.parametrize("return_block_info", [False, True])
     def test_map_blocks(
         self, example: str, tile_size: int, cluster: None | AbstractCluster, return_block_info: bool


### PR DESCRIPTION
This PR makes CI work on Windows. 

Required changes were minimal but a bit hard to track from the CI errors:
- Setup-miniconda didn't support Windows default bash well, I changed to PowerShell at the start of the job,
- Windows doesn't support `fork` for Multiprocessing cluster, I changed to `spawn` when Windows is used and adjusted tests,
- Graphic rendering didn't like Windows either (for plot tests) but is not required during tests, so I switched to using Agg.

Resolves #621 